### PR TITLE
add smn resources

### DIFF
--- a/docs/resources/smn_subscription.md
+++ b/docs/resources/smn_subscription.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Simple Message Notification (SMN)"
+---
+
+# g42cloud\_smn\_subscription
+
+Manages SMN subscription resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_smn_topic" "topic_1" {
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
+}
+
+resource "g42cloud_smn_subscription" "subscription_1" {
+  topic_urn = g42cloud_smn_topic.topic_1.id
+  endpoint  = "mailtest@gmail.com"
+  protocol  = "email"
+  remark    = "O&M"
+}
+
+resource "g42cloud_smn_subscription" "subscription_2" {
+  topic_urn = g42cloud_smn_topic.topic_1.id
+  endpoint  = "13600000000"
+  protocol  = "sms"
+  remark    = "O&M"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the SMN subscription resource. If omitted, the provider-level region will be used. Changing this creates a new SMN subscription resource.
+
+* `topic_urn` - (Required, String, ForceNew) Resource identifier of a topic, which is unique.
+
+* `endpoint` - (Required, String, ForceNew) Message endpoint.
+     For an HTTP subscription, the endpoint starts with http\://.
+     For an HTTPS subscription, the endpoint starts with https\://.
+     For an email subscription, the endpoint is a mail address.
+     For an SMS message subscription, the endpoint is a phone number.
+
+* `protocol` - (Required, String, ForceNew) Protocol of the message endpoint. Currently, email,
+     sms, http, and https are supported.
+
+* `remark` - (Optional, String, ForceNew) Remark information. The remarks must be a UTF-8-coded
+     character string containing 128 bytes.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `subscription_urn` - Resource identifier of a subscription, which is unique.
+
+* `owner` - Project ID of the topic creator.
+
+* `status` - Subscription status.
+     0 indicates that the subscription is not confirmed.
+     1 indicates that the subscription is confirmed.
+     3 indicates that the subscription is canceled.

--- a/docs/resources/smn_topic.md
+++ b/docs/resources/smn_topic.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Simple Message Notification (SMN)"
+---
+
+# g42cloud\_smn\_topic
+
+Manages a SMN Topic resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_smn_topic" "topic_1" {
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the SMN topic resource. If omitted, the provider-level region will be used. Changing this creates a new SMN Topic resource.
+
+* `name` - (Required, String, ForceNew) The name of the topic to be created.
+
+* `display_name` - (Optional, String) Topic display name, which is presented as the
+    name of the email sender in an email message.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `topic_urn` - Resource identifier of a topic, which is unique.
+
+* `push_policy` - Message pushing policy. 0 indicates that the message
+    sending fails and the message is cached in the queue. 1 indicates that the
+    failed message is discarded.
+
+* `create_time` - Time when the topic was created.
+
+* `update_time` - Time when the topic was updated.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -202,6 +202,8 @@ func Provider() terraform.ResourceProvider {
 			"g42cloud_obs_bucket_object":         huaweicloud.ResourceObsBucketObject(),
 			"g42cloud_obs_bucket_policy":         huaweicloud.ResourceObsBucketPolicy(),
 			"g42cloud_sfs_turbo":                 huaweicloud.ResourceSFSTurbo(),
+			"g42cloud_smn_subscription":          huaweicloud.ResourceSubscription(),
+			"g42cloud_smn_topic":                 huaweicloud.ResourceTopic(),
 			"g42cloud_vpc":                       huaweicloud.ResourceVirtualPrivateCloudV1(),
 			"g42cloud_vpc_bandwidth":             huaweicloud.ResourceVpcBandWidthV2(),
 			"g42cloud_vpc_eip":                   huaweicloud.ResourceVpcEIPV1(),

--- a/g42cloud/resource_g42cloud_smn_subscription_v2_test.go
+++ b/g42cloud/resource_g42cloud_smn_subscription_v2_test.go
@@ -1,0 +1,124 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/smn/v2/subscriptions"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccSMNV2Subscription_basic(t *testing.T) {
+	var subscription1 subscriptions.SubscriptionGet
+	var subscription2 subscriptions.SubscriptionGet
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSMNSubscriptionV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSMNV2SubscriptionConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMNV2SubscriptionExists("g42cloud_smn_subscription.subscription_1", &subscription1),
+					testAccCheckSMNV2SubscriptionExists("g42cloud_smn_subscription.subscription_2", &subscription2),
+					resource.TestCheckResourceAttr(
+						"g42cloud_smn_subscription.subscription_1", "endpoint",
+						"mailtest@gmail.com"),
+					resource.TestCheckResourceAttr(
+						"g42cloud_smn_subscription.subscription_2", "endpoint",
+						"13600000000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSMNSubscriptionV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	smnClient, err := config.SmnV2Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating G42Cloud smn: %s", err)
+	}
+	var subscription *subscriptions.SubscriptionGet
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_smn_subscription" {
+			continue
+		}
+		foundList, err := subscriptions.List(smnClient).Extract()
+		if err != nil {
+			return err
+		}
+		for _, subObject := range foundList {
+			if subObject.SubscriptionUrn == rs.Primary.ID {
+				subscription = &subObject
+			}
+		}
+		if subscription != nil {
+			return fmt.Errorf("subscription still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSMNV2SubscriptionExists(n string, subscription *subscriptions.SubscriptionGet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		smnClient, err := config.SmnV2Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud smn client: %s", err)
+		}
+
+		foundList, err := subscriptions.List(smnClient).Extract()
+		if err != nil {
+			return err
+		}
+		for _, subObject := range foundList {
+			if subObject.SubscriptionUrn == rs.Primary.ID {
+				subscription = &subObject
+			}
+		}
+		if subscription == nil {
+			return fmt.Errorf("subscription not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccSMNV2SubscriptionConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_smn_topic" "topic_1" {
+  name         = "%s"
+  display_name = "The display name of topic_1"
+}
+
+resource "g42cloud_smn_subscription" "subscription_1" {
+  topic_urn       = "${g42cloud_smn_topic.topic_1.id}"
+  endpoint        = "mailtest@gmail.com"
+  protocol        = "email"
+  remark          = "O&M"
+}
+
+resource "g42cloud_smn_subscription" "subscription_2" {
+  topic_urn       = "${g42cloud_smn_topic.topic_1.id}"
+  endpoint        = "13600000000"
+  protocol        = "sms"
+  remark          = "O&M"
+}
+`, rName)
+}

--- a/g42cloud/resource_g42cloud_smn_topic_v2_test.go
+++ b/g42cloud/resource_g42cloud_smn_topic_v2_test.go
@@ -1,0 +1,99 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/smn/v2/topics"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccSMNV2Topic_basic(t *testing.T) {
+	var topic topics.TopicGet
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	displayName := fmt.Sprintf("The display name of %s", rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSMNTopicV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSMNV2TopicConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMNV2TopicExists("g42cloud_smn_topic.topic_1", &topic),
+					resource.TestCheckResourceAttr(
+						"g42cloud_smn_topic.topic_1", "name", rName),
+					resource.TestCheckResourceAttr(
+						"g42cloud_smn_topic.topic_1", "display_name",
+						displayName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSMNTopicV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	smnClient, err := config.SmnV2Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating G42Cloud smn: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_smn_topic" {
+			continue
+		}
+
+		_, err := topics.Get(smnClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Topic still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSMNV2TopicExists(n string, topic *topics.TopicGet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		smnClient, err := config.SmnV2Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud smn client: %s", err)
+		}
+
+		found, err := topics.Get(smnClient, rs.Primary.ID).ExtractGet()
+		if err != nil {
+			return err
+		}
+
+		if found.TopicUrn != rs.Primary.ID {
+			return fmt.Errorf("Topic not found")
+		}
+
+		*topic = *found
+
+		return nil
+	}
+}
+
+func testAccSMNV2TopicConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_smn_topic" "topic_1" {
+  name         = "%s"
+  display_name = "The display name of %s"
+}
+`, rName, rName)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210621093751-3dd439dd31e3
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.25.2-0.20210628095113-732d0c0848ea
+	github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.25.2-0.20210629071312-e4223093e231
 )

