### PR TITLE
add cce resources

### DIFF
--- a/docs/data-sources/cce_addon_template.md
+++ b/docs/data-sources/cce_addon_template.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud\_cce\_addon\_template
+
+Use this data source to get available G42Cloud CCE add-on template.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+variable "addon_name" {}
+
+variable "addon_version" {}
+
+data "g42cloud_cce_addon_template" "test" {
+  cluster_id = var.cluster_id
+  name       = var.addon_name
+  version    = var.addon_version
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the cce add-ons.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` -  (Required, String) Specifies the ID of container cluster.
+
+* `name` -  (Required, String) Specifies the add-on name.
+
+* `version` -  (Required, String) Specifies the add-on version.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource id of the addon template.
+
+* `description` - The description of the add-on.
+
+* `spec` - The detail configuration of the add-on template.
+
+* `stable` - Whether the add-on template is a stable version.
+
+* `support_version/virtual_machine` - The cluster (Virtual Machine) version that the add-on template supported.
+
+* `support_version/bare_metal` - The cluster (Bare Metal) version that the add-on template supported.

--- a/docs/data-sources/cce_cluster.md
+++ b/docs/data-sources/cce_cluster.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud\_cce\_cluster
+
+Provides details about all clusters and obtains certificate for accessing cluster information.
+
+## Example Usage
+
+```hcl
+variable "cluster_name" { }
+
+data "g42cloud_cce_cluster" "cluster" {
+  name   = var.cluster_name
+  status = "Available"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the cce clusters. If omitted, the provider-level region will be used.
+
+* `name` -  (Optional, String)The Name of the cluster resource.
+ 
+* `id` - (Optional, String) The ID of container cluster.
+
+* `status` - (Optional, String) The state of the cluster.
+
+* `cluster_type` - (Optional, String) Type of the cluster. Possible values: VirtualMachine, BareMetal.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `billingMode` - Charging mode of the cluster.
+
+* `description` - Cluster description.
+
+* `name` - The name of the cluster in string format.
+  
+* `flavor_id` - The cluster specification in string format.
+
+* `cluster_version` - The version of cluster in string format.
+
+* `container_network_cidr` - The container network segment.
+
+* `container_network_type` - The container network type: overlay_l2 , underlay_ipvlan, vpc-router or eni.
+
+* `eni_subnet_id` - Eni subnet id. Specified when creating a CCE Turbo cluster.
+
+* `eni_subnet_cidr` - Eni network segment. Specified when creating a CCE Turbo cluster.
+
+* `service_network_cidr` - The service network segment.
+
+* `authentication_mode` - Authentication mode of the cluster, possible values are x509 and rbac. Defaults to *rbac*.
+
+* `masters` - Advanced configuration of master nodes.
+
+* `security_group_id` - Security group ID of the cluster.
+  
+* `subnet_id` - The ID of the subnet used to create the node.
+
+* `highway_subnet_id` - The ID of the high speed network used to create bare metal nodes.
+
+* `enterprise_project_id` - The enterprise project id of the cce cluster.
+
+**endpoints**
+
+* `internal` - The address accessed within the user's subnet.
+
+* `external` - Public network access address.
+
+* `certificate_clusters/name` - The cluster name.
+
+* `certificate_clusters/server` - The server IP address.
+
+* `certificate_clusters/certificate_authority_data` - The certificate data.
+
+* `certificate_users/name` - The user name.
+
+* `certificate_users/client_certificate_data` - The client certificate data.
+
+* `certificate_users/client_key_data` - The client key data.
+
+* `kube_config_raw` - Raw Kubernetes config to be used by kubectl and other compatible tools.

--- a/docs/data-sources/cce_node.md
+++ b/docs/data-sources/cce_node.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud\_cce\_node
+
+To get the specified node in a cluster.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" { }
+variable "node_name" { }
+
+data "g42cloud_cce_node" "node" {
+  cluster_id = var.cluster_id
+  name       = var.node_name
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the cce nodes. If omitted, the provider-level region will be used.
+ 
+* `Cluster_id` - (Required, String) The id of container cluster.
+
+* `name` - (Optional, String) Name of the node.
+
+* `node_id` - (Optional, String) The id of the node.
+
+* `status` - (Optional, String) The state of the node.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `flavor_id` - The flavor id to be used. 
+
+* `availability_zone` - Available partitions where the node is located. 
+
+* `os` - Operating System of the node.
+
+* `subnet_id` - The ID of the subnet which the NIC belongs to.
+
+* `esc_group_id` - The ID of Ecs group which the node belongs to.
+
+* `tags` - Tags of a VM node, key/value pair format.
+
+* `key_pair` - Key pair name when logging in to select the key pair mode.
+
+* `billing_mode` - Node's billing mode: The value is 0 (on demand).
+ 
+* `server_id` - The node's virtual machine ID in ECS.
+
+* `public_ip` - Elastic IP parameters of the node.
+
+* `private_ip` - Private IP of the node
+
+* `root_volume` - It corresponds to the system disk related configuration.
+
+  * `size` - Disk size in GB.
+  * `volumetype` - Disk type.
+  * `extend_params` - Disk expansion parameters.
+
+* `data_volumes` - Represents the data disk to be created.
+
+  * `size` - Disk size in GB.
+  * `volumetype` - Disk type.
+  * `extend_params` - Disk expansion parameters.
+

--- a/docs/data-sources/cce_node_pool.md
+++ b/docs/data-sources/cce_node_pool.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud\_cce\_node\_pool
+
+To get the specified node pool in a cluster.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" { }
+variable "node_pool_name" { }
+
+data "g42cloud_cce_node_pool" "node_pool" {
+  cluster_id = var.cluster_id
+  name       = var.node_pool_name
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the cce node pools.
+  If omitted, the provider-level region will be used.
+ 
+* `cluster_id` - (Required, String) Specifies the id of container cluster.
+
+* `name` - (Optional, String) Specifies the name of the node pool.
+
+* `node_pool_id` - (Optional, String) Specifies the id of the node pool.
+
+* `status` - (Optional, String) Specifies the state of the node pool.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `initial_node_count` - Initial number of nodes in the node pool.
+
+* `current_node_count` - Current number of nodes in the node pool.
+
+* `flavor_id` - The flavor id.
+
+* `type` - Node Pool type.
+ 
+* `availability_zone` - The name of the available partition (AZ).
+
+* `os` - Operating System of the node.
+
+* `key_pair` - Key pair name when logging in to select the key pair mode.
+
+* `subnet_id` - The ID of the subnet to which the NIC belongs.
+
+* `max_pods` - The maximum number of instances a node is allowed to create.
+
+* `extend_param` - Extended parameter.
+
+* `scall_enable` - Whether auto scaling is enabled.
+
+* `min_node_count` - Minimum number of nodes allowed if auto scaling is enabled.
+
+* `max_node_count` - Maximum number of nodes allowed if auto scaling is enabled.
+
+* `scale_down_cooldown_time` - Interval between two scaling operations, in minutes.
+
+* `priority` - Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
+
+* `labels` - Tags of a Kubernetes node, key/value pair format.
+
+* `tags` - Tags of a VM node, key/value pair format.
+
+* `root_volume` - It corresponds to the system disk related configuration.
+
+* `data_volumes` - Represents the data disk to be created.
+
+The `root_volume` block supports:
+
+* `size` - Disk size in GB.
+    
+* `volumetype` - Disk type.
+    
+* `extend_params` - Disk expansion parameters. 
+
+The `data_volumes` block supports:
+    
+* `size` - Disk size in GB.
+    
+* `volumetype` - Disk type.
+    
+* `extend_params` - Disk expansion parameters. 

--- a/docs/resources/cce_addon.md
+++ b/docs/resources/cce_addon.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+## Example Usage
+```hcl
+variable "cluster_id" { }
+
+resource "g42cloud_cce_addon" "addon_test" {
+    cluster_id    = var.cluster_id
+    template_name = "autoscaler"
+    version       = "1.15.10"
+}
+``` 
+
+## Argument Reference
+The following arguments are supported:
+* `region` - (Optional, String, ForceNew) The region in which to create the cce addon resource. If omitted, the provider-level region will be used. Changing this creates a new cce addon resource.
+* `cluster_id` - (Required, String, ForceNew) ID of the cluster. Changing this parameter will create a new resource.
+* `template_name` - (Required, String, ForceNew) Name of the addon template. Changing this parameter will create a new resource.
+* `version` - (Required, String, ForceNew) Version of the addon. Changing this parameter will create a new resource.
+* `values` - (Optional, List, ForceNew) Add-on template installation parameters. These parameters vary depending on the add-on.
+
+The `values` block supports:
+* `basic` - (Required, Map) Key/Value pairs vary depending on the add-on.
+* `custom` - (Optional, Map) Key/Value pairs vary depending on the add-on.
+* `flavor` - (Optional, Map) Key/Value pairs vary depending on the add-on.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+ * `id` -  ID of the addon instance.
+ * `status` - Addon status information.
+ * `description` - Description of addon instance.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 3 minute.
+
+## Import
+
+CCE addon can be imported using the cluster ID and addon ID
+separated by a slash, e.g.:
+
+```
+$ terraform import g42cloud_cce_addon.my_addon bb6923e4-b16e-11eb-b0cd-0255ac101da1/c7ecb230-b16f-11eb-b3b6-0255ac1015a3
+```

--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -1,0 +1,251 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud\_cce\_cluster
+
+Provides a CCE cluster resource.
+
+## Basic Usage
+
+```hcl
+resource "g42cloud_vpc" "myvpc" {
+  name = "vpc"
+  cidr = "192.168.0.0/16"
+}
+
+resource "g42cloud_vpc_subnet" "mysubnet" {
+  name          = "subnet"
+  cidr          = "192.168.0.0/16"
+  gateway_ip    = "192.168.0.1"
+
+  //dns is required for cce node installing
+  primary_dns   = "100.125.3.250"
+  secondary_dns = "100.125.3.92"
+  vpc_id        = g42cloud_vpc.myvpc.id
+}
+
+resource "g42cloud_cce_cluster" "cluster" {
+  name                   = "cluster"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.myvpc.id
+  subnet_id              = g42cloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+}
+```
+
+## Cluster With Eip
+
+```hcl
+resource "g42cloud_vpc" "myvpc" {
+  name = "vpc"
+  cidr = "192.168.0.0/16"
+}
+
+resource "g42cloud_vpc_subnet" "mysubnet" {
+  name          = "subnet"
+  cidr          = "192.168.0.0/16"
+  gateway_ip    = "192.168.0.1"
+
+  //dns is required for cce node installing
+  pprimary_dns  = "100.125.3.250"
+  secondary_dns = "100.125.3.92"
+  vpc_id        = g42cloud_vpc.myvpc.id
+}
+
+resource "g42cloud_vpc_eip" "myeip" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_cce_cluster" "cluster" {
+  name                   = "cluster"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.myvpc.id
+  subnet_id              = g42cloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+  authentication_mode    = "rbac"
+  eip                    = g42cloud_vpc_eip.myeip.address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the cce cluster resource.
+  If omitted, the provider-level region will be used. Changing this creates a new cce cluster resource.
+
+* `name` - (Required, String, ForceNew) Cluster name. Changing this parameter will create a new cluster resource.
+
+* `flavor_id` - (Required, String, ForceNew) Cluster specifications. Changing this parameter will create a new cluster resource. Possible values:
+
+	* `cce.s1.small` - small-scale single cluster (up to 50 nodes).
+	* `cce.s1.medium` - medium-scale single cluster (up to 200 nodes).
+	* `cce.s1.large` - large-scale single cluster (up to 1000 nodes).
+	* `cce.s2.small` - small-scale HA cluster (up to 50 nodes).
+	* `cce.s2.medium` - medium-scale HA cluster (up to 200 nodes).
+	* `cce.s2.large` - large-scale HA cluster (up to 1000 nodes).
+	* `cce.t1.small` - small-scale single physical machine cluster (up to 10 nodes).
+	* `cce.t1.medium` - medium-scale single physical machine cluster (up to 100 nodes).
+	* `cce.t1.large` - large-scale single physical machine cluster (up to 500 nodes).
+	* `cce.t2.small` - small-scale HA physical machine cluster (up to 10 nodes).
+	* `cce.t2.medium` - medium-scale HA physical machine cluster (up to 100 nodes).
+	* `cce.t2.large` - large-scale HA physical machine cluster (up to 500 nodes).
+
+* `cluster_version` - (Optional, String, ForceNew) For the cluster version, defaults to the latest supported version.
+  Changing this parameter will create a new cluster resource.
+
+* `cluster_type` - (Optional, String, ForceNew) Cluster Type, possible values are VirtualMachine, BareMetal and ARM64. Defaults to *VirtualMachine*.
+  Changing this parameter will create a new cluster resource.
+
+* `description` - (Optional, String) The Cluster description.
+
+* `vpc_id` - (Required, String, ForceNew) The ID of the VPC used to create the node. Changing this parameter will create a new cluster resource.
+
+* `subnet_id` - (Required, String, ForceNew) The ID of the subnet used to create the node  which should be configured with a *DNS address*.
+  Changing this parameter will create a new cluster resource.
+
+* `highway_subnet_id` - (Optional, String, ForceNew) The ID of the high speed network used to create bare metal nodes.
+  Changing this parameter will create a new cluster resource.
+
+* `container_network_type` - (Required, String, ForceNew) Container network parameters. Possible values:
+
+	* `overlay_l2` - An overlay_l2 network built for containers by using Open vSwitch(OVS).
+	* `underlay_ipvlan` - An underlay_ipvlan network built for bare metal servers by using ipvlan.
+	* `vpc-router` - An vpc-router network built for containers by using ipvlan and custom VPC routes.
+	* `eni` - A Yangtse network built for cce turbo cluster. The container network deeply integrates the native ENI capability of VPC, 
+	uses the VPC CIDR block to allocate container addresses, and supports direct connections between ELB and containers to provide high performance.
+
+* `container_network_cidr` - (Optional, String, ForceNew) Container network segment. Changing this parameter will create a new cluster resource.
+
+* `service_network_cidr` - (Optional, String, ForceNew) Service network segment. Changing this parameter will create a new cluster resource.
+
+* `eni_subnet_id` - (Optional, String, ForceNew) ENI subnet id. Specified when creating a CCE Turbo cluster.
+  Changing this parameter will create a new cluster resource.
+
+* `eni_subnet_cidr` - (Optional, String, ForceNew) ENI network segment. Specified when creating a CCE Turbo cluster.
+  Changing this parameter will create a new cluster resource.
+
+* `authentication_mode` - (Optional, String, ForceNew) Authentication mode of the cluster, possible values are x509 and rbac. Defaults to *rbac*.
+    Changing this parameter will create a new cluster resource.
+
+* `authenticating_proxy_ca` - (Optional, String, ForceNew) CA root certificate provided in the authenticating_proxy mode. The CA root certificate
+	is encoded to the Base64 format. Changing this parameter will create a new cluster resource.
+
+* `multi_az` - (Optional, Bool, ForceNew) Enable multiple AZs for the cluster, only when using HA flavors. 
+  Changing this parameter will create a new cluster resource. This parameter and `masters` are alternative
+
+* `masters` - (Optional, List, ForceNew) Advanced configuration of master nodes. Changing this creates a new cluster.
+  This parameter and `multi_az` are alternative.
+
+* `eip` - (Optional, String, ForceNew) EIP address of the cluster. Changing this parameter will create a new cluster resource.
+
+* `kube_proxy_mode` - (Optional, String, ForceNew) Service forwarding mode. Two modes are available:
+
+  - iptables: Traditional kube-proxy uses iptables rules to implement service load balancing. In this mode,
+    too many iptables rules will be generated when many services are deployed. In addition, non-incremental
+    updates will cause a latency and even obvious performance issues in the case of heavy service traffic.
+  - ipvs: Optimized kube-proxy mode with higher throughput and faster speed. This mode supports incremental
+    updates and can keep connections uninterrupted during service updates. It is suitable for large-sized clusters.
+
+* `extend_param` - (Optional, Map, ForceNew) Extended parameter. Changing this parameter will create a new cluster resource.
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the CCE cluster.
+  Valid values are *prePaid* and *postPaid*, defaults to *postPaid*.
+  Changing this creates a new cluster.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the CCE cluster.
+  Valid values are *month* and *year*. This parameter is mandatory if `charging_mode` is set to *prePaid*.
+  Changing this creates a new cluster.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the CCE cluster.
+  If `period_unit` is set to *month*, the value ranges from 1 to 9.
+  If `period_unit` is set to *year*, the value ranges from 1 to 3.
+  This parameter is mandatory if `charging_mode` is set to *prePaid*. Changing this creates a new cluster.
+
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
+  Valid values are "true" and "false". Changing this creates a new cluster.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the cce cluster.
+  Changing this creates a new cluster.
+
+* `delete_evs` - (Optional, String) Specified whether to delete associated EVS disks when deleting the CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_obs` - (Optional, String) Specified whether to delete associated OBS buckets when deleting the CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_sfs` - (Optional, String) Specified whether to delete associated SFS file systems when deleting the CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_efs` - (Optional, String) Specified whether to unbind associated SFS Turbo file systems when deleting the CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_all` - (Optional, String) Specified whether to delete all associated storage resources when deleting the CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+The `masters` block supports:
+
+* `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone of the master node. Changing this creates a new cluster.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+  * `id` -  Id of the cluster resource.
+
+  * `status` -  Cluster status information.
+
+  * `certificate_clusters/name` - The cluster name.
+
+  * `certificate_clusters/server` - The server IP address.
+
+  * `certificate_clusters/certificate_authority_data` - The certificate data.
+
+  * `certificate_users/name` - The user name.
+
+  * `certificate_users/client_certificate_data` - The client certificate data.
+
+  * `certificate_users/client_key_data` - The client key data.
+
+  * `security_group_id` - Security group ID of the cluster.
+
+  * `kube_config_raw` - Raw Kubernetes config to be used by kubectl and other compatible tools.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 30 minute.
+- `delete` - Default is 30 minute.
+
+## Import
+
+ Cluster can be imported using the cluster id, e.g.
+ ```
+ $ terraform import g42cloud_cce_cluster.cluster_1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d  
+```
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include:
+`delete_efs`, `delete_eni`, `delete_evs`, `delete_net`, `delete_obs`, `delete_sfs` and `delete_all`.
+It is generally recommended running `terraform plan` after importing an cce cluster. You can then decide if changes
+should be applied to the cluster, or the resource definition should be updated to align with the cluster. Also you can
+ignore changes as below.
+```
+resource "g42cloud_cce_cluster" "cluster_1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      delete_efs, delete_obs,
+    ]
+  }
+}
+```

--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -1,0 +1,262 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud\_cce\_node
+Add a node to a CCE cluster.
+
+## Basic Usage
+
+```hcl
+
+data "g42cloud_availability_zones" "myaz" {}
+
+resource "g42cloud_compute_keypair" "mykp" {
+  name       = "mykp"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_cce_cluster" "mycluster" {
+  name                   = "mycluster"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.myvpc.id
+  subnet_id              = g42cloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+}
+
+resource "g42cloud_cce_node" "node" {
+  cluster_id        = g42cloud_cce_cluster.mycluster.id
+  name              = "node"
+  flavor_id         = "s3.large.2"
+  availability_zone = data.g42cloud_availability_zones.myaz.names[0]
+  key_pair          = g42cloud_compute_keypair.mykp.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+}
+```
+
+## Node with Eip
+
+```hcl
+resource "g42cloud_cce_node" "mynode" {
+  cluster_id        = g42cloud_cce_cluster.mycluster.id
+  name              = "mynode"
+  flavor_id         = "s3.large.2"
+  availability_zone = data.g42cloud_availability_zones.myaz.names[0]
+  key_pair          = g42cloud_compute_keypair.mykp.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+
+  // Assign EIP
+  iptype                = "5_bgp"
+  bandwidth_charge_mode = "traffic"
+  sharetype             = "PER"
+  bandwidth_size        = 100
+}
+```
+
+## Node with Existing Eip
+
+```hcl
+resource "g42cloud_vpc_eip" "myeip" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_cce_node" "mynode" {
+  cluster_id        = g42cloud_cce_cluster.mycluster.id
+  name              = "mynode"
+  flavor_id         = "s3.large.2"
+  availability_zone = data.g42cloud_availability_zones.myaz.names[0]
+  key_pair          = g42cloud_compute_keypair.mykp.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+
+  // Assign existing EIP
+  eip_id = g42cloud_vpc_eip.myeip.id
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the cce node resource.
+    If omitted, the provider-level region will be used. Changing this creates a new cce node resource.
+
+* `cluster_id` - (Required, String, ForceNew) ID of the cluster. Changing this parameter will create a new resource.
+
+* `name` - (Optional, String) Node Name.
+
+* `flavor_id` - (Required, String, ForceNew) Specifies the flavor id. Changing this parameter will create a new resource.
+
+* `availability_zone` - (Required, String, ForceNew) specify the name of the available partition (AZ).
+    Changing this parameter will create a new resource.
+
+* `os` - (Optional, String, ForceNew) Operating System of the node. Changing this parameter will create a new resource.
+    - For VM nodes, clusters of v1.13 and later support *EulerOS 2.5* and *CentOS 7.6*.
+    - For BMS nodes purchased in the yearly/monthly billing mode, only *EulerOS 2.3* is supported.
+
+* `key_pair` - (Optional, String, ForceNew) Key pair name when logging in to select the key pair mode.
+    This parameter and `password` are alternative. Changing this parameter will create a new resource.
+
+* `password` - (Optional, String, ForceNew) root password when logging in to select the password mode.
+    This parameter must be salted and alternative to `key_pair`. Changing this parameter will create a new resource.
+
+* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
+
+  * `size` - (Required, Int) Disk size in GB.
+  * `volumetype` - (Required, String) Disk type.
+  * `extend_params` - (Optional, Map) Disk expansion parameters.
+
+* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created. Changing this parameter will create a new resource.
+
+  * `size` - (Required, Int) Disk size in GB.
+  * `volumetype` - (Required, String) Disk type.
+  * `extend_params` - (Optional, Map) Disk expansion parameters.
+
+* `subnet_id` - (Optional, String, ForceNew) The ID of the subnet to which the NIC belongs.
+    Changing this parameter will create a new resource.
+
+* `fixed_ip` - (Optional, String, ForceNew) The fixed IP of the NIC. Changing this parameter will create a new resource.
+
+* `eip_id` - (Optional, String, ForceNew) The ID of the EIP. Changing this parameter will create a new resource.
+
+
+-> **Note:** If the eip_id parameter is configured, you do not need to configure the bandwidth parameters:
+  `iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
+
+* `iptype` - (Optional, String, ForceNew) Elastic IP type. Changing this parameter will create a new resource.
+
+* `bandwidth_charge_mode` - (Optional, String, ForceNew) Bandwidth billing type. Changing this parameter will create a new resource.
+
+* `sharetype` - (Optional, String, ForceNew) Bandwidth sharing type. Changing this parameter will create a new resource.
+
+* `bandwidth_size` - (Optional, Int, ForceNew) Bandwidth size. Changing this parameter will create a new resource.
+
+* `max_pods` - (Optional, Int, ForceNew) The maximum number of instances a node is allowed to create.
+    Changing this parameter will create a new resource.
+
+* `esc_group_id` - (Optional, String, ForceNew) Ecs group id. If specified, the node will be created under the cloud server group.
+    Changing this parameter will create a new resource.
+
+* `preinstall` - (Optional, String, ForceNew) Script required before installation. The input value can be a Base64 encoded string or not.
+    Changing this parameter will create a new resource.
+
+* `postinstall` - (Optional, String, ForceNew) Script required after installation. The input value can be a Base64 encoded string or not.
+   Changing this parameter will create a new resource.
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the CCE node.
+    Valid values are *prePaid* and *postPaid*, defaults to *postPaid*.
+    Changing this creates a new resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the CCE node.
+    Valid values are *month* and *year*. This parameter is mandatory if `charging_mode` is set to *prePaid*.
+    Changing this creates a new resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the CCE node.
+    If `period_unit` is set to *month*, the value ranges from 1 to 9.
+    If `period_unit` is set to *year*, the value ranges from 1 to 3.
+    This parameter is mandatory if `charging_mode` is set to *prePaid*. Changing this creates a new resource.
+
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
+    Valid values are "true" and "false". Changing this creates a new resource.
+
+* `runtime` - (Optional, String, ForceNew) Specifies the runtime of the CCE node. Valid values are *docker* and *containerd*.
+    Changing this creates a new resource.
+
+* `extend_param` - (Optional, Map, ForceNew) Extended parameter. Changing this parameter will create a new resource. Availiable keys :
+
+  * `agency_name` - Specifies the agency name to provide temporary credentials for CCE node to access other cloud services.
+  * `alpha.cce/NodeImageID` - This parameter is required when a custom image is used to create a BMS node.
+  * `dockerBaseSize` - The available disk space of a single docker container on the node in device mapper mode.
+  * `DockerLVMConfigOverride` - Docker data disk configurations. The following is an example default configuration:
+
+```hcl
+  extend_param = {
+    DockerLVMConfigOverride = "dockerThinpool=vgpaas/90%VG;kubernetesLV=vgpaas/10%VG;diskType=evs;lvType=linear"
+  }
+```
+
+* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format. Changing this parameter will create a new resource.
+
+* `tags` - (Optional, Map) Tags of a VM node, key/value pair format.
+
+* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:
+
+  * `key` - (Required, String) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-),
+    underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
+  * `value` - (Required, String) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters,
+    digits, hyphens (-), underscores (_), and periods (.).
+  * `effect` - (Required, String) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+* `status` -  Node status information.
+* `server_id` - ID of the ECS instance associated with the node.
+* `private_ip` - Private IP of the CCE node.
+* `public_ip` - Public IP of the CCE node.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 20 minute.
+- `delete` - Default is 20 minute.
+
+## Import
+
+CCE node can be imported using the cluster ID and node ID
+separated by a slash, e.g.:
+
+```
+$ terraform import g42cloud_cce_node.my_node 5c20fdad-7288-11eb-b817-0255ac10158b/e9287dff-7288-11eb-b817-0255ac10158b
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include:
+`password`, `fixed_ip`, `eip_id`, `preinstall`, `postinstall`, `iptype`, `bandwidth_charge_mode`, `bandwidth_size`, 
+`share_type`, `max_pods`, `extend_param`, `labels`, `taints` and arguments for pre-paid.
+It is generally recommended running `terraform plan` after importing a node. 
+You can then decide if changes should be applied to the node, or the resource definition should be updated to align
+with the node. Also you can ignore changes as below.
+```
+resource "g42cloud_cce_node" "my_node" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      extend_param, labels,
+    ]
+  }
+}
+```

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -1,0 +1,179 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud\_cce\_node\_pool
+Add a node pool to a container cluster. 
+
+## Example Usage
+
+```hcl
+variable "cluster_id" { }
+variable "key_pair" { }
+variable "availability_zone" { }
+
+resource "g42cloud_cce_node_pool" "node_pool" {
+  cluster_id               = var.cluster_id
+  name                     = "testpool"
+  os                       = "EulerOS 2.5"
+  initial_node_count       = 2
+  flavor_id                = "s3.large.4"
+  availability_zone        = var.availability_zone
+  key_pair                 = var.keypair
+  scall_enable             = true
+  min_node_count           = 1
+  max_node_count           = 10
+  scale_down_cooldown_time = 100
+  priority                 = 1
+  type                     = "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+``` 
+
+## Argument Reference
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the cce pool resource. If omitted, the provider-level region will be used. Changing this creates a new cce node pool resource.
+
+* `cluster_id` - (Required, String, ForceNew) ID of the cluster. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Node Pool Name.
+
+* `initial_node_count` - (Required, Int) Initial number of expected nodes in the node pool.
+
+* `flavor_id` - (Required, String, ForceNew) Specifies the flavor id. Changing this parameter will create a new resource.
+
+*  `type` - (Optional, String, ForceNew) Node Pool type. Possible values are: "vm" and "ElasticBMS".
+ 
+* `availability_zone` - (Optional, String, ForceNew) specify the name of the available partition (AZ). Default value is random 
+    to create nodes in a random AZ in the node pool.
+    Changing this parameter will create a new resource.
+
+* `os` - (Optional, String) Operating System of the node. The value can be EulerOS 2.5 and CentOS 7.6.
+    Changing this parameter will create a new resource.
+
+* `key_pair` - (Optional, String, ForceNew) Key pair name when logging in to select the key pair mode. This parameter and `password` are alternative.
+    Changing this parameter will create a new resource.
+
+* `password` - (Optional, String, ForceNew) root password when logging in to select the password mode. This parameter must be salted and alternative to `key_pair`.
+    Changing this parameter will create a new resource.
+
+* `subnet_id` - (Optional, String, ForceNew) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
+
+* `max_pods` - (Optional, Int, ForceNew) The maximum number of instances a node is allowed to create.
+    Changing this parameter will create a new resource.
+
+* `preinstall` - (Optional, String, ForceNew) Script required before installation. The input value can be a Base64 encoded string or not.
+    Changing this parameter will create a new resource.
+
+* `postinstall` - (Optional, String, ForceNew) Script required after the installation. The input value can be a Base64 encoded string or not.
+    Changing this parameter will create a new resource.
+
+* `extend_param` - (Optional, Map, ForceNew) Extended parameter. Changing this parameter will create a new resource. Availiable keys :
+
+  * `agency_name` - Specifies the agency name to provide temporary credentials for CCE node to access other cloud services.
+  * `alpha.cce/NodeImageID` - This parameter is required when a custom image is used to create a BMS node.
+  * `dockerBaseSize` - The available disk space of a single docker container on the node in device mapper mode.
+  * `DockerLVMConfigOverride` - Docker data disk configurations. The following is an example default configuration:
+
+```hcl
+  extend_param = {
+    DockerLVMConfigOverride = "dockerThinpool=vgpaas/90%VG;kubernetesLV=vgpaas/10%VG;diskType=evs;lvType=linear"
+  }
+```
+
+* `scall_enable` - (Optional, Bool) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler add-on to use the auto scaling feature.
+
+* `min_node_count` - (Optional, Int) Minimum number of nodes allowed if auto scaling is enabled.
+
+* `max_node_count` - (Optional, Int) Maximum number of nodes allowed if auto scaling is enabled.
+
+* `scale_down_cooldown_time` - (Optional, Int) Interval between two scaling operations, in minutes.
+
+* `priority` - (Optional, Int) Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
+
+* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format. Changing this parameter will create a new resource.
+
+* `tags` - (Optional, Map) Tags of a VM node, key/value pair format.
+
+* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
+
+* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created. Changing this parameter will create a new resource.
+
+* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:
+
+
+The `root_volume` block supports:
+
+* `size` - (Required, Int) Disk size in GB.
+    
+* `volumetype` - (Required, String) Disk type.
+    
+* `extend_params` - (Optional, Map) Disk expansion parameters. 
+
+The `data_volumes` block supports:
+    
+* `size` - (Required, Int) Disk size in GB.
+    
+* `volumetype` - (Required, String) Disk type.
+    
+* `extend_params` - (Optional, Map) Disk expansion parameters. 
+
+The `taints` block supports:
+    
+* `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-), 
+  underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
+    
+* `value` - (Required, String) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters, 
+  digits, hyphens (-), underscores (_), and periods (.).
+    
+* `effect` - (Required, String) Available options are NoSchedule, PreferNoSchedule, and NoExecute. 
+    
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `status` -  Node status information.
+
+* `billing_mode` -  Billing mode of a node.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 20 minute.
+- `delete` - Default is 20 minute.
+
+## Import
+
+CCE node pool can be imported using the cluster ID and node pool ID
+separated by a slash, e.g.:
+
+```
+$ terraform import g42cloud_cce_node_pool.my_node_pool 5c20fdad-7288-11eb-b817-0255ac10158b/e9287dff-7288-11eb-b817-0255ac10158b
+```
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include:
+`password`, `subnet_id`, `preinstall`, `posteinstall`, `taints`.
+It is generally recommended running `terraform plan` after importing a node pool. 
+You can then decide if changes should be applied to the node pool, or the resource definition should be updated to align
+with the node pool. Also you can ignore changes as below.
+```
+resource "g42cloud_cce_node_pool" "my_node_pool" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      password, subnet_id,
+    ]
+  }
+}
+```

--- a/g42cloud/data_source_g42cloud_cce_addon_template_test.go
+++ b/g42cloud/data_source_g42cloud_cce_addon_template_test.go
@@ -1,0 +1,45 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEAddonTemplateV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.g42cloud_cce_addon_template.gpu_beta_test", "spec"),
+					resource.TestCheckResourceAttrSet("data.g42cloud_cce_addon_template.autoscaler_test", "spec"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCEAddonTemplateV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cce_addon_template" "gpu_beta_test" {
+  cluster_id = g42cloud_cce_cluster.test.id
+  name       = "gpu-beta"
+  version    = "1.1.11"
+}
+
+data "g42cloud_cce_addon_template" "autoscaler_test" {
+  cluster_id = g42cloud_cce_cluster.test.id
+  name       = "autoscaler"
+  version    = "1.15.10"
+}
+`, testAccCCEClusterV3_basic(rName))
+}

