### PR TITLE
feat(dli): add resource dli_queue in g42cloud

### DIFF
--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# g42cloud_dli_queue
+
+Manages a DLI queue resource within G42Cloud.
+
+## Example Usage
+
+### create a queue
+
+```hcl
+resource "g42cloud_dli_queue" "queue" {
+  name     = "terraform_dli_queue_test"
+  cu_count = 4
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the DLI queue resource.
+  If omitted, the provider-level region will be used. Changing this creates a new DLI Queue resource.
+
+* `cu_count` - (Required, Int, ForceNew) Specifies the minimum number of CUs that are bound to a queue. The value can be
+  4, 16, or 64. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of a queue. The name can contain only digits, letters, and
+  underscores (_), but cannot contain only digits or start with an
+  underscore (_). Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of a queue.
+  Changing this parameter will create a new resource.
+
+* `management_subnet_cidr` - (Optional, String, ForceNew) Specifies the CIDR of the management subnet.
+  Changing this parameter will create a new resource.
+
+* `subnet_cidr` - (Optional, String, ForceNew) Specifies the subnet CIDR. Changing this parameter will create a new resource.
+
+* `vpc_cidr` - (Optional, String, ForceNew) Specifies the VPC CIDR. Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `create_time` -  Time when a queue is created.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -173,6 +173,7 @@ func Provider() terraform.ResourceProvider {
 			"g42cloud_compute_volume_attach":     huaweicloud.ResourceComputeVolumeAttachV2(),
 			"g42cloud_dcs_instance":              huaweicloud.ResourceDcsInstanceV1(),
 			"g42cloud_dds_instance":              huaweicloud.ResourceDdsInstanceV3(),
+			"g42cloud_dli_queue":                 huaweicloud.ResourceDliQueueV1(),
 			"g42cloud_dms_instance":              ResourceDmsInstancesV1(),
 			"g42cloud_dns_recordset":             huaweicloud.ResourceDNSRecordSetV2(),
 			"g42cloud_dns_zone":                  huaweicloud.ResourceDNSZoneV2(),

--- a/g42cloud/resource_g42cloud_dli_queue_v1_test.go
+++ b/g42cloud/resource_g42cloud_dli_queue_v1_test.go
@@ -1,0 +1,125 @@
+package g42cloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccDliQueueV1_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDliQueueV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliQueueV1_basic(acctest.RandString(10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDliQueueV1Exists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccDliQueueV1_basic(val string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_dli_queue" "queue" {
+  name = "terraform_dli_queue_test_%s"
+  cu_count = 16
+}
+	`, val)
+}
+
+func testAccCheckDliQueueV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	client, err := config.DliV1Client(G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating sdk client, err=%s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_dli_queue" {
+			continue
+		}
+
+		_, err = fetchDliQueueV1ByListOnTest(rs, client)
+		if err != nil {
+			if strings.Index(err.Error(), "Error finding the resource by list api") != -1 {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("g42cloud_dli_queue still exists")
+	}
+
+	return nil
+}
+
+func testAccCheckDliQueueV1Exists() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*config.Config)
+		client, err := config.DliV1Client(G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating sdk client, err=%s", err)
+		}
+
+		rs, ok := s.RootModule().Resources["g42cloud_dli_queue.queue"]
+		if !ok {
+			return fmt.Errorf("Error checking g42cloud_dli_queue.queue exist, err=not found this resource")
+		}
+
+		_, err = fetchDliQueueV1ByListOnTest(rs, client)
+		if err != nil {
+			if strings.Index(err.Error(), "Error finding the resource by list api") != -1 {
+				return fmt.Errorf("g42cloud_dli_queue is not exist")
+			}
+			return fmt.Errorf("Error checking g42cloud_dli_queue.queue exist, err=%s", err)
+		}
+		return nil
+	}
+}
+
+func fetchDliQueueV1ByListOnTest(rs *terraform.ResourceState,
+	client *golangsdk.ServiceClient) (interface{}, error) {
+	link := client.ServiceURL("queues")
+
+	return findDliQueueV1ByList(client, link, rs.Primary.ID)
+}
+
+func findDliQueueV1ByList(client *golangsdk.ServiceClient, link, resourceID string) (interface{}, error) {
+	r, err := sendDliQueueV1ListRequest(client, link)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range r.([]interface{}) {
+		val, ok := item.(map[string]interface{})["queue_name"]
+		if ok && resourceID == convertToStr(val) {
+			return item, nil
+		}
+	}
+
+	return nil, fmtp.Errorf("Error finding the resource by list api")
+}
+
+func sendDliQueueV1ListRequest(client *golangsdk.ServiceClient, url string) (interface{}, error) {
+	r := golangsdk.Result{}
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"}})
+	if r.Err != nil {
+		return nil, fmtp.Errorf("Error running api(list) for resource(DliQueueV1), err=%s", r.Err)
+	}
+
+	v, err := navigateValue(r.Body, []string{"queues"}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
+}

--- a/g42cloud/transport.go
+++ b/g42cloud/transport.go
@@ -1,0 +1,53 @@
+package g42cloud
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func convertToStr(v interface{}) string {
+	return fmt.Sprintf("%v", v)
+}
+
+func navigateValue(d interface{}, index []string, arrayIndex map[string]int) (interface{}, error) {
+	for n, i := range index {
+		if d == nil {
+			return nil, nil
+		}
+		if d1, ok := d.(map[string]interface{}); ok {
+			d, ok = d1[i]
+			if !ok {
+				msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+				return nil, fmt.Errorf("%s: '%s' may not exist", msg, i)
+			}
+		} else {
+			msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+			return nil, fmt.Errorf("%s: Can not convert (%s) to map", msg, reflect.TypeOf(d))
+		}
+
+		if arrayIndex != nil {
+			if j, ok := arrayIndex[strings.Join(index[:n+1], ".")]; ok {
+				if d == nil {
+					return nil, nil
+				}
+				if d2, ok := d.([]interface{}); ok {
+					if len(d2) == 0 {
+						return nil, nil
+					}
+					if j >= len(d2) {
+						msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+						return nil, fmt.Errorf("%s: The index is out of array", msg)
+					}
+
+					d = d2[j]
+				} else {
+					msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+					return nil, fmt.Errorf("%s: Can not convert (%s) to array, index=%s.%v", msg, reflect.TypeOf(d), i, j)
+				}
+			}
+		}
+	}
+
+	return d, nil
+}


### PR DESCRIPTION
add resource dli_queue in g42cloud

Test result:
```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccDliQueueV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccDliQueueV1_basic -timeout 360m -parallel=4
=== RUN   TestAccDliQueueV1_basic
=== PAUSE TestAccDliQueueV1_basic
=== CONT  TestAccDliQueueV1_basic
--- PASS: TestAccDliQueueV1_basic (19.48s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      19.522s
```