### PR TITLE
add resources of OBS

### DIFF
--- a/docs/data-sources/obs_bucket_object.md
+++ b/docs/data-sources/obs_bucket_object.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# g42cloud\_obs\_bucket\_object
+
+Use this data source to get info of special G42Cloud obs object.
+
+```hcl
+data "g42cloud_obs_bucket_object" "object" {
+  bucket = "my-test-bucket"
+  key    = "new-key"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the OBS object. If omitted, the provider-level region will be used.
+
+* `bucket` - (Required, String) The name of the bucket to put the file in.
+
+* `key` - (Required, String) The name of the object once it is in the bucket.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - the `key` of the resource supplied above.
+* `bucket` -  the name of the bucket to put the file in.
+* `key` - the name of the object once it is in the bucket.
+* `etag` - the ETag generated for the object (an MD5 sum of the object content).
+  When the object is encrypted on the server side, the ETag value is not the MD5 value of the object,
+  but the unique identifier calculated through the server-side encryption.
+* `size` - the size of the object in bytes.
+* `version_id` - a unique version ID value for the object, if bucket versioning is enabled.
+* `storage_class` - specifies the storage class of the object.
+* `content_type` - a standard MIME type describing the format of the object data, e.g. application/octet-stream.
+  All Valid MIME Types are valid for this input.

--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -1,0 +1,280 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# g42cloud\_obs\_bucket
+
+Provides an OBS bucket resource.
+
+## Example Usage
+
+### Private Bucket with Tags
+
+```hcl
+resource "g42cloud_obs_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    foo = "bar"
+    Env = "Test"
+  }
+}
+```
+
+### Enable versioning
+
+```hcl
+resource "g42cloud_obs_bucket" "b" {
+  bucket     = "my-tf-test-bucket"
+  acl        = "private"
+  versioning = true
+}
+```
+
+### Enable Logging
+
+```hcl
+resource "g42cloud_obs_bucket" "log_bucket" {
+  bucket = "my-tf-log-bucket"
+  acl    = "log-delivery-write"
+}
+
+resource "g42cloud_obs_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  logging {
+    target_bucket = g42cloud_obs_bucket.log_bucket.id
+    target_prefix = "log/"
+  }
+}
+```
+
+### Static Website Hosting
+
+```hcl
+resource "g42cloud_obs_bucket" "b" {
+  bucket = "obs-website-test.hashicorp.com"
+  acl    = "public-read"
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+
+    routing_rules = <<EOF
+[{
+    "Condition": {
+        "KeyPrefixEquals": "docs/"
+    },
+    "Redirect": {
+        "ReplaceKeyPrefixWith": "documents/"
+    }
+}]
+EOF
+  }
+}
+```
+
+### Using CORS
+
+```hcl
+resource "g42cloud_obs_bucket" "b" {
+  bucket = "obs-website-test.hashicorp.com"
+  acl    = "public-read"
+
+  cors_rule {
+    allowed_origins = ["https://obs-website-test.hashicorp.com"]
+    allowed_methods = ["PUT", "POST"]
+    allowed_headers = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+```
+
+### Using object lifecycle
+
+```hcl
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket     = "my-bucket"
+  acl        = "private"
+  versioning = true
+
+  lifecycle_rule {
+    name    = "log"
+    prefix  = "log/"
+    enabled = true
+
+    expiration {
+      days = 365
+    }
+    transition {
+      days = 60
+      storage_class = "WARM"
+    }
+    transition {
+      days = 180
+      storage_class = "COLD"
+    }
+  }
+
+  lifecycle_rule {
+    name    = "tmp"
+    prefix  = "tmp/"
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = 180
+    }
+    noncurrent_version_transition {
+      days = 30
+      storage_class = "WARM"
+    }
+    noncurrent_version_transition {
+      days = 60
+      storage_class = "COLD"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required, String, ForceNew) Specifies the name of the bucket. Changing this parameter will create a new resource.
+  A bucket must be named according to the globally applied DNS naming regulations as follows:
+	* The name must be globally unique in OBS.
+	* The name must contain 3 to 63 characters. Only lowercase letters, digits, hyphens (-), and periods (.) are allowed.
+	* The name cannot start or end with a period (.) or hyphen (-), and cannot contain two consecutive periods (.) or contain a period (.) and a hyphen (-) adjacent to each other.
+	* The name cannot be an IP address.
+	* If the name contains any periods (.), a security certificate verification message may appear when you access the bucket or its objects by entering a domain name.
+
+* `storage_class` - (Optional, String) Specifies the storage class of the bucket. OBS provides three storage classes: "STANDARD", "WARM" (Infrequent Access) and "COLD" (Archive). Defaults to `STANDARD`.
+
+* `acl` - (Optional, String) Specifies the ACL policy for a bucket. The predefined common policies are as follows: "private", "public-read", "public-read-write" and "log-delivery-write". Defaults to `private`.
+
+* `policy` - (Optional, String) Specifies the text of the bucket policy in JSON format. For more information about
+  obs format bucket policy, see the [Developer Guide](https://docs.g42cloud.com/en-us/api/obs/obs_04_0027.html).
+
+* `policy_format` - (Optional, String) Specifies the policy format, the supported values are *obs* and *s3*. Defaults to *obs*.
+
+* `tags` - (Optional, Map) A mapping of tags to assign to the bucket. Each tag is represented by one key-value pair.
+
+* `versioning` - (Optional, Bool) Whether enable versioning. Once you version-enable a bucket, it can never return to an unversioned state.
+  You can, however, suspend versioning on that bucket.
+
+* `logging` - (Optional, Map) A settings of bucket logging (documented below).
+
+* `quota` - (Optional, Int) Specifies bucket storage quota. Must be a positive integer in the unit of byte. The maximum storage quota is 2<sup>63</sup> – 1 bytes. The default bucket storage quota is 0, indicating that the bucket storage quota is not limited.
+
+* `website` - (Optional, List) A website object (documented below).
+* `cors_rule` - (Optional, List) A rule of Cross-Origin Resource Sharing (documented below).
+* `lifecycle_rule` - (Optional, List) A configuration of object lifecycle management (documented below).
+
+* `force_destroy` - (Optional, Bool) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. Default to `false`.
+
+* `region` - (Optional, String, ForceNew) Specified the region where this bucket will be created. If not specified, used the region by the provider.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the OBS bucket. Changing this creates a OBS bucket.
+
+The `logging` object supports the following:
+
+* `target_bucket` - (Required, String) The name of the bucket that will receive the log objects.
+  The acl policy of the target bucket should be `log-delivery-write`.
+* `target_prefix` - (Optional, String) To specify a key prefix for log objects.
+
+The `website` object supports the following:
+
+* `index_document` - (Required, String)  Unless using `redirect_all_requests_to`. Specifies the default homepage of the static website, only HTML web pages are supported.
+  OBS only allows files such as `index.html` in the root directory of a bucket to function as the default homepage.
+  That is to say, do not set the default homepage with a multi-level directory structure (for example, /page/index.html).
+
+* `error_document` - (Optional, String) Specifies the error page returned when an error occurs during static website access.
+  Only HTML, JPG, PNG, BMP, and WEBP files under the root directory are supported.
+
+* `redirect_all_requests_to` - (Optional, String) A hostname to redirect all website requests for this bucket to. Hostname can optionally be prefixed with a protocol (`http://` or `https://`) to use when redirecting requests. The default is the protocol that is used in the original request.
+
+* `routing_rules` - (Optional, String) A JSON or XML format containing routing rules describing redirect behavior and when redirects are applied.
+  Each rule contains a `Condition` and a `Redirect` as shown in the following table:
+
+Parameter | Key
+-|-
+Condition | KeyPrefixEquals, HttpErrorCodeReturnedEquals
+Redirect | Protocol, HostName, ReplaceKeyPrefixWith, ReplaceKeyWith, HttpRedirectCode
+
+The `cors_rule` object supports the following:
+
+* `allowed_origins` - (Required, List) Requests from this origin can access the bucket. Multiple matching rules are allowed.
+  One rule occupies one line, and allows one wildcard character (*) at most.
+
+* `allowed_methods` - (Required, List) Specifies the acceptable operation type of buckets and objects.
+  The methods include `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+
+* `allowed_headers` - (Optional, List) Specifies the allowed header of cross-origin requests.
+  Only CORS requests matching the allowed header are valid.
+
+* `expose_headers` - (Optional, List) Specifies the exposed header in CORS responses, providing additional information for clients.
+
+* `max_age_seconds` - (Optional, Int) Specifies the duration that your browser can cache CORS responses, expressed in seconds.
+  The default value is 100.
+
+The `lifecycle_rule` object supports the following:
+
+* `name` - (Required, String) Unique identifier for lifecycle rules. The Rule Name contains a maximum of 255 characters.
+
+* `enabled` - (Required, Bool) Specifies lifecycle rule status.
+
+* `prefix` - (Optional, String) Object key prefix identifying one or more objects to which the rule applies.
+  If omitted, all objects in the bucket will be managed by the lifecycle rule.
+  The prefix cannot start or end with a slash (/), cannot have consecutive slashes (/), and cannot contain the following special characters: \:*?"<>|.
+
+* `expiration` - (Optional, List) Specifies a period when objects that have been last updated are automatically deleted. (documented below).
+* `transition` - (Optional, List) Specifies a period when objects that have been last updated are automatically transitioned to `WARM` or `COLD` storage class (documented below).
+* `noncurrent_version_expiration` - (Optional, List) Specifies a period when noncurrent object versions are automatically deleted. (documented below).
+* `noncurrent_version_transition` - (Optional, List) Specifies a period when noncurrent object versions are automatically transitioned to `WARM` or `COLD` storage class (documented below).
+
+At least one of `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
+
+The `expiration` object supports the following
+
+* `days` - (Required, Int) Specifies the number of days when objects that have been last updated are automatically deleted.
+  The expiration time must be greater than the transition times.
+
+The `transition` object supports the following
+
+* `days` - (Required, Int) Specifies the number of days when objects that have been last updated are automatically transitioned to the specified storage class.
+* `storage_class` - (Required, String) The class of storage used to store the object. Only `WARM` and `COLD` are supported.
+
+The `noncurrent_version_expiration` object supports the following
+
+* `days` - (Required, Int) Specifies the number of days when noncurrent object versions are automatically deleted.
+
+The `noncurrent_version_transition` object supports the following
+
+* `days` - (Required, Int) Specifies the number of days when noncurrent object versions are automatically transitioned to the specified storage class.
+* `storage_class` - (Required, String) The class of storage used to store the object. Only `WARM` and `COLD` are supported.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the bucket.
+* `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.obs.region.g42cloud.com`.
+* `region` - The region where this bucket resides in.
+
+## Import
+
+OBS bucket can be imported using the `bucket`, e.g.
+
+```
+$ terraform import g42cloud_obs_bucket.bucket <bucket-name>
+```
+
+OBS bucket with S3 foramt bucket policy can be imported using the `bucket` and "s3" by a slash, e.g.
+
+```
+$ terraform import g42cloud_obs_bucket_policy.s3_policy <bucket-name>/s3
+```

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# g42cloud\_obs\_bucket\_object
+
+Provides an OBS bucket object resource.
+
+## Example Usage
+
+### Uploading to a bucket
+
+```hcl
+resource "g42cloud_obs_bucket_object" "object" {
+  bucket       = "your_bucket_name"
+  key          = "new_key_from_content"
+  content      = "some object content"
+  content_type = "application/xml"
+}
+```
+
+### Uploading a file to a bucket
+
+```hcl
+resource "g42cloud_obs_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+  acl    = "private"
+}
+
+resource "g42cloud_obs_bucket_object" "object" {
+  bucket = g42cloud_obs_bucket.examplebucket.bucket
+  key    = "new_key_from_file"
+  source = "index.html"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the OBS bucket object resource. If omitted, the provider-level region will be used. Changing this creates a new OBS bucket object resource.
+
+* `bucket` - (Required, String, ForceNew) The name of the bucket to put the file in.
+
+* `key` - (Required, String, ForceNew) The name of the object once it is in the bucket.
+
+* `source` - (Optional, String) The path to the source file being uploaded to the bucket.
+
+* `content` - (Optional, String) The literal content being uploaded to the bucket.
+
+* `acl` - (Optional, String) The ACL policy to apply. Defaults to `private`.
+
+* `storage_class` - (Optioanl, String) Specifies the storage class of the object. Defaults to `STANDARD`.
+
+* `content_type` - (Optional, String) A standard MIME type describing the format of the object data, e.g. application/octet-stream.
+  All Valid MIME Types are valid for this input.
+
+* `sse_kms_key_id` - (Optional, String) The ID of the kms key. If omitted, the default master key will be used.
+
+* `etag` - (Optional, String) Specifies the unique identifier of the object content. It can be used to trigger updates.
+  The only meaningful value is `md5(file("path_to_file"))`.
+
+Either `source` or `content` must be provided to specify the bucket content.
+These two arguments are mutually-exclusive.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - the `key` of the resource supplied above.
+* `etag` - the ETag generated for the object (an MD5 sum of the object content).
+  When the object is encrypted on the server side, the ETag value is not the MD5 value of the object,
+  but the unique identifier calculated through the server-side encryption.
+* `size` - the size of the object in bytes.
+* `version_id` - A unique version ID value for the object, if bucket versioning is enabled.
+

--- a/docs/resources/obs_bucket_policy.md
+++ b/docs/resources/obs_bucket_policy.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# g42cloud\_obs\_bucket\_policy
+
+Attaches a policy to an OBS bucket resource.
+
+## Example Usage
+
+### Policy with OBS format
+
+```hcl
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket = "my-test-bucket"
+}
+
+resource "g42cloud_obs_bucket_policy" "policy" {
+  bucket = g42cloud_obs_bucket.bucket.id
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Sid": "AddPerm",
+      "Effect": "Allow",
+      "Principal": {"ID": "*"},
+      "Action": ["GetObject"],
+      "Resource": "my-test-bucket/*"
+    } 
+  ]
+}
+POLICY
+}
+```
+
+### Policy with S3 format
+
+```hcl
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket = "my-test-bucket"
+}
+
+resource "g42cloud_obs_bucket_policy" "s3_policy" {
+  bucket        = g42cloud_obs_bucket.bucket.id
+  policy_format = "s3"
+  policy        = <<POLICY
+{
+  "Version": "2008-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::my-test-bucket/*",
+      "Condition": {
+        "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}
+POLICY
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the OBS bucket policy resource. If omitted, the provider-level region will be used. Changing this creates a new OBS bucket policy resource.
+
+* `bucket` - (Required, String, ForceNew) Specifies the name of the bucket to which to apply the policy.
+* `policy` - (Required, String) Specifies the text of the bucket policy in JSON format. For more information about
+  obs format bucket policy, see the [Developer Guide](https://docs.g42cloud.com/en-us/api/obs/obs_04_0027.html).
+* `policy_format` - (Optional, String) Specifies the policy format, the supported values are *obs* and *s3*. Defaults to *obs* .
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+## Import
+
+OBS format bucket policy can be imported using the `<bucket>`, e.g.
+
+```
+$ terraform import g42cloud_obs_bucket_policy.policy <bucket-name>
+```
+
+S3 foramt bucket policy can be imported using the `<bucket>` and "s3" by a slash, e.g.
+
+```
+$ terraform import g42cloud_obs_bucket_policy.s3_policy <bucket-name>/s3
+```

--- a/g42cloud/data_source_g42cloud_obs_bucket_object_test.go
+++ b/g42cloud/data_source_g42cloud_obs_bucket_object_test.go
@@ -1,0 +1,225 @@
+package g42cloud
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccG42CloudObsBucketObjectDataSource_content(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceConf, dataSourceConf := testAccG42CloudObsBucketObjectDataSource_content(rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("g42cloud_obs_bucket_object.object"),
+				),
+			},
+			{
+				Config: dataSourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsObsObjectDataSourceExists("data.g42cloud_obs_bucket_object.obj"),
+					resource.TestCheckResourceAttr("data.g42cloud_obs_bucket_object.obj", "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr("data.g42cloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccG42CloudObsBucketObjectDataSource_source(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	rInt := acctest.RandInt()
+
+	// write test data to the tempfile
+	for i := 0; i < 1024; i++ {
+		_, err := tmpFile.WriteString("test obs object file storage")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	tmpFile.Close()
+
+	resourceConf, dataSourceConf := testAccG42CloudObsBucketObjectDataSource_source(rInt, tmpFile.Name())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("g42cloud_obs_bucket_object.object"),
+				),
+			},
+			{
+				Config: dataSourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsObsObjectDataSourceExists("data.g42cloud_obs_bucket_object.obj"),
+					resource.TestCheckResourceAttr("data.g42cloud_obs_bucket_object.obj", "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr("data.g42cloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccG42CloudObsBucketObjectDataSource_allParams(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceConf, dataSourceConf := testAccG42CloudObsBucketObjectDataSource_allParams(rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("g42cloud_obs_bucket_object.object"),
+				),
+			},
+			{
+				Config: dataSourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsObsObjectDataSourceExists("data.g42cloud_obs_bucket_object.obj"),
+					resource.TestCheckResourceAttr("data.g42cloud_obs_bucket_object.obj", "content_type", "application/unknown"),
+					resource.TestCheckResourceAttr("data.g42cloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Obs object data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Obs object data source ID not set")
+		}
+
+		bucket := rs.Primary.Attributes["bucket"]
+		key := rs.Primary.Attributes["key"]
+
+		config := testAccProvider.Meta().(*config.Config)
+		obsClient, err := config.ObjectStorageClient(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud OBS client: %s", err)
+		}
+
+		respList, err := obsClient.ListObjects(&obs.ListObjectsInput{
+			Bucket: bucket,
+			ListObjsInput: obs.ListObjsInput{
+				Prefix: key,
+			},
+		})
+		if err != nil {
+			return getObsError("Error listing objects of OBS bucket", bucket, err)
+		}
+
+		var exist bool
+		for _, content := range respList.Contents {
+			if key == content.Key {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			return fmt.Errorf("object %s not found in bucket %s", key, bucket)
+		}
+
+		return nil
+	}
+}
+
+func testAccG42CloudObsBucketObjectDataSource_content(randInt int) (string, string) {
+	resource := fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "object_bucket" {
+	bucket = "tf-object-test-bucket-%d"
+}
+resource "g42cloud_obs_bucket_object" "object" {
+	bucket = g42cloud_obs_bucket.object_bucket.bucket
+	key = "test-key-%d"
+	content = "some_bucket_content"
+}
+`, randInt, randInt)
+
+	dataSource := fmt.Sprintf(`%s
+data "g42cloud_obs_bucket_object" "obj" {
+	bucket = "tf-object-test-bucket-%d"
+	key = "test-key-%d"
+}`, resource, randInt, randInt)
+
+	return resource, dataSource
+}
+
+func testAccG42CloudObsBucketObjectDataSource_source(randInt int, source string) (string, string) {
+	resource := fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "object_bucket" {
+	bucket = "tf-object-test-bucket-%d"
+}
+resource "g42cloud_obs_bucket_object" "object" {
+	bucket = g42cloud_obs_bucket.object_bucket.bucket
+	key = "test-key-%d"
+	source = "%s"
+	content_type = "binary/octet-stream"
+}
+`, randInt, randInt, source)
+
+	dataSource := fmt.Sprintf(`%s
+data "g42cloud_obs_bucket_object" "obj" {
+	bucket = "tf-object-test-bucket-%d"
+	key = "test-key-%d"
+}`, resource, randInt, randInt)
+
+	return resource, dataSource
+}
+
+func testAccG42CloudObsBucketObjectDataSource_allParams(randInt int) (string, string) {
+	resource := fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "object_bucket" {
+	bucket = "tf-object-test-bucket-%d"
+}
+resource "g42cloud_obs_bucket_object" "object" {
+	bucket = g42cloud_obs_bucket.object_bucket.bucket
+	key = "test-key-%d"
+	content = <<CONTENT
+	{"msg": "Hi there!"}
+CONTENT
+	acl = "private"
+	content_type = "application/unknown"
+	storage_class = "STANDARD"
+}
+`, randInt, randInt)
+
+	dataSource := fmt.Sprintf(`%s
+data "g42cloud_obs_bucket_object" "obj" {
+	bucket = "tf-object-test-bucket-%d"
+	key = "test-key-%d"
+}`, resource, randInt, randInt)
+
+	return resource, dataSource
+}

--- a/g42cloud/provider_test.go
+++ b/g42cloud/provider_test.go
@@ -16,6 +16,8 @@ var (
 	G42_ACCOUNT_NAME               = os.Getenv("G42_ACCOUNT_NAME")
 	G42_ADMIN                      = os.Getenv("G42_ADMIN")
 	G42_ENTERPRISE_PROJECT_ID_TEST = os.Getenv("G42_ENTERPRISE_PROJECT_ID_TEST")
+	G42_ACCESS_KEY                 = os.Getenv("G42_ACCESS_KEY")
+	G42_SECRET_KEY                 = os.Getenv("G42_SECRET_KEY")
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -47,6 +49,12 @@ func testAccPreCheckAdminOnly(t *testing.T) {
 func testAccPreCheckEpsID(t *testing.T) {
 	if G42_ENTERPRISE_PROJECT_ID_TEST == "" {
 		t.Skip("This environment does not support EPS_ID tests")
+	}
+}
+
+func testAccPreCheckOBS(t *testing.T) {
+	if G42_ACCESS_KEY == "" || G42_SECRET_KEY == "" {
+		t.Skip("G42_ACCESS_KEY and G42_SECRET_KEY must be set for OBS acceptance tests")
 	}
 }
 

--- a/g42cloud/resource_g42cloud_obs_bucket_object_test.go
+++ b/g42cloud/resource_g42cloud_obs_bucket_object_test.go
@@ -1,0 +1,214 @@
+package g42cloud
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccObsBucketObject_source(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	rInt := acctest.RandInt()
+	// write some data to the tempfile
+	err = ioutil.WriteFile(tmpFile.Name(), []byte("initial object state"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketObjectConfigSource(rInt, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("g42cloud_obs_bucket_object.object"),
+					resource.TestCheckResourceAttr(
+						"g42cloud_obs_bucket_object.object", "key", "test-key"),
+					resource.TestCheckResourceAttr(
+						"g42cloud_obs_bucket_object.object", "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr(
+						"g42cloud_obs_bucket_object.object", "storage_class", "STANDARD"),
+				),
+			},
+			{
+				// update with encryption
+				Config: testAccObsBucketObjectConfig_withSSE(rInt, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"g42cloud_obs_bucket_object.object", "encryption", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucketObject_content(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObsBucketObjectConfigContent(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("g42cloud_obs_bucket_object.object"),
+					resource.TestCheckResourceAttr(
+						"g42cloud_obs_bucket_object.object", "key", "test-key"),
+					resource.TestCheckResourceAttr(
+						"g42cloud_obs_bucket_object.object", "size", "19"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	obsClient, err := config.ObjectStorageClient(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating G42Cloud OBS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_obs_bucket_object" {
+			continue
+		}
+
+		bucket := rs.Primary.Attributes["bucket"]
+		key := rs.Primary.Attributes["key"]
+		input := &obs.ListObjectsInput{}
+		input.Bucket = bucket
+		input.Prefix = key
+
+		resp, err := obsClient.ListObjects(input)
+		if err != nil {
+			if obsError, ok := err.(obs.ObsError); ok && obsError.Code == "NoSuchBucket" {
+				return nil
+			}
+			return fmt.Errorf("Error listing objects of OBS bucket %s: %s", bucket, err)
+		}
+
+		var exist bool
+		for _, content := range resp.Contents {
+			if key == content.Key {
+				exist = true
+				break
+			}
+		}
+		if exist {
+			return fmt.Errorf("Resource %s still exists in bucket %s", rs.Primary.ID, bucket)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No OBS Bucket Object ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		obsClient, err := config.ObjectStorageClient(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud OBS client: %s", err)
+		}
+
+		bucket := rs.Primary.Attributes["bucket"]
+		key := rs.Primary.Attributes["key"]
+		input := &obs.ListObjectsInput{}
+		input.Bucket = bucket
+		input.Prefix = key
+
+		resp, err := obsClient.ListObjects(input)
+		if err != nil {
+			return getObsError("Error listing objects of OBS bucket", bucket, err)
+		}
+
+		var exist bool
+		for _, content := range resp.Contents {
+			if key == content.Key {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			return fmt.Errorf("Resource %s not found in bucket %s", rs.Primary.ID, bucket)
+		}
+
+		return nil
+	}
+}
+
+func getObsError(action string, bucket string, err error) error {
+	if obsError, ok := err.(obs.ObsError); ok {
+		return fmt.Errorf("%s %s: %s,\n Reason: %s", action, bucket, obsError.Code, obsError.Message)
+	}
+	return err
+}
+
+func testAccObsBucketObjectConfigSource(randInt int, source string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "object_bucket" {
+    bucket = "tf-object-test-bucket-%d"
+}
+resource "g42cloud_obs_bucket_object" "object" {
+	bucket = g42cloud_obs_bucket.object_bucket.bucket
+	key = "test-key"
+	source = "%s"
+	content_type = "binary/octet-stream"
+}
+`, randInt, source)
+}
+
+func testAccObsBucketObjectConfigContent(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "object_bucket" {
+        bucket = "tf-object-test-bucket-%d"
+}
+resource "g42cloud_obs_bucket_object" "object" {
+        bucket = g42cloud_obs_bucket.object_bucket.bucket
+        key = "test-key"
+        content = "some_bucket_content"
+}
+`, randInt)
+}
+
+func testAccObsBucketObjectConfig_withSSE(randInt int, source string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "object_bucket" {
+	bucket = "tf-object-test-bucket-%d"
+}
+
+resource "g42cloud_obs_bucket_object" "object" {
+	bucket = g42cloud_obs_bucket.object_bucket.bucket
+	key = "test-key"
+	source = "%s"
+	content_type = "binary/octet-stream"
+	encryption = true
+}
+`, randInt, source)
+}

--- a/g42cloud/resource_g42cloud_obs_bucket_policy_test.go
+++ b/g42cloud/resource_g42cloud_obs_bucket_policy_test.go
@@ -1,0 +1,237 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccObsBucketPolicy_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+	obsName := "g42cloud_obs_bucket.bucket"
+	policyName := "g42cloud_obs_bucket_policy.policy"
+
+	expectedPolicyText := fmt.Sprintf(
+		`{"Statement":[{"Sid":"test1","Effect":"Allow","Principal":{"ID":["*"]},"Action":["GetObject"],"Resource":["%s/*"]}]}`,
+		name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(obsName),
+					testAccCheckObsBucketHasPolicy(policyName, expectedPolicyText),
+					resource.TestCheckResourceAttr(policyName, "policy_format", "obs"),
+				),
+			},
+			{
+				ResourceName:      policyName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccObsBucketPolicy_update(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+	obsName := "g42cloud_obs_bucket.bucket"
+	policyName := "g42cloud_obs_bucket_policy.policy"
+
+	expectedPolicyText1 := fmt.Sprintf(
+		`{"Statement":[{"Sid":"test1","Effect":"Allow","Principal":{"ID":["*"]},"Action":["GetObject"],"Resource":["%s/*"]}]}`,
+		name)
+
+	expectedPolicyText2 := fmt.Sprintf(
+		`{"Statement":[{"Sid":"test2","Effect":"Allow","Principal":{"ID":["*"]},"Action":["GetObject","PutObject","DeleteObject"],"Resource":["%s/*"]}]}`,
+		name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(obsName),
+					testAccCheckObsBucketHasPolicy(policyName, expectedPolicyText1),
+					resource.TestCheckResourceAttr(policyName, "policy_format", "obs"),
+				),
+			},
+
+			{
+				Config: testAccObsBucketPolicyConfig_updated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(obsName),
+					testAccCheckObsBucketHasPolicy(policyName, expectedPolicyText2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucketPolicy_s3(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+	obsName := "g42cloud_obs_bucket.bucket"
+	policyName := "g42cloud_obs_bucket_policy.s3_policy"
+
+	expectedPolicyText := fmt.Sprintf(
+		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::%s","arn:aws:s3:::%s/*"]}]}`,
+		name, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPolicyS3Foramt(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(obsName),
+					testAccCheckObsBucketHasPolicy(policyName, expectedPolicyText),
+					resource.TestCheckResourceAttr(policyName, "policy_format", "s3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckObsBucketHasPolicy(n string, expectedPolicyText string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No OBS Bucket ID is set")
+		}
+
+		var err error
+		var obsClient *obs.ObsClient
+
+		config := testAccProvider.Meta().(*config.Config)
+		format := rs.Primary.Attributes["policy_format"]
+		if format == "obs" {
+			obsClient, err = config.ObjectStorageClientWithSignature(G42_REGION_NAME)
+		} else {
+			obsClient, err = config.ObjectStorageClient(G42_REGION_NAME)
+		}
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud OBS client: %s", err)
+		}
+
+		policy, err := obsClient.GetBucketPolicy(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("GetBucketPolicy error: %v", err)
+		}
+
+		actualPolicyText := policy.Policy
+		if actualPolicyText != expectedPolicyText {
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
+				expectedPolicyText, actualPolicyText)
+		}
+
+		return nil
+	}
+}
+
+func testAccObsBucketPolicyConfig(bucketName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "%s"
+	tags = {
+	  TestName = "TestAccObsBucketPolicy_basic"
+	}
+}
+
+resource "g42cloud_obs_bucket_policy" "policy" {
+	bucket = g42cloud_obs_bucket.bucket.bucket
+	policy =<<POLICY
+{
+	"Statement": [{
+		"Sid": "test1",
+		"Effect": "Allow",
+		"Principal": {
+			"ID": ["*"]
+		},
+		"Action": ["GetObject"],
+		"Resource": ["%s/*"]
+	}]
+}
+POLICY
+}
+`, bucketName, bucketName)
+}
+
+func testAccObsBucketPolicyConfig_updated(bucketName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "%s"
+	tags = {
+	  TestName = "TestAccObsBucketPolicy_updated"
+	}
+}
+
+resource "g42cloud_obs_bucket_policy" "policy" {
+	bucket = g42cloud_obs_bucket.bucket.bucket
+	policy =<<POLICY
+{
+	"Statement": [{
+		"Sid": "test2",
+		"Effect": "Allow",
+		"Principal": {
+			"ID": ["*"]
+		},
+		"Action": ["GetObject", "PutObject", "DeleteObject"],
+		"Resource": ["%s/*"]
+	}]
+}
+POLICY
+}
+`, bucketName, bucketName)
+}
+
+func testAccObsBucketPolicyS3Foramt(bucketName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "%s"
+	tags = {
+	  TestName = "TestAccObsBucketPolicy_s3"
+	}
+}
+
+resource "g42cloud_obs_bucket_policy" "s3_policy" {
+	bucket = g42cloud_obs_bucket.bucket.bucket
+	policy_format = "s3"
+	policy =<<POLICY
+{
+	"Version": "2008-10-17",
+	"Statement": [{
+		"Effect": "Allow",
+		"Principal": {
+			"AWS": ["*"]
+		},
+		"Action": [
+			"s3:*"
+		],
+		"Resource": [
+			"arn:aws:s3:::%s",
+			"arn:aws:s3:::%s/*"
+		]
+	}]
+}
+POLICY
+}
+`, bucketName, bucketName, bucketName)
+}

--- a/g42cloud/resource_g42cloud_obs_bucket_test.go
+++ b/g42cloud/resource_g42cloud_obs_bucket_test.go
@@ -1,0 +1,536 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccObsBucket_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucket_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "bucket", testAccObsBucketName(rInt)),
+					resource.TestCheckResourceAttr(
+						resourceName, "bucket_domain_name", testAccObsBucketDomainName(rInt)),
+					resource.TestCheckResourceAttr(
+						resourceName, "acl", "private"),
+					resource.TestCheckResourceAttr(
+						resourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(
+						resourceName, "region", G42_REGION_NAME),
+				),
+			},
+			{
+				Config: testAccObsBucket_basic_update(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "acl", "public-read"),
+					resource.TestCheckResourceAttr(
+						resourceName, "storage_class", "WARM"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_withEpsId(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucket_epsId(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "bucket", testAccObsBucketName(rInt)),
+					resource.TestCheckResourceAttr(
+						resourceName, "enterprise_project_id", G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_tags(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.name", testAccObsBucketName(rInt)),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_versioning(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithVersioning(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "versioning", "true"),
+				),
+			},
+			{
+				Config: testAccObsBucketConfigWithDisableVersioning(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "versioning", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_logging(t *testing.T) {
+	rInt := acctest.RandInt()
+	target_bucket := fmt.Sprintf("tf-test-log-bucket-%d", rInt)
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithLogging(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					testAccCheckObsBucketLogging(resourceName, target_bucket, "log/"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_quota(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithQuota(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "quota", "1000000000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_lifecycle(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithLifecycle(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.0.name", "rule1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.0.prefix", "path1/"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.1.name", "rule2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.1.prefix", "path2/"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.2.name", "rule3"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.2.prefix", "path3/"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.1.transition.0.days", "30"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.1.transition.1.days", "180"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.2.noncurrent_version_transition.0.days", "60"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.2.noncurrent_version_transition.1.days", "180"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_website(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketWebsiteConfigWithRoutingRules(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "website.0.index_document", "index.html"),
+					resource.TestCheckResourceAttr(
+						resourceName, "website.0.error_document", "error.html"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_cors(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "g42cloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithCORS(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "cors_rule.0.allowed_origins.0", "https://www.example.com"),
+					resource.TestCheckResourceAttr(
+						resourceName, "cors_rule.0.allowed_methods.0", "PUT"),
+					resource.TestCheckResourceAttr(
+						resourceName, "cors_rule.0.allowed_headers.0", "*"),
+					resource.TestCheckResourceAttr(
+						resourceName, "cors_rule.0.expose_headers.1", "ETag"),
+					resource.TestCheckResourceAttr(
+						resourceName, "cors_rule.0.max_age_seconds", "3000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckObsBucketDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	obsClient, err := config.ObjectStorageClient(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating G42Cloud OBS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_obs_bucket" {
+			continue
+		}
+
+		_, err := obsClient.HeadBucket(rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("G42Cloud OBS Bucket %s still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckObsBucketExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		obsClient, err := config.ObjectStorageClient(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud OBS client: %s", err)
+		}
+
+		_, err = obsClient.HeadBucket(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("G42Cloud OBS Bucket not found: %v", err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckObsBucketLogging(name, target, prefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		obsClient, err := config.ObjectStorageClient(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating G42Cloud OBS client: %s", err)
+		}
+
+		output, err := obsClient.GetBucketLoggingConfiguration(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error getting logging configuration of OBS bucket: %s", err)
+		}
+
+		if output.TargetBucket != target {
+			return fmt.Errorf("%s.logging: Attribute 'target_bucket' expected %s, got %s",
+				name, output.TargetBucket, target)
+		}
+		if output.TargetPrefix != prefix {
+			return fmt.Errorf("%s.logging: Attribute 'target_prefix' expected %s, got %s",
+				name, output.TargetPrefix, prefix)
+		}
+
+		return nil
+	}
+}
+
+// These need a bit of randomness as the name can only be used once globally
+func testAccObsBucketName(randInt int) string {
+	return fmt.Sprintf("tf-test-bucket-%d", randInt)
+}
+
+func testAccObsBucketDomainName(randInt int) string {
+	return fmt.Sprintf("tf-test-bucket-%d.obs.%s.g42cloud.com", randInt, G42_REGION_NAME)
+}
+
+func testAccObsBucket_basic(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+    storage_class = "STANDARD"
+	acl = "private"
+}
+`, randInt)
+}
+
+func testAccObsBucket_epsId(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket = "tf-test-bucket-%d"
+  storage_class = "STANDARD"
+  acl = "private"
+  enterprise_project_id = "%s"
+}
+`, randInt, G42_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccObsBucket_basic_update(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+    storage_class = "WARM"
+	acl = "public-read"
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigWithTags(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+
+	tags = {
+		name = "tf-test-bucket-%d"
+        foo = "bar"
+        key1 = "value1"
+	}
+}
+`, randInt, randInt)
+}
+
+func testAccObsBucketConfigWithVersioning(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+	versioning = true
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigWithDisableVersioning(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+	versioning = false
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigWithLogging(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "log_bucket" {
+	bucket = "tf-test-log-bucket-%d"
+	acl = "log-delivery-write"
+    force_destroy = "true"
+}
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+
+	logging {
+		target_bucket = g42cloud_obs_bucket.log_bucket.id
+		target_prefix = "log/"
+	}
+}
+`, randInt, randInt)
+}
+
+func testAccObsBucketConfigWithQuota(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+	quota = 1000000000
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigWithLifecycle(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "private"
+	versioning = true
+
+	lifecycle_rule {
+		name = "rule1"
+		prefix = "path1/"
+		enabled = true
+
+		expiration {
+			days = 365
+		}
+	}
+	lifecycle_rule {
+		name = "rule2"
+		prefix = "path2/"
+		enabled = true
+
+		expiration {
+			days = 365
+		}
+
+		transition {
+			days = 30
+			storage_class = "WARM"
+		}
+		transition {
+			days = 180
+			storage_class = "COLD"
+		}
+	}
+	lifecycle_rule {
+		name = "rule3"
+		prefix = "path3/"
+		enabled = true
+
+		noncurrent_version_expiration {
+			days = 365
+		}
+
+		noncurrent_version_transition {
+			days = 60
+			storage_class = "WARM"
+		}
+		noncurrent_version_transition {
+			days = 180
+			storage_class = "COLD"
+		}
+	}
+}
+`, randInt)
+}
+
+func testAccObsBucketWebsiteConfigWithRoutingRules(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+
+	website {
+		index_document = "index.html"
+		error_document = "error.html"
+		routing_rules = <<EOF
+[{
+	"Condition": {
+		"KeyPrefixEquals": "docs/"
+	},
+	"Redirect": {
+		"ReplaceKeyPrefixWith": "documents/"
+	}
+}]
+EOF
+	}
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigWithCORS(randInt int) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+
+	cors_rule {
+		allowed_headers = ["*"]
+		allowed_methods = ["PUT","POST"]
+		allowed_origins = ["https://www.example.com"]
+		expose_headers  = ["x-amz-server-side-encryption","ETag"]
+		max_age_seconds = 3000
+	}
+}
+`, randInt)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.12
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/huaweicloud/golangsdk v0.0.0-20210706092920-c12079d6a740
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.26.1-0.20210708094519-bfbad0f15b43
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.26.1-0.20210712114231-42e55fb03f2c
 )

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210706092920-c12079d6a740 h1:RCAJI5jVLah5GJkr1lk9I0g6+PdTjUMCwzY5pUUd7fA=
 github.com/huaweicloud/golangsdk v0.0.0-20210706092920-c12079d6a740/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.26.1-0.20210708094519-bfbad0f15b43 h1:aNctfG7G28d83tqdMKbwHYYi8mRFVVEAfBcn83eL4Fo=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.26.1-0.20210708094519-bfbad0f15b43/go.mod h1:OKm++WWk31GyaRAL+gj7SgLu7uaOjw20K+NNoB8fQOA=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.26.1-0.20210712114231-42e55fb03f2c h1:nKLIk+f6HWSdDKIPUXjFDpax0c31tdCCHIFhTv6QVwY=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.26.1-0.20210712114231-42e55fb03f2c/go.mod h1:OKm++WWk31GyaRAL+gj7SgLu7uaOjw20K+NNoB8fQOA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
The following resources are added:
data_source_g42cloud_obs_bucket_object
resource_g42cloud_obs_bucket_object
resource_g42cloud_obs_bucket_policy
resource_g42cloud_obs_bucket

Test results:
```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccG42CloudObsBucketObjectDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccG42CloudObsBucketObjectDataSource -timeout 360m -parallel=4
=== RUN   TestAccG42CloudObsBucketObjectDataSource_content
=== PAUSE TestAccG42CloudObsBucketObjectDataSource_content
=== RUN   TestAccG42CloudObsBucketObjectDataSource_source
=== PAUSE TestAccG42CloudObsBucketObjectDataSource_source
=== RUN   TestAccG42CloudObsBucketObjectDataSource_allParams
=== PAUSE TestAccG42CloudObsBucketObjectDataSource_allParams
=== CONT  TestAccG42CloudObsBucketObjectDataSource_content
=== CONT  TestAccG42CloudObsBucketObjectDataSource_allParams
=== CONT  TestAccG42CloudObsBucketObjectDataSource_source
--- PASS: TestAccG42CloudObsBucketObjectDataSource_content (56.70s)
--- PASS: TestAccG42CloudObsBucketObjectDataSource_allParams (58.05s)
--- PASS: TestAccG42CloudObsBucketObjectDataSource_source (60.13s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      60.196s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccObsBucket'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccObsBucket -timeout 360m -parallel=4
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucket_versioning
=== CONT  TestAccObsBucketPolicy_s3
=== CONT  TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucketPolicy_s3 (31.44s)
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketPolicy_basic (34.47s)
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucket_versioning (57.57s)
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucketObject_source (59.34s)
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucketObject_content (38.76s)
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_tags (29.51s)
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_website (30.92s)
=== CONT  TestAccObsBucket_quota
--- PASS: TestAccObsBucketPolicy_update (70.14s)
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_basic (60.69s)
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_cors (37.53s)
--- PASS: TestAccObsBucket_quota (30.51s)
--- PASS: TestAccObsBucket_lifecycle (31.78s)
--- PASS: TestAccObsBucket_logging (35.33s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      155.455s、

make testacc TEST='./g42cloud' TESTARGS='-run TestAccObsBucketObject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccObsBucketObject -timeout 360m -parallel=4
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (35.57s)
--- PASS: TestAccObsBucketObject_source (55.61s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      55.677s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccObsBucketPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccObsBucketPolicy -timeout 360m -parallel=4
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== CONT  TestAccObsBucketPolicy_basic
=== CONT  TestAccObsBucketPolicy_s3
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucketPolicy_s3 (35.24s)
--- PASS: TestAccObsBucketPolicy_basic (37.42s)
--- PASS: TestAccObsBucketPolicy_update (55.09s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      55.155s
```