--- a/g42cloud/data_source_g42cloud_cce_cluster_test.go
+++ b/g42cloud/data_source_g42cloud_cce_cluster_test.go
@@ -1,0 +1,56 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCEClusterV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find cluster data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("cluster data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccCCEClusterV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cce_cluster" "test" {
+  name = g42cloud_cce_cluster.test.name
+}
+`, testAccCCEClusterV3_basic(rName))
+}

--- a/g42cloud/data_source_g42cloud_cce_node_pool_test.go
+++ b/g42cloud/data_source_g42cloud_cce_node_pool_test.go
@@ -1,0 +1,55 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCCENodePoolV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.g42cloud_cce_node_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodePoolV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodePoolV3DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCENodePoolV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find node pools data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Node pool data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccCCENodePoolV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cce_node_pool" "test" {
+  cluster_id = g42cloud_cce_cluster.test.id
+  name       = g42cloud_cce_node_pool.test.name
+}
+`, testAccCCENodePool_basic(rName))
+}

--- a/g42cloud/data_source_g42cloud_cce_node_test.go
+++ b/g42cloud/data_source_g42cloud_cce_node_test.go
@@ -1,0 +1,55 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCCENodeV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.g42cloud_cce_node.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodeV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCENodeV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find nodes data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Node data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccCCENodeV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cce_node" "test" {
+  cluster_id = g42cloud_cce_cluster.test.id
+  name       = g42cloud_cce_node.test.name
+}
+`, testAccCCENodeV3_basic(rName))
+}

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 // This is a global MutexKV for use within this plugin.
@@ -128,6 +129,8 @@ func Provider() terraform.ResourceProvider {
 			"g42cloud_availability_zones":  huaweicloud.DataSourceAvailabilityZones(),
 			"g42cloud_cce_cluster":         huaweicloud.DataSourceCCEClusterV3(),
 			"g42cloud_cce_node":            huaweicloud.DataSourceCCENodeV3(),
+			"g42cloud_cce_addon_template":  huaweicloud.DataSourceCCEAddonTemplateV3(),
+			"g42cloud_cce_node_pool":       huaweicloud.DataSourceCCENodePoolV3(),
 			"g42cloud_compute_flavors":     huaweicloud.DataSourceEcsFlavors(),
 			"g42cloud_identity_role":       huaweicloud.DataSourceIdentityRoleV3(),
 			"g42cloud_images_image":        huaweicloud.DataSourceImagesImageV2(),
@@ -150,6 +153,8 @@ func Provider() terraform.ResourceProvider {
 			"g42cloud_as_policy":                 huaweicloud.ResourceASPolicy(),
 			"g42cloud_cce_cluster":               huaweicloud.ResourceCCEClusterV3(),
 			"g42cloud_cce_node":                  huaweicloud.ResourceCCENodeV3(),
+			"g42cloud_cce_addon":                 huaweicloud.ResourceCCEAddonV3(),
+			"g42cloud_cce_node_pool":             huaweicloud.ResourceCCENodePool(),
 			"g42cloud_dns_recordset":             huaweicloud.ResourceDNSRecordSetV2(),
 			"g42cloud_dns_zone":                  huaweicloud.ResourceDNSZoneV2(),
 			"g42cloud_identity_role_assignment":  huaweicloud.ResourceIdentityRoleAssignmentV3(),
@@ -246,7 +251,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		project_name = d.Get("region").(string)
 	}
 
-	config := huaweicloud.Config{
+	config := config.Config{
 		AccessKey:           d.Get("access_key").(string),
 		SecretKey:           d.Get("secret_key").(string),
 		DomainName:          d.Get("account_name").(string),

--- a/g42cloud/resource_g42cloud_as_configuration_v1_test.go
+++ b/g42cloud/resource_g42cloud_as_configuration_v1_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccASV1Configuration_basic(t *testing.T) {
@@ -33,7 +33,7 @@ func TestAccASV1Configuration_basic(t *testing.T) {
 }
 
 func testAccCheckASV1ConfigurationDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
@@ -66,7 +66,7 @@ func testAccCheckASV1ConfigurationExists(n string, configuration *configurations
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)

--- a/g42cloud/resource_g42cloud_as_group_v1_test.go
+++ b/g42cloud/resource_g42cloud_as_group_v1_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccASV1Group_basic(t *testing.T) {
@@ -37,7 +37,7 @@ func TestAccASV1Group_basic(t *testing.T) {
 }
 
 func testAccCheckASV1GroupDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
@@ -70,7 +70,7 @@ func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestChe
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)

--- a/g42cloud/resource_g42cloud_as_policy_v1_test.go
+++ b/g42cloud/resource_g42cloud_as_policy_v1_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/policies"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccASV1Policy_basic(t *testing.T) {
@@ -33,7 +33,7 @@ func TestAccASV1Policy_basic(t *testing.T) {
 }
 
 func testAccCheckASV1PolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)
@@ -66,7 +66,7 @@ func testAccCheckASV1PolicyExists(n string, policy *policies.Policy) resource.Te
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		asClient, err := config.AutoscalingV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating g42cloud autoscaling client: %s", err)

--- a/g42cloud/resource_g42cloud_cce_addon_test.go
+++ b/g42cloud/resource_g42cloud_cce_addon_test.go
@@ -1,0 +1,163 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/addons"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCCEAddonV3_basic(t *testing.T) {
+	var addon addons.Addon
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "g42cloud_cce_addon.test"
+	clusterName := "g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEAddonV3_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEAddonV3Exists(resourceName, clusterName, &addon),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCEAddonImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceAddonV3Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating G42Cloud CCE Addon client: %s", err)
+	}
+
+	var clusterId string
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "g42cloud_cce_cluster" {
+			clusterId = rs.Primary.ID
+		}
+
+		if rs.Type != "g42cloud_cce_addon" {
+			continue
+		}
+
+		if clusterId != "" {
+			_, err := addons.Get(cceClient, rs.Primary.ID, clusterId).Extract()
+			if err == nil {
+				return fmt.Errorf("addon still exists")
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckCCEAddonV3Exists(n string, cluster string, addon *addons.Addon) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		c, ok := s.RootModule().Resources[cluster]
+		if !ok {
+			return fmt.Errorf("Cluster not found: %s", c)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		if c.Primary.ID == "" {
+			return fmt.Errorf("Cluster id is not set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceAddonV3Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud CCE Addon client: %s", err)
+		}
+
+		found, err := addons.Get(cceClient, rs.Primary.ID, c.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Metadata.Id != rs.Primary.ID {
+			return fmt.Errorf("Addon not found")
+		}
+
+		*addon = *found
+
+		return nil
+	}
+}
+
+func testAccCCEAddonImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var clusterID string
+		var addonID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "g42cloud_cce_cluster" {
+				clusterID = rs.Primary.ID
+			} else if rs.Type == "g42cloud_cce_addon" {
+				addonID = rs.Primary.ID
+			}
+		}
+		if clusterID == "" || addonID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", clusterID, addonID)
+		}
+		return fmt.Sprintf("%s/%s", clusterID, addonID), nil
+	}
+}
+
+func testAccCCEAddonV3_Base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node" "test" {
+  cluster_id        = g42cloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  key_pair          = g42cloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}
+
+func testAccCCEAddonV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_addon" "test" {
+  cluster_id    = g42cloud_cce_cluster.test.id
+  version       = "1.15.10"
+  template_name = "autoscaler"
+  depends_on    = [g42cloud_cce_node.test]
+}
+`, testAccCCEAddonV3_Base(rName))
+}

