### PR TITLE
feat(vpc): add resource networking_eip_associate

### DIFF
--- a/docs/resources/networking_eip_associate.md
+++ b/docs/resources/networking_eip_associate.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# g42cloud_networking_eip_associate
+
+Associates an EIP to a port.
+
+## Example Usage
+
+```hcl
+variable network_id {}
+variable fixed_ip {}
+
+data "g42cloud_networking_port" "myport" {
+  network_id = var.network_id
+  fixed_ip   = var.fixed_ip
+}
+
+resource "g42cloud_vpc_eip" "myeip" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_networking_eip_associate" "associated" {
+  public_ip = g42cloud_vpc_eip.myeip.address
+  port_id   = data.g42cloud_networking_port.myport.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `public_ip` - (Required, String, ForceNew) Specifies the EIP address to associate.
+
+* `port_id` - (Required, String, ForceNew) Specifies an existing port ID to associate with this EIP.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+## Import
+
+EIP associations can be imported using the `id` of the EIP, e.g.
+
+```
+$ terraform import g42cloud_networking_eip_associate.eip 2c7f39f3-702b-48d1-940c-b50384177ee1
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -227,6 +227,7 @@ func Provider() *schema.Provider {
 			"g42cloud_vpc_route":                 vpc.ResourceVPCRouteV2(),
 			"g42cloud_vpc_peering_connection":    vpc.ResourceVpcPeeringConnectionV2(),
 			"g42cloud_vpc_subnet":                vpc.ResourceVpcSubnetV1(),
+			"g42cloud_networking_eip_associate":  huaweicloud.ResourceNetworkingFloatingIPAssociateV2(),
 			"g42cloud_networking_secgroup":       huaweicloud.ResourceNetworkingSecGroupV2(),
 			"g42cloud_networking_secgroup_rule":  huaweicloud.ResourceNetworkingSecGroupRuleV2(),
 			// Legacy

--- a/g42cloud/resource_g42cloud_networking_eip_associate_test.go
+++ b/g42cloud/resource_g42cloud_networking_eip_associate_test.go
@@ -1,0 +1,87 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccNetworkingV2EIPAssociate_basic(t *testing.T) {
+	var eip eips.PublicIp
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "g42cloud_networking_eip_associate.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2EIPAssociateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2EIPAssociate_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcV1EIPExists("g42cloud_vpc_eip.test", &eip),
+					resource.TestCheckResourceAttrPtr(
+						resourceName, "public_ip", &eip.PublicAddress),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingV2EIPAssociateDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	networkingClient, err := config.NetworkingV1Client(G42_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating EIP Client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_vpc_eip" {
+			continue
+		}
+
+		_, err := eips.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmtp.Errorf("EIP still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccNetworkingV2EIPAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "%s"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_networking_eip_associate" "test" {
+  public_ip = g42cloud_vpc_eip.test.address
+  port_id   = g42cloud_compute_instance.test.network[0].port
+}
+`, testAccComputeV2Instance_basic(rName), rName)
+}


### PR DESCRIPTION
add resource networking_eip_associate

test result:
```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccNetworkingV2EIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccNetworkingV2EIPAssociate_basic -timeout 360m -parallel=4
=== RUN   TestAccNetworkingV2EIPAssociate_basic
=== PAUSE TestAccNetworkingV2EIPAssociate_basic
=== CONT  TestAccNetworkingV2EIPAssociate_basic
--- PASS: TestAccNetworkingV2EIPAssociate_basic (188.04s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      188.137s
```