--- a/go.sum
+++ b/go.sum
@@ -215,10 +215,10 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210621093751-3dd439dd31e3 h1:RF1TuFSkplWinbZpl6BfVJ+r394k4xOkVKXUt09IjJo=
-github.com/huaweicloud/golangsdk v0.0.0-20210621093751-3dd439dd31e3/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.25.2-0.20210628095113-732d0c0848ea h1:WWkMCB88HEHG/x+uTrYcbI4c1TKhMElR2NnfvSZku48=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.25.2-0.20210628095113-732d0c0848ea/go.mod h1:VbNxIwsq/XMytgCufas1OF0VbJYyZxcv+shzv0OUsPs=
+github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172 h1:6OLBFIxdht5gTP3AVkKM4CngryJSwRrFGX43xqAPAu4=
+github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.25.2-0.20210629071312-e4223093e231 h1:tQmU23PVFAVncY7CtFiF3k01WkS0ltYOtEzxqH3DNTQ=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.25.2-0.20210629071312-e4223093e231/go.mod h1:mq/7geAc7LaLTfsCOnlGFR3rFCNvAqFws4uzoKFU3II=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
The following resources are added:
resource_g42cloud_smn_subscription
resource_g42cloud_smn_topic

Test results:
```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccSMNV2Topic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccSMNV2Topic -timeout 360m -parallel=4
=== RUN   TestAccSMNV2Topic_basic
=== PAUSE TestAccSMNV2Topic_basic
=== CONT  TestAccSMNV2Topic_basic
--- PASS: TestAccSMNV2Topic_basic (15.74s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      15.783s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccSMNV2Subscription'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccSMNV2Subscription -timeout 360m -parallel=4
=== RUN   TestAccSMNV2Subscription_basic
=== PAUSE TestAccSMNV2Subscription_basic
=== CONT  TestAccSMNV2Subscription_basic
--- PASS: TestAccSMNV2Subscription_basic (18.57s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      18.613s
```