--- a/g42cloud/resource_g42cloud_cce_cluster_test.go
+++ b/g42cloud/resource_g42cloud_cce_cluster_test.go
@@ -1,0 +1,250 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCCEClusterV3_basic(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "cce.s1.small"),
+					resource.TestCheckResourceAttr(resourceName, "container_network_type", "overlay_l2"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCCEClusterV3_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "new description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCCEClusterV3_withEip(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3_withEip(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"eip",
+				},
+			},
+		},
+	})
+}
+
+func TestAccCCEClusterV3_withEpsId(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3_withEpsId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCEClusterV3Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_cce_cluster" {
+			continue
+		}
+
+		_, err := clusters.Get(cceClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Cluster still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCCEClusterV3Exists(n string, cluster *clusters.Clusters) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+		}
+
+		found, err := clusters.Get(cceClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Metadata.Id != rs.Primary.ID {
+			return fmt.Errorf("Cluster not found")
+		}
+
+		*cluster = *found
+
+		return nil
+	}
+}
+
+func testAccCCEClusterV3_Base(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name          = "%s"
+  cidr          = "192.168.0.0/16"
+  gateway_ip    = "192.168.0.1"
+
+  //dns is required for cce node installing
+  primary_dns   = "100.125.3.250"
+  secondary_dns = "100.125.3.92"
+  vpc_id        = g42cloud_vpc.test.id
+}
+`, rName, rName)
+}
+
+func testAccCCEClusterV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.test.id
+  subnet_id              = g42cloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+`, testAccCCEClusterV3_Base(rName), rName)
+}
+
+func testAccCCEClusterV3_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.test.id
+  subnet_id              = g42cloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  description            = "new description"
+}
+`, testAccCCEClusterV3_Base(rName), rName)
+}
+
+func testAccCCEClusterV3_withEip(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_cce_cluster" "test" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.test.id
+  subnet_id              = g42cloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  authentication_mode    = "rbac"
+  eip                    = g42cloud_vpc_eip.test.address
+}
+`, testAccCCEClusterV3_Base(rName), rName)
+}
+
+func testAccCCEClusterV3_withEpsId(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.test.id
+  subnet_id              = g42cloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  enterprise_project_id  = "%s"
+}
+
+`, testAccCCEClusterV3_Base(rName), rName, G42_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/g42cloud/resource_g42cloud_cce_node_pool_test.go
+++ b/g42cloud/resource_g42cloud_cce_node_pool_test.go
@@ -1,0 +1,391 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/nodepools"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCCENodePool_basic(t *testing.T) {
+	var nodePool nodepools.NodePool
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	updateName := rName + "update"
+	resourceName := "g42cloud_cce_node_pool.test"
+	//clusterName here is used to provide the cluster id to fetch cce node pool.
+	clusterName := "g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCENodePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodePool_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCENodePoolImportStateIdFunc(),
+			},
+			{
+				Config: testAccCCENodePool_update(rName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scall_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "min_node_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "max_node_count", "9"),
+					resource.TestCheckResourceAttr(resourceName, "scale_down_cooldown_time", "100"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+				),
+			},
+			{
+				Config: testAccCCENodePool_volume_extendParams(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.extend_params.test_key", "test_val"),
+					resource.TestCheckResourceAttr(resourceName, "data_volumes.0.extend_params.test_key1", "test_val1"),
+					resource.TestCheckResourceAttr(resourceName, "data_volumes.1.extend_params.test_key2", "test_val2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCCENodePool_tags(t *testing.T) {
+	var nodePool nodepools.NodePool
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "g42cloud_cce_node_pool.test"
+	//clusterName here is used to provide the cluster id to fetch cce node pool.
+	clusterName := "g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCENodePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodePool_tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.test1", "val1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.test2", "val2"),
+				),
+			},
+			{
+				Config: testAccCCENodePool_tags_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.test1", "val1_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.test2_update", "val2_update"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCENodePoolDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating G42Cloud CCE client: %s", err)
+	}
+
+	var clusterId string
+	var nodepollId string
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "g42cloud_cce_cluster" {
+			clusterId = rs.Primary.ID
+		}
+
+		if rs.Type == "g42cloud_cce_node_pool" {
+			nodepollId = rs.Primary.ID
+		}
+
+		if clusterId == "" || nodepollId == "" {
+			continue
+		}
+
+		_, err := nodepools.Get(cceClient, clusterId, nodepollId).Extract()
+		if err == nil {
+			return fmt.Errorf("Node still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCCENodePoolImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		cluster, ok := s.RootModule().Resources["g42cloud_cce_cluster.test"]
+		if !ok {
+			return "", fmt.Errorf("Cluster not found: %s", cluster)
+		}
+		nodePool, ok := s.RootModule().Resources["g42cloud_cce_node_pool.test"]
+		if !ok {
+			return "", fmt.Errorf("Node pool not found: %s", nodePool)
+		}
+		if cluster.Primary.ID == "" || nodePool.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", cluster.Primary.ID, nodePool.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", cluster.Primary.ID, nodePool.Primary.ID), nil
+	}
+}
+
+func testAccCheckCCENodePoolExists(n string, cluster string, nodePool *nodepools.NodePool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		c, ok := s.RootModule().Resources[cluster]
+		if !ok {
+			return fmt.Errorf("Cluster not found: %s", c)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		if c.Primary.ID == "" {
+			return fmt.Errorf("Cluster id is not set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud CCE client: %s", err)
+		}
+
+		found, err := nodepools.Get(cceClient, c.Primary.ID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Metadata.Id != rs.Primary.ID {
+			return fmt.Errorf("Node Pool not found")
+		}
+
+		*nodePool = *found
+
+		return nil
+	}
+}
+
+func testAccCCENodePool_Base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_compute_keypair" "test" {
+  name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_cce_cluster" "test" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.test.id
+  subnet_id              = g42cloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+`, testAccCCEClusterV3_Base(rName), rName, rName)
+}
+
+func testAccCCENodePool_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node_pool" "test" {
+  cluster_id         = g42cloud_cce_cluster.test.id
+  name               = "%s"
+  os                 = "EulerOS 2.5"
+  flavor_id          = "s6.large.2"
+  initial_node_count = 1
+  availability_zone  = data.g42cloud_availability_zones.test.names[0]
+  key_pair           = g42cloud_compute_keypair.test.name
+  scall_enable      = false
+  min_node_count    = 0
+  max_node_count    = 0
+  scale_down_cooldown_time = 0
+  priority          = 0
+  type 				= "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+}
+`, testAccCCENodePool_Base(rName), rName)
+}
+
+func testAccCCENodePool_update(rName, updateName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node_pool" "test" {
+  cluster_id         = g42cloud_cce_cluster.test.id
+  name               = "%s"
+  os                 = "EulerOS 2.5"
+  flavor_id          = "s6.large.2"
+  initial_node_count = 2
+  availability_zone  = data.g42cloud_availability_zones.test.names[0]
+  key_pair           = g42cloud_compute_keypair.test.name
+  scall_enable      = true
+  min_node_count    = 2
+  max_node_count    = 9
+  scale_down_cooldown_time = 100
+  priority          = 1
+  type 				= "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+}
+`, testAccCCENodePool_Base(rName), updateName)
+}
+
+func testAccCCENodePool_volume_extendParams(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node_pool" "test" {
+  cluster_id         = g42cloud_cce_cluster.test.id
+  name               = "%s"
+  os                 = "EulerOS 2.5"
+  flavor_id          = "s6.large.2"
+  initial_node_count = 1
+  availability_zone  = data.g42cloud_availability_zones.test.names[0]
+  key_pair           = g42cloud_compute_keypair.test.name
+  scall_enable      = false
+  min_node_count    = 0
+  max_node_count    = 0
+  scale_down_cooldown_time = 0
+  priority          = 0
+  type 				= "vm"
+
+  root_volume {
+    size       = 40
+	volumetype = "SSD"
+	extend_params = {
+	  test_key = "test_val"
+	}
+  }
+
+  data_volumes {
+    size       = 100
+	volumetype = "SSD"
+	extend_params = {
+	  test_key1 = "test_val1"
+	}
+  }
+
+  data_volumes {
+    size       = 100
+	volumetype = "SSD"
+	extend_params = {
+	  test_key2 = "test_val2"
+	}
+  }
+}
+`, testAccCCENodePool_Base(rName), rName)
+}
+
+func testAccCCENodePool_tags(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node_pool" "test" {
+  cluster_id               = g42cloud_cce_cluster.test.id
+  name                     = "%s"
+  os                       = "EulerOS 2.5"
+  flavor_id                = "s6.large.2"
+  initial_node_count       = 1
+  availability_zone        = data.g42cloud_availability_zones.test.names[0]
+  key_pair                 = g42cloud_compute_keypair.test.name
+  scall_enable             = false
+  min_node_count           = 0
+  max_node_count           = 0
+  scale_down_cooldown_time = 0
+  priority                 = 0
+  type                     = "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  tags = {
+	test1 = "val1"
+	test2 = "val2"
+  }
+}
+`, testAccCCENodePool_Base(rName), rName)
+}
+
+func testAccCCENodePool_tags_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node_pool" "test" {
+  cluster_id               = g42cloud_cce_cluster.test.id
+  name                     = "%s"
+  os                       = "EulerOS 2.5"
+  flavor_id                = "s6.large.2"
+  initial_node_count       = 1
+  availability_zone        = data.g42cloud_availability_zones.test.names[0]
+  key_pair                 = g42cloud_compute_keypair.test.name
+  scall_enable             = false
+  min_node_count           = 0
+  max_node_count           = 0
+  scale_down_cooldown_time = 0
+  priority                 = 0
+  type                     = "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  tags = {
+	test1        = "val1_update"
+	test2_update = "val2_update"
+  }
+}
+`, testAccCCENodePool_Base(rName), rName)
+}

--- a/g42cloud/resource_g42cloud_cce_node_test.go
+++ b/g42cloud/resource_g42cloud_cce_node_test.go
@@ -1,0 +1,271 @@
+package g42cloud
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCCENodeV3_basic(t *testing.T) {
+	var node nodes.Nodes
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	updateName := rName + "update"
+	resourceName := "g42cloud_cce_node.test"
+	//clusterName here is used to provide the cluster id to fetch cce node.
+	clusterName := "g42cloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodeV3_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccCCENodeV3_update(rName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+				),
+			},
+			{
+				Config: testAccCCENodeV3_auto_assign_eip(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
+				),
+			},
+			{
+				Config: testAccCCENodeV3_existing_eip(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+	}
+
+	var clusterId string
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "g42cloud_cce_cluster" {
+			clusterId = rs.Primary.ID
+		}
+
+		if rs.Type != "g42cloud_cce_node" {
+			continue
+		}
+
+		_, err := nodes.Get(cceClient, clusterId, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Node still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		c, ok := s.RootModule().Resources[cluster]
+		if !ok {
+			return fmt.Errorf("Cluster not found: %s", c)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		if c.Primary.ID == "" {
+			return fmt.Errorf("Cluster id is not set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud CCE client: %s", err)
+		}
+
+		found, err := nodes.Get(cceClient, c.Primary.ID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Metadata.Id != rs.Primary.ID {
+			return fmt.Errorf("Node not found")
+		}
+
+		*node = *found
+
+		return nil
+	}
+}
+
+func testAccCCENodeV3_Base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_compute_keypair" "test" {
+  name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_cce_cluster" "test" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.test.id
+  subnet_id              = g42cloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+`, testAccCCEClusterV3_Base(rName), rName, rName)
+}
+
+func testAccCCENodeV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node" "test" {
+  cluster_id        = g42cloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  key_pair          = g42cloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}
+
+func testAccCCENodeV3_update(rName, updateName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node" "test" {
+  cluster_id        = g42cloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  key_pair          = g42cloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+  tags = {
+    foo = "bar"
+    key = "value_update"
+  }
+}
+`, testAccCCENodeV3_Base(rName), updateName)
+}
+
+func testAccCCENodeV3_auto_assign_eip(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_node" "test" {
+  cluster_id        = g42cloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  key_pair          = g42cloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  // Assign EIP
+  iptype="5_bgp"
+  bandwidth_charge_mode="traffic"
+  sharetype= "PER"
+  bandwidth_size= 100
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}
+
+func testAccCCENodeV3_existing_eip(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_cce_node" "test" {
+  cluster_id        = g42cloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  key_pair          = g42cloud_compute_keypair.test.name
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  // Assign existing EIP
+  eip_id = g42cloud_vpc_eip.test.id
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}

--- a/g42cloud/resource_g42cloud_compute_eip_associate_test.go
+++ b/g42cloud/resource_g42cloud_compute_eip_associate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/servers"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/eips"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccComputeV2EIPAssociate_basic(t *testing.T) {
@@ -74,7 +74,7 @@ func TestAccComputeV2EIPAssociate_fixedIP(t *testing.T) {
 }
 
 func testAccCheckComputeV2EIPAssociateDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud compute client: %s", err)
@@ -131,7 +131,7 @@ func parseComputeFloatingIPAssociateId(id string) (string, string, string, error
 func testAccCheckComputeV2EIPAssociateAssociated(
 	eip *eips.PublicIp, instance *servers.Server, n int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 
 		newInstance, err := servers.Get(computeClient, instance.ID).Extract()

--- a/g42cloud/resource_g42cloud_compute_instance_test.go
+++ b/g42cloud/resource_g42cloud_compute_instance_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/huaweicloud/golangsdk/openstack/common/tags"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/servers"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccComputeV2Instance_basic(t *testing.T) {
@@ -113,7 +113,7 @@ func TestAccComputeV2Instance_tags(t *testing.T) {
 }
 
 func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud compute client: %s", err)
@@ -146,7 +146,7 @@ func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) res
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud compute client: %s", err)
@@ -170,7 +170,7 @@ func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) res
 func testAccCheckComputeV2InstanceTags(
 	instance *servers.Server, k, v string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		client, err := config.ComputeV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud compute v1 client: %s", err)
@@ -196,7 +196,7 @@ func testAccCheckComputeV2InstanceTags(
 func testAccCheckComputeV2InstanceNoTags(
 	instance *servers.Server) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		client, err := config.ComputeV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud compute v1 client: %s", err)

--- a/g42cloud/resource_g42cloud_compute_interface_attach_test.go
+++ b/g42cloud/resource_g42cloud_compute_interface_attach_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/attachinterfaces"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccComputeV2InterfaceAttach_Basic(t *testing.T) {
@@ -34,7 +34,7 @@ func TestAccComputeV2InterfaceAttach_Basic(t *testing.T) {
 }
 
 func testAccCheckComputeV2InterfaceAttachDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud compute client: %s", err)
@@ -70,7 +70,7 @@ func testAccCheckComputeV2InterfaceAttachExists(n string, ai *attachinterfaces.I
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud compute client: %s", err)

--- a/g42cloud/resource_g42cloud_compute_keypair_test.go
+++ b/g42cloud/resource_g42cloud_compute_keypair_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/keypairs"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccComputeV2Keypair_basic(t *testing.T) {
@@ -38,7 +38,7 @@ func TestAccComputeV2Keypair_basic(t *testing.T) {
 }
 
 func testAccCheckComputeV2KeypairDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud compute client: %s", err)
@@ -69,7 +69,7 @@ func testAccCheckComputeV2KeypairExists(n string, kp *keypairs.KeyPair) resource
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud compute client: %s", err)

--- a/g42cloud/resource_g42cloud_compute_servergroup_test.go
+++ b/g42cloud/resource_g42cloud_compute_servergroup_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/servers"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccComputeV2ServerGroup_basic(t *testing.T) {
@@ -60,7 +60,7 @@ func TestAccComputeV2ServerGroup_affinity(t *testing.T) {
 }
 
 func testAccCheckComputeV2ServerGroupDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud compute client: %s", err)
@@ -91,7 +91,7 @@ func testAccCheckComputeV2ServerGroupExists(n string, kp *servergroups.ServerGro
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud compute client: %s", err)

--- a/g42cloud/resource_g42cloud_compute_volume_attach_test.go
+++ b/g42cloud/resource_g42cloud_compute_volume_attach_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccComputeV2VolumeAttach_basic(t *testing.T) {
@@ -57,7 +57,7 @@ func TestAccComputeV2VolumeAttach_device(t *testing.T) {
 }
 
 func testAccCheckComputeV2VolumeAttachDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud compute client: %s", err)
@@ -93,7 +93,7 @@ func testAccCheckComputeV2VolumeAttachExists(n string, va *volumeattach.VolumeAt
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		computeClient, err := config.ComputeV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud compute client: %s", err)

--- a/g42cloud/resource_g42cloud_dns_recordset_v2_test.go
+++ b/g42cloud/resource_g42cloud_dns_recordset_v2_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/recordsets"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func randomZoneName() string {
@@ -93,7 +93,7 @@ func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 }
 
 func testAccCheckDNSV2RecordSetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	dnsClient, err := config.DnsV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
@@ -129,7 +129,7 @@ func testAccCheckDNSV2RecordSetExists(n string, recordset *recordsets.RecordSet)
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		dnsClient, err := config.DnsV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)

--- a/g42cloud/resource_g42cloud_dns_zone_v2_test.go
+++ b/g42cloud/resource_g42cloud_dns_zone_v2_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/zones"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccDNSV2Zone_basic(t *testing.T) {
@@ -61,7 +61,7 @@ func TestAccDNSV2Zone_readTTL(t *testing.T) {
 }
 
 func testAccCheckDNSV2ZoneDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	dnsClient, err := config.DnsV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud DNS client: %s", err)
@@ -92,7 +92,7 @@ func testAccCheckDNSV2ZoneExists(n string, zone *zones.Zone) resource.TestCheckF
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		dnsClient, err := config.DnsV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud DNS client: %s", err)

--- a/g42cloud/resource_g42cloud_evs_snapshot_test.go
+++ b/g42cloud/resource_g42cloud_evs_snapshot_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/evs/v2/snapshots"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccEvsSnapshotV2_basic(t *testing.T) {
@@ -37,7 +37,7 @@ func TestAccEvsSnapshotV2_basic(t *testing.T) {
 }
 
 func testAccCheckEvsSnapshotV2Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	evsClient, err := config.BlockStorageV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud EVS storage client: %s", err)
@@ -68,7 +68,7 @@ func testAccCheckEvsSnapshotV2Exists(n string, sp *snapshots.Snapshot) resource.
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		evsClient, err := config.BlockStorageV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud EVS storage client: %s", err)

--- a/g42cloud/resource_g42cloud_evs_volume_test.go
+++ b/g42cloud/resource_g42cloud_evs_volume_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccEvsStorageV3Volume_basic(t *testing.T) {
@@ -65,7 +65,7 @@ func TestAccEvsStorageV3Volume_image(t *testing.T) {
 }
 
 func testAccCheckEvsStorageV3VolumeDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	blockStorageClient, err := config.BlockStorageV3Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud evs storage client: %s", err)
@@ -96,7 +96,7 @@ func testAccCheckEvsStorageV3VolumeExists(n string, volume *volumes.Volume) reso
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		blockStorageClient, err := config.BlockStorageV3Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud evs storage client: %s", err)
@@ -128,7 +128,7 @@ func testAccCheckEvsStorageV3VolumeTags(n string, k string, v string) resource.T
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		blockStorageClient, err := config.BlockStorageV3Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud block storage client: %s", err)

--- a/g42cloud/resource_g42cloud_identity_group_membership_v3_test.go
+++ b/g42cloud/resource_g42cloud_identity_group_membership_v3_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/users"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccIdentityV3GroupMembership_basic(t *testing.T) {
@@ -48,7 +48,7 @@ func TestAccIdentityV3GroupMembership_basic(t *testing.T) {
 }
 
 func testAccCheckIdentityV3GroupMembershipDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud identity client: %s", err)
@@ -80,7 +80,7 @@ func testAccCheckIdentityV3GroupMembershipExists(n string, us []string) resource
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud identity client: %s", err)

--- a/g42cloud/resource_g42cloud_identity_group_v3_test.go
+++ b/g42cloud/resource_g42cloud_identity_group_v3_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/groups"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccIdentityV3Group_basic(t *testing.T) {
@@ -53,7 +53,7 @@ func TestAccIdentityV3Group_basic(t *testing.T) {
 }
 
 func testAccCheckIdentityV3GroupDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud identity client: %s", err)
@@ -84,7 +84,7 @@ func testAccCheckIdentityV3GroupExists(n string, group *groups.Group) resource.T
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud identity client: %s", err)

--- a/g42cloud/resource_g42cloud_identity_role_assignment_v3_test.go
+++ b/g42cloud/resource_g42cloud_identity_role_assignment_v3_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/projects"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/roles"
 	"github.com/huaweicloud/golangsdk/pagination"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func extractRoleAssignmentID(roleAssignmentID string) (string, string, string, string) {
@@ -49,7 +49,7 @@ func TestAccIdentityV3RoleAssignment_basic(t *testing.T) {
 }
 
 func testAccCheckIdentityV3RoleAssignmentDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud identity client: %s", err)
@@ -80,7 +80,7 @@ func testAccCheckIdentityV3RoleAssignmentExists(n string, role *roles.Role, grou
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud identity client: %s", err)

--- a/g42cloud/resource_g42cloud_identity_user_v3_test.go
+++ b/g42cloud/resource_g42cloud_identity_user_v3_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/users"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccIdentityV3User_basic(t *testing.T) {
@@ -49,7 +49,7 @@ func TestAccIdentityV3User_basic(t *testing.T) {
 }
 
 func testAccCheckIdentityV3UserDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud identity client: %s", err)
@@ -80,7 +80,7 @@ func testAccCheckIdentityV3UserExists(n string, user *users.User) resource.TestC
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		identityClient, err := config.IdentityV3Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud identity client: %s", err)

--- a/g42cloud/resource_g42cloud_images_image_test.go
+++ b/g42cloud/resource_g42cloud_images_image_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/ims/v2/cloudimages"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -72,7 +72,7 @@ func getCloudimage(client *golangsdk.ServiceClient, id string) (*cloudimages.Ima
 }
 
 func testAccCheckImsImageDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	imageClient, err := config.ImageV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud Image: %s", err)
@@ -103,7 +103,7 @@ func testAccCheckImsImageExists(n string, image *cloudimages.Image) resource.Tes
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		imageClient, err := config.ImageV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud Image: %s", err)

--- a/g42cloud/resource_g42cloud_lb_certificate_test.go
+++ b/g42cloud/resource_g42cloud_lb_certificate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/certificates"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2Certificate_basic(t *testing.T) {
@@ -63,7 +63,7 @@ func TestAccLBV2Certificate_client(t *testing.T) {
 }
 
 func testAccCheckLBV2CertificateDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud elb client: %s", err)
@@ -95,7 +95,7 @@ func testAccCheckLBV2CertificateExists(
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud elb client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_l7policy_test.go
+++ b/g42cloud/resource_g42cloud_lb_l7policy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/l7policies"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2L7Policy_basic(t *testing.T) {
@@ -40,7 +40,7 @@ func TestAccLBV2L7Policy_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2L7PolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	lbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud load balancing client: %s", err)
@@ -71,7 +71,7 @@ func testAccCheckLBV2L7PolicyExists(n string, l7Policy *l7policies.L7Policy) res
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		lbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud load balancing client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_l7rule_test.go
+++ b/g42cloud/resource_g42cloud_lb_l7rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	l7rules "github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/l7policies"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2L7Rule_basic(t *testing.T) {
@@ -51,7 +51,7 @@ func TestAccLBV2L7Rule_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2L7RuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	lbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud load balancing client: %s", err)
@@ -94,7 +94,7 @@ func testAccCheckLBV2L7RuleExists(n string, l7rule *l7rules.Rule) resource.TestC
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		lbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud load balancing client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_listener_test.go
+++ b/g42cloud/resource_g42cloud_lb_listener_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2Listener_basic(t *testing.T) {
@@ -41,7 +41,7 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud elb client: %s", err)
@@ -72,7 +72,7 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud elb client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_loadbalancer_test.go
+++ b/g42cloud/resource_g42cloud_lb_loadbalancer_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/ports"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2LoadBalancer_basic(t *testing.T) {
@@ -100,7 +100,7 @@ func TestAccLBV2LoadBalancer_secGroup(t *testing.T) {
 }
 
 func testAccCheckLBV2LoadBalancerDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud elb client: %s", err)
@@ -132,7 +132,7 @@ func testAccCheckLBV2LoadBalancerExists(
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud networking client: %s", err)
@@ -156,7 +156,7 @@ func testAccCheckLBV2LoadBalancerExists(
 func testAccCheckLBV2LoadBalancerHasSecGroup(
 	lb *loadbalancers.LoadBalancer, sg *groups.SecGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		networkingClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud networking client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_member_test.go
+++ b/g42cloud/resource_g42cloud_lb_member_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/pools"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2Member_basic(t *testing.T) {
@@ -42,7 +42,7 @@ func TestAccLBV2Member_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud elb client: %s", err)
@@ -74,7 +74,7 @@ func testAccCheckLBV2MemberExists(n string, member *pools.Member) resource.TestC
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud elb client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_monitor_test.go
+++ b/g42cloud/resource_g42cloud_lb_monitor_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2Monitor_basic(t *testing.T) {
@@ -44,7 +44,7 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud elb client: %s", err)
@@ -75,7 +75,7 @@ func testAccCheckLBV2MonitorExists(n string, monitor *monitors.Monitor) resource
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud elb client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_pool_test.go
+++ b/g42cloud/resource_g42cloud_lb_pool_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/pools"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2Pool_basic(t *testing.T) {
@@ -42,7 +42,7 @@ func TestAccLBV2Pool_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2PoolDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud elb client: %s", err)
@@ -73,7 +73,7 @@ func testAccCheckLBV2PoolExists(n string, pool *pools.Pool) resource.TestCheckFu
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud elb client: %s", err)

--- a/g42cloud/resource_g42cloud_lb_whitelist_test.go
+++ b/g42cloud/resource_g42cloud_lb_whitelist_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccLBV2Whitelist_basic(t *testing.T) {
@@ -38,7 +38,7 @@ func TestAccLBV2Whitelist_basic(t *testing.T) {
 }
 
 func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud elb client: %s", err)
@@ -69,7 +69,7 @@ func testAccCheckLBV2WhitelistExists(n string, whitelist *whitelists.Whitelist) 
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud elb client: %s", err)

--- a/g42cloud/resource_g42cloud_nat_dnat_rule_test.go
+++ b/g42cloud/resource_g42cloud_nat_dnat_rule_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/huaweicloud/golangsdk"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccNatDnat_basic(t *testing.T) {
@@ -81,7 +81,7 @@ func TestAccNatDnat_protocol(t *testing.T) {
 }
 
 func testAccCheckNatDnatDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	client, err := config.NatGatewayClient(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
@@ -111,7 +111,7 @@ func testAccCheckNatDnatDestroy(s *terraform.State) error {
 
 func testAccCheckNatDnatExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		client, err := config.NatGatewayClient(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating sdk client, err=%s", err)

--- a/g42cloud/resource_g42cloud_nat_gateway_test.go
+++ b/g42cloud/resource_g42cloud_nat_gateway_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/natgateways"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccNatGateway_basic(t *testing.T) {
@@ -49,7 +49,7 @@ func TestAccNatGateway_basic(t *testing.T) {
 }
 
 func testAccCheckNatV2GatewayDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	natClient, err := config.NatGatewayClient(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud nat client: %s", err)
@@ -80,7 +80,7 @@ func testAccCheckNatV2GatewayExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		natClient, err := config.NatGatewayClient(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud nat client: %s", err)

--- a/g42cloud/resource_g42cloud_nat_snat_rule_test.go
+++ b/g42cloud/resource_g42cloud_nat_snat_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/hw_snatrules"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccNatSnatRule_basic(t *testing.T) {
@@ -39,7 +39,7 @@ func TestAccNatSnatRule_basic(t *testing.T) {
 }
 
 func testAccCheckNatV2SnatRuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	natClient, err := config.NatGatewayClient(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud nat client: %s", err)
@@ -70,7 +70,7 @@ func testAccCheckNatV2SnatRuleExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		natClient, err := config.NatGatewayClient(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud nat client: %s", err)

--- a/g42cloud/resource_g42cloud_network_acl_rule_test.go
+++ b/g42cloud/resource_g42cloud_network_acl_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/rules"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccNetworkACLRule_basic(t *testing.T) {
@@ -94,7 +94,7 @@ func TestAccNetworkACLRule_anyProtocol(t *testing.T) {
 }
 
 func testAccCheckNetworkACLRuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	fwClient, err := config.FwV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud fw client: %s", err)
@@ -126,7 +126,7 @@ func testAccCheckNetworkACLRuleExists(key string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set in %s", key)
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		fwClient, err := config.FwV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud fw client: %s", err)

--- a/g42cloud/resource_g42cloud_network_acl_test.go
+++ b/g42cloud/resource_g42cloud_network_acl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/firewall_groups"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccNetworkACL_basic(t *testing.T) {
@@ -110,7 +111,7 @@ func TestAccNetworkACL_remove(t *testing.T) {
 }
 
 func testAccCheckNetworkACLDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	fwClient, err := config.FwV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42Cloud fw client: %s", err)
@@ -142,7 +143,7 @@ func testAccCheckNetworkACLExists(n string, fwGroup *huaweicloud.FirewallGroup) 
 			return fmt.Errorf("No ID is set in %s", n)
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		fwClient, err := config.FwV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42Cloud fw client: %s", err)

--- a/g42cloud/resource_g42cloud_networking_secgroup_rule_v2_test.go
+++ b/g42cloud/resource_g42cloud_networking_secgroup_rule_v2_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/rules"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccNetworkingV2SecGroupRule_basic(t *testing.T) {
@@ -116,7 +116,7 @@ func TestAccNetworkingV2SecGroupRule_numericProtocol(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2SecGroupRuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	networkingClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
@@ -147,7 +147,7 @@ func testAccCheckNetworkingV2SecGroupRuleExists(n string, security_group_rule *r
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		networkingClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)

--- a/g42cloud/resource_g42cloud_networking_secgroup_v2_test.go
+++ b/g42cloud/resource_g42cloud_networking_secgroup_v2_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
@@ -85,7 +85,7 @@ func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
 }
 
 func testAccCheckNetworkingV2SecGroupDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	networkingClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
@@ -116,7 +116,7 @@ func testAccCheckNetworkingV2SecGroupExists(n string, security_group *groups.Sec
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		networkingClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)

--- a/g42cloud/resource_g42cloud_sfs_turbo_test.go
+++ b/g42cloud/resource_g42cloud_sfs_turbo_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/sfs_turbo/v1/shares"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccSFSTurbo_basic(t *testing.T) {
@@ -52,7 +52,7 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 }
 
 func testAccCheckSFSTurboDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	sfsClient, err := config.SfsV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating G42cloud sfs turbo client: %s", err)
@@ -83,7 +83,7 @@ func testAccCheckSFSTurboExists(n string, share *shares.Turbo) resource.TestChec
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		sfsClient, err := config.SfsV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating G42cloud sfs turbo client: %s", err)

--- a/g42cloud/resource_g42cloud_vpc_bandwidth_test.go
+++ b/g42cloud/resource_g42cloud_vpc_bandwidth_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/bandwidths"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccVpcBandWidthV2_basic(t *testing.T) {
@@ -70,7 +70,7 @@ func TestAccVpcBandWidthV2_WithEpsId(t *testing.T) {
 }
 
 func testAccCheckVpcBandWidthV2Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	networkingClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating g42cloud networking client: %s", err)
@@ -101,7 +101,7 @@ func testAccCheckVpcBandWidthV2Exists(n string, bandwidth *bandwidths.BandWidth)
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		networkingClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating g42cloud networking client: %s", err)

--- a/g42cloud/resource_g42cloud_vpc_eip_test.go
+++ b/g42cloud/resource_g42cloud_vpc_eip_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/eips"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccVpcV1EIP_basic(t *testing.T) {
@@ -55,7 +55,7 @@ func TestAccVpcV1EIP_share(t *testing.T) {
 }
 
 func testAccCheckVpcV1EIPDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	networkingClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating EIP Client: %s", err)
@@ -86,7 +86,7 @@ func testAccCheckVpcV1EIPExists(n string, eip *eips.PublicIp) resource.TestCheck
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		networkingClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating networking client: %s", err)

--- a/g42cloud/resource_g42cloud_vpc_peering_connection_test.go
+++ b/g42cloud/resource_g42cloud_vpc_peering_connection_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/peerings"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccVpcPeeringConnectionV2_basic(t *testing.T) {
@@ -48,7 +48,7 @@ func TestAccVpcPeeringConnectionV2_basic(t *testing.T) {
 }
 
 func testAccCheckVpcPeeringConnectionV2Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating huaweicloud Peering client: %s", err)
@@ -79,7 +79,7 @@ func testAccCheckVpcPeeringConnectionV2Exists(n string, peering *peerings.Peerin
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		peeringClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating huaweicloud Peering client: %s", err)

--- a/g42cloud/resource_g42cloud_vpc_route_test.go
+++ b/g42cloud/resource_g42cloud_vpc_route_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/routes"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccVpcRouteV2_basic(t *testing.T) {
@@ -41,7 +41,7 @@ func TestAccVpcRouteV2_basic(t *testing.T) {
 }
 
 func testAccCheckRouteV2Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	routeClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating huaweicloud route client: %s", err)
@@ -72,7 +72,7 @@ func testAccCheckRouteV2Exists(n string, route *routes.Route) resource.TestCheck
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		routeClient, err := config.NetworkingV2Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating huaweicloud route client: %s", err)

--- a/g42cloud/resource_g42cloud_vpc_subnet_test.go
+++ b/g42cloud/resource_g42cloud_vpc_subnet_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccVpcSubnetV1_basic(t *testing.T) {
@@ -52,7 +52,7 @@ func TestAccVpcSubnetV1_basic(t *testing.T) {
 }
 
 func testAccCheckVpcSubnetV1Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating huaweicloud vpc client: %s", err)
@@ -82,7 +82,7 @@ func testAccCheckVpcSubnetV1Exists(n string, subnet *subnets.Subnet) resource.Te
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		subnetClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating huaweicloud Vpc client: %s", err)

--- a/g42cloud/resource_g42cloud_vpc_test.go
+++ b/g42cloud/resource_g42cloud_vpc_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/vpcs"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func TestAccVpcV1_basic(t *testing.T) {
@@ -54,7 +54,7 @@ func TestAccVpcV1_basic(t *testing.T) {
 }
 
 func testAccCheckVpcV1Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*huaweicloud.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating huaweicloud vpc client: %s", err)
@@ -85,7 +85,7 @@ func testAccCheckVpcV1Exists(n string, vpc *vpcs.Vpc) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*huaweicloud.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		vpcClient, err := config.NetworkingV1Client(G42_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating huaweicloud vpc client: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210323020602-6d5ee0030244
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.22.3-0.20210325093634-f44e24d59cc2
+	github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.24.2
 )

--- a/go.sum
+++ b/go.sum
@@ -213,10 +213,10 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210323020602-6d5ee0030244 h1:Jzq3828aWxaRquRxPqv8aG1A6B+LatrIHiD3SMlHpFM=
-github.com/huaweicloud/golangsdk v0.0.0-20210323020602-6d5ee0030244/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.22.3-0.20210325093634-f44e24d59cc2 h1:zKqa2HIa0bie/qguebrAuRbsfPuieVrvF/d7OsaKZLY=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.22.3-0.20210325093634-f44e24d59cc2/go.mod h1:qNIXQeWgnLcfQzlJ2A4ckgr1I08dl2I8RPDF7v7OKlo=
+github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0 h1:ap/m0dp+LvmAHQsQmSwYU0yOKxYz2b7iYpbgtUnXO0Y=
+github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.24.2 h1:Nf/o7GqGoWgEQNFv2ccJ8O+53OOd5+olh3D92dIOCks=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.24.2/go.mod h1:rPt3nkLckiRJMQYxhjPa4OeZ71IayOTlLzkkvW8KwDc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
The following resources and data_sources are added:
g42cloud/resource_g42cloud_cce_cluster
g42cloud/resource_g42cloud_cce_node
g42cloud/resource_g42cloud_cce_node_pool
g42cloud/resource_g42cloud_cce_addon

g42cloud/data_source_g42cloud_cce_cluster
g42cloud/data_source_g42cloud_cce_node
g42cloud/data_source_g42cloud_cce_node_pool
g42cloud/data_source_g42cloud_cce_addon_template


Test results:
```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCEClusterV3_basic -timeout 360m -parallel=4
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (381.42s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      381.509s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCEClusterV3_with' TEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCEClusterV3_with -timeout 360m -parallel=1
=== RUN   TestAccCCEClusterV3_withEip
=== PAUSE TestAccCCEClusterV3_withEip
=== RUN   TestAccCCEClusterV3_withEpsId
=== PAUSE TestAccCCEClusterV3_withEpsId
=== CONT  TestAccCCEClusterV3_withEip
--- PASS: TestAccCCEClusterV3_withEip (321.58s)
=== CONT  TestAccCCEClusterV3_withEpsId
--- PASS: TestAccCCEClusterV3_withEpsId (318.39s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      640.032s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel=4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (1256.83s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      1256.880s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCENodePool' TEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCENodePool -timeout 360m -parallel=1
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== RUN   TestAccCCENodePool_tags
=== PAUSE TestAccCCENodePool_tags
=== CONT  TestAccCCENodePoolV3DataSource_basic
--- PASS: TestAccCCENodePoolV3DataSource_basic (603.55s)
=== CONT  TestAccCCENodePool_tags
--- PASS: TestAccCCENodePool_tags (618.30s)
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (984.78s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      2206.681s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCEAddonV3_basic' TEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCEAddonV3_basic -timeout 360m -parallel=1
=== RUN   TestAccCCEAddonV3_basic
=== PAUSE TestAccCCEAddonV3_basic
=== CONT  TestAccCCEAddonV3_basic
--- PASS: TestAccCCEAddonV3_basic (690.59s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      690.622s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCEClusterV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCEClusterV3DataSource_basic -timeout 360m -parallel=4
=== RUN   TestAccCCEClusterV3DataSource_basic
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== CONT  TestAccCCEClusterV3DataSource_basic
--- PASS: TestAccCCEClusterV3DataSource_basic (313.17s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      313.212s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCENodeV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCENodeV3DataSource_basic -timeout 360m -parallel=4
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== CONT  TestAccCCENodeV3DataSource_basic
--- PASS: TestAccCCENodeV3DataSource_basic (633.01s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      633.090s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCENodePoolV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCENodePoolV3DataSource_basic -timeout 360m -parallel=4
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== CONT  TestAccCCENodePoolV3DataSource_basic
--- PASS: TestAccCCENodePoolV3DataSource_basic (580.49s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      580.590s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccCCEAddonTemplateV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccCCEAddonTemplateV3DataSource_basic -timeout 360m -parallel=4
=== RUN   TestAccCCEAddonTemplateV3DataSource_basic
=== PAUSE TestAccCCEAddonTemplateV3DataSource_basic
=== CONT  TestAccCCEAddonTemplateV3DataSource_basic
--- PASS: TestAccCCEAddonTemplateV3DataSource_basic (327.05s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      327.094s
```