### PR TITLE
add AS resources

### DIFF
--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -1,0 +1,172 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud\_as\_configuration
+
+Manages a AS Configuration resource within G42Cloud.
+
+## Example Usage
+
+### Basic AS Configuration
+
+```hcl
+resource "g42cloud_as_configuration" "my_as_config" {
+  scaling_configuration_name = "my_as_config"
+  instance_config {
+    flavor = var.flavor
+    image  = var.image_id
+    disk {
+      size        = 40
+      volume_type = "SATA"
+      disk_type   = "SYS"
+    }
+    key_name  = var.keyname
+    user_data = file("userdata.txt")
+  }
+}
+```
+
+### AS Configuration With Encrypted Data Disk
+
+```hcl
+resource "g42cloud_as_configuration" "my_as_config" {
+  scaling_configuration_name = "my_as_config"
+  instance_config {
+    flavor = var.flavor
+    image  = var.image_id
+    disk {
+      size        = 40
+      volume_type = "SATA"
+      disk_type   = "SYS"
+    }
+    disk {
+      size        = 100
+      volume_type = "SATA"
+      disk_type   = "DATA"
+      kms_id      = var.kms_id
+    }
+    key_name  = var.keyname
+    user_data = file("userdata.txt")
+  }
+}
+```
+
+### AS Configuration With User Data and Metadata
+
+```hcl
+resource "g42cloud_as_configuration" "my_as_config" {
+  scaling_configuration_name = "my_as_config"
+  instance_config {
+    flavor = var.flavor
+    image  = var.image_id
+    disk {
+      size        = 40
+      volume_type = "SATA"
+      disk_type   = "SYS"
+    }
+    key_name  = var.keyname
+    user_data = file("userdata.txt")
+    metadata = {
+      some_key = "some_value"
+    }
+  }
+}
+```
+
+`user_data` can come from a variety of sources: inline, read in from the `file`
+function, or the `template_cloudinit_config` resource.
+
+### AS Configuration uses the existing instance specifications as the template
+
+```hcl
+resource "g42cloud_as_configuration" "my_as_config" {
+  scaling_configuration_name = "my_as_config"
+  instance_config {
+    instance_id = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+    key_name    = var.keyname
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the AS configuration. If
+    omitted, the `region` argument of the provider is used. Changing this
+    creates a new AS configuration.
+
+* `scaling_configuration_name` - (Required, String, ForceNew) The name of the AS configuration. The name can contain letters,
+    digits, underscores(_), and hyphens(-), and cannot exceed 64 characters.
+
+* `instance_config` - (Required, List, ForceNew) The information about instance configurations. The instance_config
+    dictionary data structure is documented below.
+
+The `instance_config` block supports:
+
+* `instance_id` - (Optional, String) When using the existing instance specifications as the template to
+    create AS configurations, specify this argument. In this case, flavor, image,
+    and disk arguments do not take effect. If the instance_id argument is not specified,
+    flavor, image, and disk arguments are mandatory.
+
+* `flavor` - (Required, String) The flavor name.
+
+* `image` - (Optional, String) The image ID.
+
+* `disk` - (Optional, List) The disk group information. System disks are mandatory and data disks are optional.
+    The dick structure is described below.
+
+* `key_name` - (Required, String) The name of the SSH key pair used to log in to the instance.
+
+* `user_data` - (Optional, String, ForceNew) The user data to provide when launching the instance.
+    The file content must be encoded with Base64.
+
+* `personality` - (Optional, List) Customize the personality of an instance by
+    defining one or more files and their contents. The personality structure
+    is described below.
+
+* `public_ip` - (Optional, List) The elastic IP address of the instance. The public_ip structure
+    is described below.
+
+* `metadata` - (Optional, Map) Metadata key/value pairs to make available from
+    within the instance.
+
+The `disk` block supports:
+
+* `size` - (Required, Int) The disk size. The unit is GB. The system disk size ranges from 40 to 32768,
+    and the data disk size ranges from 10 to 32768.
+
+* `volume_type` - (Required, String) The disk type, which must be the same as the disk type available in the system.
+    The options include `SATA` (common I/O disk type) and `SSD` (ultra-high I/O disk type).
+
+* `disk_type` - (Required, String) Whether the disk is a system disk or a data disk. Option `DATA` indicates
+    a data disk. option `SYS` indicates a system disk.
+
+* `kms_id` - (Optional, String, ForceNew) The Encryption KMS ID of the data disk.
+
+The `personality` block supports:
+
+* `path` - (Required, String) The absolute path of the destination file.
+
+* `contents` - (Required, String) The content of the injected file, which must be encoded with base64.
+
+The `public_ip` block supports:
+
+* `eip` - (Required, List) The configuration parameter for creating an elastic IP address
+    that will be automatically assigned to the instance. The eip structure is described below.
+
+The `eip` block supports:
+
+* `ip_type` - (Required, String) The IP address type. The system only supports `5_bgp` (indicates dynamic BGP).
+
+* `bandwidth` - (Required, List) The bandwidth information. The structure is described below.
+
+
+The `bandwidth` block supports:
+
+* `size` - (Required, Int) The bandwidth (Mbit/s). The value range is 1 to 300.
+
+* `share_type` - (Required, String) The bandwidth sharing type. The system only supports `PER` (indicates exclusive bandwidth).
+
+* `charging_mode` - (Required, String) The bandwidth charging mode. The system only supports `traffic`.

--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -1,0 +1,221 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud\_as\_group
+
+Manages a Autoscaling Group resource within G42Cloud.
+
+## Example Usage
+
+### Basic Autoscaling Group
+
+```hcl
+resource "g42cloud_as_group" "my_as_group" {
+  scaling_group_name       = "my_as_group"
+  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  desire_instance_number   = 2
+  min_instance_number      = 0
+  max_instance_number      = 10
+  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  delete_publicip          = true
+  delete_instances         = "yes"
+
+  networks {
+    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  }
+  security_groups {
+    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
+  }
+}
+```
+
+### Autoscaling Group with tags
+
+```hcl
+resource "g42cloud_as_group" "my_as_group_tags" {
+  scaling_group_name       = "my_as_group_tags"
+  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  desire_instance_number   = 2
+  min_instance_number      = 0
+  max_instance_number      = 10
+  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  delete_publicip          = true
+  delete_instances         = "yes"
+
+  networks {
+    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  }
+  security_groups {
+    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+### Autoscaling Group Only Remove Members When Scaling Down
+
+```hcl
+resource "g42cloud_as_group" "my_as_group_only_remove_members" {
+  scaling_group_name       = "my_as_group_only_remove_members"
+  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  desire_instance_number   = 2
+  min_instance_number      = 0
+  max_instance_number      = 10
+  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  delete_publicip          = true
+  delete_instances         = "no"
+
+  networks {
+    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  }
+  security_groups {
+    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
+  }
+}
+```
+
+### Autoscaling Group With Enhanced Load Balancer Listener
+
+```hcl
+resource "g42cloud_lb_loadbalancer" "loadbalancer_1" {
+  name          = "loadbalancer_1"
+  vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+}
+
+resource "g42cloud_lb_listener" "listener_1" {
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = g42cloud_lb_loadbalancer.loadbalancer_1.id
+}
+
+resource "g42cloud_lb_pool" "pool_1" {
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = g42cloud_lb_listener.listener_1.id
+}
+
+resource "g42cloud_as_group" "my_as_group_with_enhanced_lb" {
+  scaling_group_name       = "my_as_group_with_enhanced_lb"
+  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  desire_instance_number   = 2
+  min_instance_number      = 0
+  max_instance_number      = 10
+  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+
+  networks {
+    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  }
+  security_groups {
+    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
+  }
+  lbaas_listeners {
+    pool_id       = g42cloud_lb_pool.pool_1.id
+    protocol_port = g42cloud_lb_listener.listener_1.protocol_port
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the AS group. If
+    omitted, the `region` argument of the provider is used. Changing this
+    creates a new AS group.
+
+* `scaling_group_name` - (Required, String) The name of the scaling group. The name can contain letters,
+    digits, underscores(_), and hyphens(-),and cannot exceed 64 characters.
+
+* `scaling_configuration_id` - (Optional, String) The configuration ID which defines
+    configurations of instances in the AS group.
+
+* `desire_instance_number` - (Optional, Int) The expected number of instances. The default
+    value is the minimum number of instances. The value ranges from the minimum number of
+    instances to the maximum number of instances.
+
+* `min_instance_number` - (Optional, Int) The minimum number of instances.
+    The default value is 0.
+
+* `max_instance_number` - (Optional, Int) The maximum number of instances.
+    The default value is 0.
+
+* `cool_down_time` - (Optional, Int) The cooling duration (in seconds). The value ranges
+    from 0 to 86400, and is 300 by default.
+
+* `lbaas_listeners` - (Optional, List) An array of one or more enhanced load balancer.
+    The system supports the binding of up to six load balancers.
+    The object structure is documented below.
+
+* `available_zones` - (Optional, List) The availability zones in which to create
+    the instances in the autoscaling group.
+
+* `networks` - (Required, List) An array of one or more network IDs.
+    The system supports up to five networks. The networks object structure
+    is documented below.
+
+* `security_groups` - (Required, List) An array of one or more security group IDs
+    to associate with the group. The security_groups object structure is
+    documented below.
+
+* `vpc_id` - (Required, String, ForceNew) The VPC ID. Changing this creates a new group.
+
+* `health_periodic_audit_method` - (Optional, String) The health check method for instances
+    in the AS group. The health check methods include `ELB_AUDIT` and `NOVA_AUDIT`.
+    If load balancing is configured, the default value of this parameter is `ELB_AUDIT`.
+    Otherwise, the default value is `NOVA_AUDIT`.
+
+* `health_periodic_audit_time` - (Optional, Int) The health check period for instances.
+    The period has four options: 5 minutes (default), 15 minutes, 60 minutes, and 180 minutes.
+
+* `instance_terminate_policy` - (Optional, String) The instance removal policy. The policy has
+    four options: `OLD_CONFIG_OLD_INSTANCE` (default), `OLD_CONFIG_NEW_INSTANCE`,
+    `OLD_INSTANCE`, and `NEW_INSTANCE`.
+
+* `tags` - (Optional, Map) The key/value pairs to associate with the scaling group.
+
+* `notifications` - (Optional, List) The notification mode. The system only supports `EMAIL`
+    mode which refers to notification by email.
+
+* `delete_publicip` - (Optional, Bool) Whether to delete the elastic IP address bound to the
+    instances of AS group when deleting the instances. The options are `true` and `false`.
+
+* `delete_instances` - (Optional, String) Whether to delete the instances in the AS group
+    when deleting the AS group. The options are `yes` and `no`.
+
+The `networks` block supports:
+
+* `id` - (Required, String) The network UUID.
+
+The `security_groups` block supports:
+
+* `id` - (Required, String) The UUID of the security group.
+
+The `lbaas_listeners` block supports:
+
+* `pool_id` - (Required, String) Specifies the backend ECS group ID.
+* `protocol_port` - (Required, Int) Specifies the backend protocol, which is the port on which
+  a backend ECS listens for traffic. The number of the port ranges from 1 to 65535.
+* `weight` - (Optional, Int) Specifies the weight, which determines the portion of requests a
+  backend ECS processes compared to other backend ECSs added to the same listener. The value
+  of this parameter ranges from 0 to 100. The default value is 1.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `status` - Indicates the status of the AS group.
+* `current_instance_number` - Indicates the number of current instances in the AS group.
+
+* `instances` - The instances IDs of the AS group.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 10 minute.
+

--- a/docs/resources/as_policy.md
+++ b/docs/resources/as_policy.md
@@ -1,0 +1,155 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud\_as\_policy
+
+Manages a AS Policy resource within G42Cloud.
+
+## Example Usage
+
+### AS Recurrence Policy
+
+```hcl
+resource "g42cloud_as_policy" "my_aspolicy" {
+  scaling_policy_name = "my_aspolicy"
+  scaling_policy_type = "RECURRENCE"
+  scaling_group_id    = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+  cool_down_time      = 900
+
+  scaling_policy_action {
+    operation       = "ADD"
+    instance_number = 1
+  }
+  scheduled_policy {
+    launch_time     = "07:00"
+    recurrence_type = "Daily"
+    start_time      = "2020-11-30T12:00Z"
+    end_time        = "2020-12-30T12:00Z"
+  }
+}
+```
+
+### AS Scheduled Policy
+
+```hcl
+resource "g42cloud_as_policy" "my_aspolicy_1" {
+  scaling_policy_name = "my_aspolicy_1"
+  scaling_policy_type = "SCHEDULED"
+  scaling_group_id    = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+  cool_down_time      = 900
+
+  scaling_policy_action {
+    operation       = "REMOVE"
+    instance_number = 1
+  }
+  scheduled_policy {
+    launch_time = "2020-12-22T12:00Z"
+  }
+}
+```
+
+Please note that the `launch_time` of the `SCHEDULED` policy cannot be earlier than the current time.
+
+### AS Alarm Policy
+
+```hcl
+resource "g42cloud_ces_alarmrule" "alarm_rule" {
+  alarm_name = "as_alarm_rule"
+
+  metric {
+    namespace   = "SYS.AS"
+    metric_name = "cpu_util"
+    dimensions {
+      name  = "AutoScalingGroup"
+      value = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+    }
+  }
+  condition {
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 60
+    unit                = "%"
+    count               = 1
+  }
+  alarm_actions {
+    type              = "autoscaling"
+    notification_list = []
+  }
+}
+
+resource "g42cloud_as_policy" "my_aspolicy_2" {
+  scaling_policy_name = "my_aspolicy_2"
+  scaling_policy_type = "ALARM"
+  scaling_group_id    = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+  alarm_id            = g42cloud_ces_alarmrule.alarm_rule.id
+  cool_down_time      = 900
+
+  scaling_policy_action {
+    operation       = "ADD"
+    instance_number = 1
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the AS policy. If
+    omitted, the `region` argument of the provider is used. Changing this
+    creates a new AS policy.
+
+* `scaling_policy_name` - (Required, String) The name of the AS policy. The name can contain letters,
+    digits, underscores(_), and hyphens(-), and cannot exceed 64 characters.
+
+* `scaling_policy_type` - (Required, String) The AS policy type. The values can be `ALARM`, `SCHEDULED`,
+    and `RECURRENCE`.
+
+* `scaling_group_id` - (Required, String, ForceNew) The AS group ID. Changing this creates a new AS policy.
+
+* `alarm_id` - (Optional, String) The alarm rule ID. This argument is mandatory when `scaling_policy_type`
+    is set to `ALARM`. You can create an alarm rule with `g42cloud_ces_alarmrule`.
+
+* `scheduled_policy` - (Optional, List) The periodic or scheduled AS policy. This argument is mandatory
+    when `scaling_policy_type` is set to `SCHEDULED` or `RECURRENCE`. The scheduled_policy structure
+    is documented below.
+
+* `scaling_policy_action` - (Optional, List) The action of the AS policy. The scaling_policy_action
+    structure is documented below.
+
+* `cool_down_time` - (Optional, Int) The cooling duration (in seconds), and is 900 by default.
+
+The `scheduled_policy` block supports:
+
+* `launch_time` - (Required, String) The time when the scaling action is triggered.
+    - If `scaling_policy_type` is set to `SCHEDULED`, the time format is YYYY-MM-DDThh:mmZ.
+    - If `scaling_policy_type` is set to `RECURRENCE`, the time format is hh:mm.
+
+* `recurrence_type` - (Optional, String) The periodic triggering type. This argument is mandatory when
+    `scaling_policy_type` is set to `RECURRENCE`. The options include `Daily`, `Weekly`, and `Monthly`.
+
+* `recurrence_value` - (Optional, String) The frequency at which scaling actions are triggered.
+
+* `start_time` - (Optional, String) The start time of the scaling action triggered periodically.
+    The time format complies with UTC. The current time is used by default. The time
+    format is YYYY-MM-DDThh:mmZ.
+
+* `end_time` - (Optional, String) The end time of the scaling action triggered periodically.
+    The time format complies with UTC. This argument is mandatory when `scaling_policy_type`
+    is set to `RECURRENCE`. The time format is YYYY-MM-DDThh:mmZ.
+
+The `scaling_policy_action` block supports:
+
+* `operation` - (Optional, String) The operation to be performed. The options include `ADD` (default), `REMOVE`,
+    and `SET`.
+
+* `instance_number` - (Optional, Int) The number of instances to be operated. The default number is 1.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+

--- a/g42cloud/resource_g42cloud_as_configuration_v1_test.go
+++ b/g42cloud/resource_g42cloud_as_configuration_v1_test.go
@@ -1,0 +1,125 @@
+package g42cloud
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+)
+
+func TestAccASV1Configuration_basic(t *testing.T) {
+	var asConfig configurations.Configuration
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckASV1ConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccASV1Configuration_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASV1ConfigurationExists("g42cloud_as_configuration.hth_as_config", &asConfig),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckASV1ConfigurationDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*huaweicloud.Config)
+	asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_as_configuration" {
+			continue
+		}
+
+		_, err := configurations.Get(asClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("AS configuration still exists")
+		}
+	}
+
+	log.Printf("[DEBUG] testAccCheckASV1ConfigurationDestroy success!")
+
+	return nil
+}
+
+func testAccCheckASV1ConfigurationExists(n string, configuration *configurations.Configuration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*huaweicloud.Config)
+		asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
+		}
+
+		found, err := configurations.Get(asClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Autoscaling Configuration not found")
+		}
+		log.Printf("[DEBUG] test found is: %#v", found)
+		configuration = &found
+
+		return nil
+	}
+}
+
+func testAccASV1Configuration_basic(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "g42cloud_compute_flavors" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "g42cloud_compute_keypair" "hth_key" {
+  name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_as_configuration" "hth_as_config"{
+  scaling_configuration_name = "%s"
+  instance_config {
+	image = data.g42cloud_images_image.test.id
+	flavor = data.g42cloud_compute_flavors.test.ids[0]
+    disk {
+      size = 40
+      volume_type = "SAS"
+      disk_type = "SYS"
+    }
+    key_name = "${g42cloud_compute_keypair.hth_key.id}"
+  }
+}
+`, rName, rName)
+}

--- a/g42cloud/resource_g42cloud_as_group_v1_test.go
+++ b/g42cloud/resource_g42cloud_as_group_v1_test.go
@@ -1,0 +1,182 @@
+package g42cloud
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+)
+
+func TestAccASV1Group_basic(t *testing.T) {
+	var asGroup groups.Group
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "g42cloud_as_group.hth_as_group"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckASV1GroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testASV1Group_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASV1GroupExists(resourceName, &asGroup),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckASV1GroupDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*huaweicloud.Config)
+	asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_as_group" {
+			continue
+		}
+
+		_, err := groups.Get(asClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("AS group still exists")
+		}
+	}
+
+	log.Printf("[DEBUG] testCheckASV1GroupDestroy success!")
+
+	return nil
+}
+
+func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*huaweicloud.Config)
+		asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
+		}
+
+		found, err := groups.Get(asClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Autoscaling Group not found")
+		}
+		log.Printf("[DEBUG] test found is: %#v", found)
+		group = &found
+
+		return nil
+	}
+}
+
+func testASV1Group_basic(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "g42cloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "g42cloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "g42cloud_compute_flavors" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "g42cloud_networking_secgroup" "secgroup" {
+  name        = "%s"
+  description = "This is a terraform test security group"
+}
+
+resource "g42cloud_compute_keypair" "hth_key" {
+  name       = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_lb_loadbalancer" "loadbalancer_1" {
+  name          = "%s"
+  vip_subnet_id = data.g42cloud_vpc_subnet.test.subnet_id
+}
+
+resource "g42cloud_lb_listener" "listener_1" {
+  name            = "%s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = g42cloud_lb_loadbalancer.loadbalancer_1.id
+}
+
+resource "g42cloud_lb_pool" "pool_1" {
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = g42cloud_lb_listener.listener_1.id
+}
+
+resource "g42cloud_as_configuration" "hth_as_config"{
+  scaling_configuration_name = "%s"
+  instance_config {
+	image    = data.g42cloud_images_image.test.id
+	flavor   = data.g42cloud_compute_flavors.test.ids[0]
+    key_name = g42cloud_compute_keypair.hth_key.id
+    disk {
+      size        = 40
+      volume_type = "SAS"
+      disk_type   = "SYS"
+    }
+  }
+}
+
+resource "g42cloud_as_group" "hth_as_group"{
+  scaling_group_name       = "%s"
+  scaling_configuration_id = g42cloud_as_configuration.hth_as_config.id
+  vpc_id                   = data.g42cloud_vpc.test.id
+
+  networks {
+    id = data.g42cloud_vpc_subnet.test.id
+  }
+  security_groups {
+    id = g42cloud_networking_secgroup.secgroup.id
+  }
+  lbaas_listeners {
+    pool_id       = g42cloud_lb_pool.pool_1.id
+    protocol_port = g42cloud_lb_listener.listener_1.protocol_port
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName, rName, rName, rName, rName, rName, rName)
+}

--- a/g42cloud/resource_g42cloud_as_policy_v1_test.go
+++ b/g42cloud/resource_g42cloud_as_policy_v1_test.go
@@ -1,0 +1,161 @@
+package g42cloud
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/policies"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+)
+
+func TestAccASV1Policy_basic(t *testing.T) {
+	var asPolicy policies.Policy
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckASV1PolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testASV1Policy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASV1PolicyExists("g42cloud_as_policy.acc_as_policy", &asPolicy),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckASV1PolicyDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*huaweicloud.Config)
+	asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_as_policy" {
+			continue
+		}
+
+		_, err := policies.Get(asClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("AS policy still exists")
+		}
+	}
+
+	log.Printf("[DEBUG] testCheckASV1PolicyDestroy success!")
+
+	return nil
+}
+
+func testAccCheckASV1PolicyExists(n string, policy *policies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*huaweicloud.Config)
+		asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
+		}
+
+		found, err := policies.Get(asClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] test found is: %#v", found)
+		policy = &found
+
+		return nil
+	}
+}
+
+func testASV1Policy_basic(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "g42cloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "g42cloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "g42cloud_compute_flavors" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "g42cloud_networking_secgroup" "secgroup" {
+  name        = "%s"
+  description = "This is a terraform test security group"
+}
+
+resource "g42cloud_compute_keypair" "acc_key" {
+  name       = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_as_configuration" "acc_as_config"{
+  scaling_configuration_name = "%s"
+  instance_config {
+	image    = data.g42cloud_images_image.test.id
+	flavor   = data.g42cloud_compute_flavors.test.ids[0]
+	key_name = g42cloud_compute_keypair.acc_key.id
+    disk {
+      size        = 40
+      volume_type = "SAS"
+      disk_type   = "SYS"
+    }
+  }
+}
+
+resource "g42cloud_as_group" "acc_as_group"{
+  scaling_group_name       = "%s"
+  scaling_configuration_id = g42cloud_as_configuration.acc_as_config.id
+  vpc_id                   = data.g42cloud_vpc.test.id
+  networks {
+    id = data.g42cloud_vpc_subnet.test.id
+  }
+  security_groups {
+    id = g42cloud_networking_secgroup.secgroup.id
+  }
+}
+
+resource "g42cloud_as_policy" "acc_as_policy"{
+  scaling_policy_name = "%s"
+  scaling_policy_type = "SCHEDULED"
+  scaling_group_id    = g42cloud_as_group.acc_as_group.id
+
+  scaling_policy_action {
+    operation       = "ADD"
+    instance_number = 1
+  }
+  scheduled_policy {
+    launch_time = "2021-12-22T12:00Z"
+  }
+}
+`, rName, rName, rName, rName, rName)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.14
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/huaweicloud/golangsdk v0.0.0-20201228013212-d10065a3dc7f
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201229034225-02b8669757e5
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201230034232-9a4459ada075
 )

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20201228013212-d10065a3dc7f h1:5gf/WhTTYklU59Ah+hcnCkQAyQzlylglysX6E8I82f8=
 github.com/huaweicloud/golangsdk v0.0.0-20201228013212-d10065a3dc7f/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201229034225-02b8669757e5 h1:LdHTa0g1p1icVSHAIGkkoUKSBE2VDA1bew3yRTuNgoI=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201229034225-02b8669757e5/go.mod h1:KhzmKc/lbq0UxIeW+zBziJZZ8DGPZtm7qwsXTY9Fn94=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201230034232-9a4459ada075 h1:z4wDyT9uG6VNw5NWEbhnjKqV9mxrft+OrFTZNGXA9Uw=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201230034232-9a4459ada075/go.mod h1:KhzmKc/lbq0UxIeW+zBziJZZ8DGPZtm7qwsXTY9Fn94=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/requests.go
