### PR TITLE
add vendor directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ terraform-provider-g42cloud
 
 # Log of test
 *.log
+
+# vendor directory
+vendor/


### PR DESCRIPTION
add vendor directory in gitignore
the vendor directory can be used in local development and debugging, but will not be uploaded