### PR TITLE
feat(dns/pptrrecord): add dns_ptrrecord resource in g42cloud

### DIFF
--- a/docs/resources/dns_ptrrecord.md
+++ b/docs/resources/dns_ptrrecord.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Domain Name Service (DNS)"
+---
+
+# g42cloud_dns_ptrrecord
+
+Manages a DNS PTR record in the G42Cloud DNS Service.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_vpc_eip" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_dns_ptrrecord" "ptr_1" {
+  name          = "ptr.example.com."
+  description   = "An example PTR record"
+  floatingip_id = g42cloud_vpc_eip.eip_1.id
+  ttl           = 3000
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the PTR record. If omitted, the `region`
+  argument of the provider will be used. Changing this creates a new PTR record.
+
+* `name` - (Required, String) Domain name of the PTR record. A domain name is case insensitive. Uppercase letters will
+  also be converted into lowercase letters.
+
+* `description` - (Optional, String) Description of the PTR record.
+
+* `floatingip_id` - (Required, String, ForceNew) The ID of the FloatingIP/EIP.
+
+* `ttl` - (Optional, Int) The time to live (TTL) of the record set (in seconds). The value range is 300–2147483647. The
+  default value is 300.
+
+* `tags` - (Optional, Map) Tags key/value pairs to associate with the PTR record.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the PTR record. Changing this
+  creates a new PTR record.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The PTR record ID, which is in {region}:{floatingip_id} format.
+
+* `address` - The address of the FloatingIP/EIP.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+PTR records can be imported using region and floatingip/eip ID, separated by a colon(:), e.g.
+
+```
+$ terraform import g42cloud_dns_ptrrecord.ptr_1 cn-north-1:d90ce693-5ccf-4136-a0ed-152ce412b6b9
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -202,6 +202,7 @@ func Provider() *schema.Provider {
 			"g42cloud_dms_kafka_instance":        dms.ResourceDmsKafkaInstance(),
 			"g42cloud_dms_kafka_topic":           dms.ResourceDmsKafkaTopic(),
 			"g42cloud_dms_rabbitmq_instance":     dms.ResourceDmsRabbitmqInstance(),
+			"g42cloud_dns_ptrrecord":             huaweicloud.ResourceDNSPtrRecordV2(),
 			"g42cloud_dns_recordset":             huaweicloud.ResourceDNSRecordSetV2(),
 			"g42cloud_dns_zone":                  huaweicloud.ResourceDNSZoneV2(),
 			"g42cloud_evs_snapshot":              huaweicloud.ResourceEvsSnapshotV2(),

--- a/g42cloud/provider_test.go
+++ b/g42cloud/provider_test.go
@@ -18,6 +18,7 @@ var (
 	G42_ENTERPRISE_PROJECT_ID_TEST = os.Getenv("G42_ENTERPRISE_PROJECT_ID_TEST")
 	G42_ACCESS_KEY                 = os.Getenv("G42_ACCESS_KEY")
 	G42_SECRET_KEY                 = os.Getenv("G42_SECRET_KEY")
+	G42_DNS_ENVIRONMENT            = os.Getenv("G42_DNS_ENVIRONMENT")
 )
 
 var testAccProviders map[string]*schema.Provider
@@ -55,6 +56,12 @@ func testAccPreCheckEpsID(t *testing.T) {
 func testAccPreCheckOBS(t *testing.T) {
 	if G42_ACCESS_KEY == "" || G42_SECRET_KEY == "" {
 		t.Skip("G42_ACCESS_KEY and G42_SECRET_KEY must be set for OBS acceptance tests")
+	}
+}
+
+func testAccPreCheckDNS(t *testing.T) {
+	if G42_DNS_ENVIRONMENT == "" {
+		t.Skip("This environment does not support DNS tests")
 	}
 }
 

--- a/g42cloud/resource_g42cloud_dns_ptrrecord_v2_test.go
+++ b/g42cloud/resource_g42cloud_dns_ptrrecord_v2_test.go
@@ -1,0 +1,196 @@
+package g42cloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func randomPtrName() string {
+	return fmt.Sprintf("acpttest-%s.com.", acctest.RandString(5))
+}
+
+func TestAccDNSV2PtrRecord_basic(t *testing.T) {
+	var ptrrecord ptrrecords.Ptr
+	ptrName := randomPtrName()
+	resourceName := "g42cloud_dns_ptrrecord.ptr_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckDNS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2PtrRecord_basic(ptrName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					resource.TestCheckResourceAttr(resourceName, "description", "a ptr record"),
+				),
+			},
+			{
+				Config: testAccDNSV2PtrRecord_update(ptrName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					resource.TestCheckResourceAttr(resourceName, "description", "ptr record updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDNSV2PtrRecord_withEpsId(t *testing.T) {
+	var ptrrecord ptrrecords.Ptr
+	ptrName := randomPtrName()
+	resourceName := "g42cloud_dns_ptrrecord.ptr_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckDNS(t); testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2PtrRecord_withEpsId(ptrName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDNSV2PtrRecordDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	dnsClient, err := config.DnsV2Client(G42_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating g42cloud DNS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_dns_ptrrecord" {
+			continue
+		}
+
+		_, err = ptrrecords.Get(dnsClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmtp.Errorf("Ptr record still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDNSV2PtrRecordExists(n string, ptrrecord *ptrrecords.Ptr) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		dnsClient, err := config.DnsV2Client(G42_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("Error creating G42Cloud DNS client: %s", err)
+		}
+
+		found, err := ptrrecords.Get(dnsClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmtp.Errorf("Ptr record not found")
+		}
+
+		*ptrrecord = *found
+
+		return nil
+	}
+}
+
+func testAccDNSV2PtrRecord_basic(ptrName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_eip" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_dns_ptrrecord" "ptr_1" {
+  name          = "%s"
+  description   = "a ptr record"
+  floatingip_id = g42cloud_vpc_eip.eip_1.id
+  ttl           = 6000
+}
+`, ptrName)
+}
+
+func testAccDNSV2PtrRecord_update(ptrName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_eip" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_dns_ptrrecord" "ptr_1" {
+  name          = "%s"
+  description   = "ptr record updated"
+  floatingip_id = g42cloud_vpc_eip.eip_1.id
+  ttl           = 6000
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, ptrName)
+}
+
+func testAccDNSV2PtrRecord_withEpsId(ptrName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_eip" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "g42cloud_dns_ptrrecord" "ptr_1" {
+  name                  = "%s"
+  description           = "a ptr record"
+  floatingip_id         = g42cloud_vpc_eip.eip_1.id
+  ttl                   = 6000
+  enterprise_project_id = "%s"
+}
+`, ptrName, G42_ENTERPRISE_PROJECT_ID_TEST)
+}


### PR DESCRIPTION
add dns_ptrrecord resource in g42cloud

```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccDNSV2PtrRecord_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccDNSV2PtrRecord_basic -timeout 360m -parallel=4
=== RUN   TestAccDNSV2PtrRecord_basic
=== PAUSE TestAccDNSV2PtrRecord_basic
=== CONT  TestAccDNSV2PtrRecord_basic
--- PASS: TestAccDNSV2PtrRecord_basic (64.40s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      64.447s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccDNSV2PtrRecord_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccDNSV2PtrRecord_withEpsId -timeout 360m -parallel=4
=== RUN   TestAccDNSV2PtrRecord_withEpsId
=== PAUSE TestAccDNSV2PtrRecord_withEpsId
=== CONT  TestAccDNSV2PtrRecord_withEpsId
--- PASS: TestAccDNSV2PtrRecord_withEpsId (41.87s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      41.916s
```