@@ -1,0 +1,169 @@
+package subnets
+
+import (
+	"net/http"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+type CreateOpts struct {
+	// Specifies the subnet name. The value is a string of 1 to 64
+	// characters that can contain letters, digits, underscores (_), and hyphens (-).
+	Name string `json:"name" required:"true"`
+
+	// Specifies the network segment on which the subnet resides. The
+	// value must be in CIDR format. The value must be within the CIDR block of the VPC. The
+	// subnet mask cannot be greater than 28.
+	Cidr string `json:"cidr" required:"true"`
+
+	// Specifies the gateway of the subnet. The value must be a valid
+	// IP address. The value must be an IP address in the subnet segment.
+	GatewayIP string `json:"gateway_ip" required:"true"`
+
+	// Specifies whether the DHCP function is enabled for the subnet.
+	// The value can be true or false. If this parameter is left blank, it is set to true by
+	// default.
+	DhcpEnable *bool `json:"dhcp_enable,omitempty"`
+
+	// Specifies the IP address of DNS server 1 on the subnet. The
+	// value must be a valid IP address.
+	PrimaryDNS string `json:"primary_dns,omitempty"`
+
+	// Specifies the IP address of DNS server 2 on the subnet. The
+	// value must be a valid IP address.
+	SecondaryDNS string `json:"secondary_dns,omitempty"`
+
+	// Specifies the DNS server address list of a subnet. This field
+	// is required if you need to use more than two DNS servers. This parameter value is the
+	// superset of both DNS server address 1 and DNS server address 2.
+	DNSList []string `json:"dnsList,omitempty"`
+
+	// Specifies the ID of the VPC to which the subnet belongs.
+	VpcID string `json:"vpc_id" required:"true"`
+
+	SiteID string `json:"site_id,omitempty" required:"true"`
+}
+
+type CreateOptsBuilder interface {
+	ToCreateMap() (map[string]interface{}, error)
+}
+
+func (opts CreateOpts) ToCreateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "subnet")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+type VpcResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	createURL := CreateURL(client)
+
+	var resp *http.Response
+	resp, r.Err = client.Post(createURL, b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+func Delete(client *golangsdk.ServiceClient, subnetId string) (r DeleteResult) {
+	deleteURL := DeleteURL(client, subnetId)
+
+	var resp *http.Response
+	resp, r.Err = client.Delete(deleteURL, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusNoContent},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+func Get(client *golangsdk.ServiceClient, subnetId string) (r GetResult) {
+	getURL := GetURL(client, subnetId)
+
+	var resp *http.Response
+	resp, r.Err = client.Get(getURL, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+type UpdateOpts struct {
+	// Specifies the subnet name. The value is a string of 1 to 64
+	// characters that can contain letters, digits, underscores (_), and hyphens (-).
+	Name string `json:"name" required:"true"`
+
+	// Specifies whether the DHCP function is enabled for the subnet.
+	// The value can be true or false. If this parameter is left blank, it is set to true by
+	// default.
+	DhcpEnable *bool `json:"dhcp_enable,omitempty"`
+
+	// Specifies the IP address of DNS server 1 on the subnet. The
+	// value must be a valid IP address.
+	PrimaryDNS string `json:"primary_dns,omitempty"`
+
+	// Specifies the IP address of DNS server 2 on the subnet. The
+	// value must be a valid IP address.
+	SecondaryDNS string `json:"secondary_dns,omitempty"`
+
+	// Specifies the DNS server address list of a subnet. This field
+	// is required if you need to use more than two DNS servers. This parameter value is the
+	// superset of both DNS server address 1 and DNS server address 2.
+	DNSList []string `json:"dnsList,omitempty"`
+}
+
+type UpdateOptsBuilder interface {
+	ToUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "subnet")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Update(client *golangsdk.ServiceClient, subnetId string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	updateURL := UpdateURL(client, subnetId)
+
+	var resp *http.Response
+	resp, r.Err = client.Put(updateURL, b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/results.go
@@ -1,0 +1,73 @@
+package subnets
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/common"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// SubnetPage is the page returned by a pager when traversing over a collection
+// of subnets.
+type SubnetPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a SubnetPage struct is empty.
+func (r SubnetPage) IsEmpty() (bool, error) {
+	is, err := ExtractSubnets(r)
+	return len(is) == 0, err
+}
+
+// ExtractSubnets accepts a Page struct, specifically a SubnetPage struct,
+// and extracts the elements into a slice of Subnet structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractSubnets(r pagination.Page) ([]common.Subnet, error) {
+	var s struct {
+		Subnets []common.Subnet `json:"subnets"`
+	}
+	err := (r.(SubnetPage)).ExtractInto(&s)
+	return s.Subnets, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+func (r CreateResult) Extract() (*common.Subnet, error) {
+	var entity common.Subnet
+	err := r.ExtractIntoStructPtr(&entity, "subnet")
+	return &entity, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+func (r GetResult) Extract() (*common.Subnet, error) {
+	var entity common.Subnet
+	err := r.ExtractIntoStructPtr(&entity, "subnet")
+	return &entity, err
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type UpdateResp struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+func (r UpdateResult) Extract() (*UpdateResp, error) {
+	var entity UpdateResp
+	err := r.ExtractIntoStructPtr(&entity, "subnet")
+	return &entity, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/urls.go
@@ -1,0 +1,19 @@
+package subnets
+
+import "github.com/huaweicloud/golangsdk"
+
+func CreateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("subnets")
+}
+
+func DeleteURL(c *golangsdk.ServiceClient, subnetId string) string {
+	return c.ServiceURL("subnets", subnetId)
+}
+
+func GetURL(c *golangsdk.ServiceClient, subnetId string) string {
+	return c.ServiceURL("subnets", subnetId)
+}
+
+func UpdateURL(c *golangsdk.ServiceClient, subnetId string) string {
+	return c.ServiceURL("subnets", subnetId)
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/provider.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/provider.go
@@ -395,6 +395,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_identity_role_assignment":        ResourceIdentityRoleAssignmentV3(),
 			"huaweicloud_identity_user":                   ResourceIdentityUserV3(),
 			"huaweicloud_iec_vpc":                         ResourceIecVpc(),
+			"huaweicloud_iec_vpc_subnet":                  resourceIecSubnet(),
 			"huaweicloud_images_image":                    ResourceImsImage(),
 			"huaweicloud_kms_key":                         resourceKmsKeyV1(),
 			"huaweicloud_lb_certificate":                  ResourceCertificateV2(),

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_as_configuration_v1.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_as_configuration_v1.go
@@ -427,7 +427,7 @@ func resourceASConfigurationValidateDiskType(v interface{}, k string) (ws []stri
 	return
 }
 
-var VolumeTypes = [2]string{"SATA", "SSD"}
+var VolumeTypes = [5]string{"SATA", "SSD", "SAS", "co-p1", "uh-l1"}
 
 func resourceASConfigurationValidateVolumeType(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_iec_vpc_subnet.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_iec_vpc_subnet.go
@@ -1,0 +1,242 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets"
+)
+
+func resourceIecSubnetDNSListV1(d *schema.ResourceData) []string {
+	rawDNSN := d.Get("dns_list").([]interface{})
+	dnsn := make([]string, len(rawDNSN))
+	for i, raw := range rawDNSN {
+		dnsn[i] = raw.(string)
+	}
+	return dnsn
+}
+
+func resourceIecSubnet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceIecSubnetV1Create,
+		Read:   resourceIecSubnetV1Read,
+		Update: resourceIecSubnetV1Update,
+		Delete: resourceIecSubnetV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"site_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"gateway_ip": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateIP,
+			},
+			"dhcp_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"dns_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"site_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIecSubnetV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	subnetClient, err := config.IECV1Client(GetRegion(d, config))
+
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	dhcp := d.Get("dhcp_enable").(bool)
+	createOpts := subnets.CreateOpts{
+		Name:       d.Get("name").(string),
+		Cidr:       d.Get("cidr").(string),
+		VpcID:      d.Get("vpc_id").(string),
+		SiteID:     d.Get("site_id").(string),
+		GatewayIP:  d.Get("gateway_ip").(string),
+		DhcpEnable: &dhcp,
+		DNSList:    resourceIecSubnetDNSListV1(d),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	n, err := subnets.Create(subnetClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC subnets: %s", err)
+	}
+
+	d.SetId(n.ID)
+	log.Printf("[DEBUG] Waiting for IEC subnets (%s) to become active", n.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"UNKNOWN"},
+		Target:     []string{"ACTIVE"},
+		Refresh:    waitForIecSubnetStatus(subnetClient, n.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, stateErr := stateConf.WaitForState()
+	if stateErr != nil {
+		return fmt.Errorf(
+			"Error waiting for IEC subnets (%s) to become ACTIVE: %s",
+			n.ID, stateErr)
+	}
+
+	return resourceIecSubnetV1Read(d, config)
+}
+
+func resourceIecSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	subnetClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	n, err := subnets.Get(subnetClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "Error retrieving Huaweicloud IEC subnets")
+	}
+
+	log.Printf("[DEBUG] IEC subnets %s: %+v", d.Id(), n)
+
+	d.Set("name", n.Name)
+	d.Set("cidr", n.Cidr)
+	d.Set("vpc_id", n.VpcID)
+	d.Set("site_id", n.SiteID)
+	d.Set("gateway_ip", n.GatewayIP)
+	d.Set("dhcp_enable", n.DhcpEnable)
+	d.Set("dns_list", n.DNSList)
+	d.Set("site_info", n.SiteInfo)
+	d.Set("status", n.Status)
+
+	return nil
+}
+
+func resourceIecSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	subnetClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	var updateOpts subnets.UpdateOpts
+
+	// name is mandatory while updating subnets
+	updateOpts.Name = d.Get("name").(string)
+
+	if d.HasChange("dhcp_enable") {
+		dhcp := d.Get("dhcp_enable").(bool)
+		updateOpts.DhcpEnable = &dhcp
+	}
+	if d.HasChange("dns_list") {
+		updateOpts.DNSList = resourceSubnetDNSListV1(d)
+	}
+
+	_, err = subnets.Update(subnetClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating Huaweicloud IEC subnets: %s", err)
+	}
+
+	return resourceIecSubnetV1Read(d, meta)
+}
+
+func resourceIecSubnetV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	subnetClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	err = subnets.Delete(subnetClient, d.Id()).ExtractErr()
+	if err != nil {
+		return CheckDeleted(d, err, "Error deleting Huaweicloud IEC subnets")
+	}
+
+	// waiting for subnets to become deleted
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"ACTIVE", "UNKNOWN"},
+		Target:     []string{"DELETED"},
+		Refresh:    waitForIecSubnetStatus(subnetClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, stateErr := stateConf.WaitForState()
+	if stateErr != nil {
+		return fmt.Errorf(
+			"Error waiting for IEC subnets (%s) to become deleted: %s",
+			d.Id(), stateErr)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func waitForIecSubnetStatus(subnetClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		n, err := subnets.Get(subnetClient, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[INFO] Successfully deleted Huaweicloud IEC subnets %s", id)
+				return n, "DELETED", nil
+			}
+			return n, "ERROR", err
+		}
+
+		return n, n.Status, nil
+	}
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_obs_bucket.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_obs_bucket.go
@@ -914,12 +914,12 @@ func setObsBucketStorageClass(obsClient *obs.ObsClient, d *schema.ResourceData) 
 	bucket := d.Id()
 	output, err := obsClient.GetBucketStoragePolicy(bucket)
 	if err != nil {
-		return getObsError("Error getting storage class of OBS bucket", bucket, err)
+		log.Printf("[WARN] Error getting storage class of OBS bucket %s: %s", bucket, err)
+	} else {
+		class := string(output.StorageClass)
+		log.Printf("[DEBUG] getting storage class of OBS bucket %s: %s", bucket, class)
+		d.Set("storage_class", normalizeStorageClass(class))
 	}
-
-	class := string(output.StorageClass)
-	log.Printf("[DEBUG] getting storage class of OBS bucket %s: %s", bucket, class)
-	d.Set("storage_class", normalizeStorageClass(class))
 
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -341,6 +341,7 @@ github.com/huaweicloud/golangsdk/openstack/iec/v1/common
 github.com/huaweicloud/golangsdk/openstack/iec/v1/flavors
 github.com/huaweicloud/golangsdk/openstack/iec/v1/images
 github.com/huaweicloud/golangsdk/openstack/iec/v1/sites
+github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets
 github.com/huaweicloud/golangsdk/openstack/iec/v1/vpcs
 github.com/huaweicloud/golangsdk/openstack/imageservice/v2/imagedata
 github.com/huaweicloud/golangsdk/openstack/imageservice/v2/images
@@ -418,7 +419,7 @@ github.com/huaweicloud/golangsdk/openstack/vbs/v2/tags
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/pagination
-# github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201229034225-02b8669757e5
+# github.com/huaweicloud/terraform-provider-huaweicloud v1.20.3-0.20201230034232-9a4459ada075
 ## explicit
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud
 # github.com/imdario/mergo v0.3.9


### PR DESCRIPTION
The following resources were added:
resource_g42cloud_as_configuration
resource_g42cloud_as_group
resource_g42cloud_as_policy

```bash
make testacc TEST='./g42cloud' TESTARGS='-run TestAccAS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccAS -timeout 360m -parallel=4
=== RUN   TestAccASV1Configuration_basic
=== PAUSE TestAccASV1Configuration_basic
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== RUN   TestAccASV1Policy_basic
=== PAUSE TestAccASV1Policy_basic
=== CONT  TestAccASV1Configuration_basic
=== CONT  TestAccASV1Policy_basic
=== CONT  TestAccASV1Group_basic
--- PASS: TestAccASV1Configuration_basic (128.94s)
--- PASS: TestAccASV1Policy_basic (163.41s)
--- PASS: TestAccASV1Group_basic (247.13s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      247.168s
```