### PR TITLE
feat(eps): add EPS resources in G42 cloud

### DIFF
--- a/docs/data-sources/enterprise_project.md
+++ b/docs/data-sources/enterprise_project.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+---
+
+# g42cloud_enterprise_project
+
+Use this data source to get an enterprise project from G42Cloud
+
+## Example Usage
+
+```hcl
+data "g42cloud_enterprise_project" "test" {
+  name = "test"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the enterprise project name. Fuzzy search is supported.
+
+* `id` - (Optional, String) Specifies the ID of an enterprise project. The value 0 indicates enterprise project default.
+
+* `status` - (Optional, Int) Specifies the status of an enterprise project.
+    + 1 indicates Enabled.
+    + 2 indicates Disabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - Provides supplementary information about the enterprise project.
+
+* `created_at` - Specifies the time (UTC) when the enterprise project was created. Example: 2018-05-18T06:49:06Z
+
+* `updated_at` - Specifies the time (UTC) when the enterprise project was modified. Example: 2018-05-28T02:21:36Z

--- a/docs/resources/enterprise_project.md
+++ b/docs/resources/enterprise_project.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+---
+
+# g42cloud_enterprise_project
+
+Use this resource to manage an enterprise project within G42Cloud.
+
+-> **NOTE:** Deleting enterprise projects is not support. If you destroy a resource of enterprise project,
+  the project is only disabled and removed from the state, but it remains in the cloud.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_enterprise_project" "test" {
+  name        = "test"
+  description = "example project"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the name of the enterprise project.
+  This parameter can contain 1 to 64 characters. Only letters, digits, underscores (_), and hyphens (-) are allowed.
+  The name must be unique in the domain and cannot include any form of the word "default" ("deFaulT", for instance).
+
+* `description` - (Optional, String) Specifies the description of the enterprise project.
+
+* `type` - (Optional, String) Specifies the type of the enterprise project.
+  The valid values are *poc* and *prod*, default to *prod*.
+
+* `enable` - (Optional, Bool) Specifies whether to enable the enterprise project. Default to *true*.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `status` - Indicates the status of an enterprise project.
+  + 1 indicates Enabled.
+  + 2 indicates Disabled.
+
+* `created_at` - Indicates the time (UTC) when the enterprise project was created. Example: 2018-05-18T06:49:06Z
+
+* `updated_at` - Indicates the time (UTC) when the enterprise project was modified. Example: 2018-05-28T02:21:36Z
+
+## Import
+
+Enterprise projects can be imported using the `id`, e.g.
+
+```
+$ terraform import g42cloud_enterprise_project.test 88f889c7-270e-4e77-8230-bf7db08d9b0e
+```
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5minute.
+* `update` - Default is 5 minute.
+* `delete` - Default is 5 minute.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/evs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
@@ -163,6 +164,7 @@ func Provider() *schema.Provider {
 			"g42cloud_dms_az":              deprecated.DataSourceDmsAZ(),
 			"g42cloud_dms_product":         dms.DataSourceDmsProduct(),
 			"g42cloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),
+			"g42cloud_enterprise_project":  eps.DataSourceEnterpriseProject(),
 			"g42cloud_identity_role":       iam.DataSourceIdentityRoleV3(),
 			"g42cloud_images_image":        ims.DataSourceImagesImageV2(),
 			"g42cloud_kms_key":             huaweicloud.DataSourceKmsKeyV1(),
@@ -209,6 +211,7 @@ func Provider() *schema.Provider {
 			"g42cloud_dns_ptrrecord":                   huaweicloud.ResourceDNSPtrRecordV2(),
 			"g42cloud_dns_recordset":                   huaweicloud.ResourceDNSRecordSetV2(),
 			"g42cloud_dns_zone":                        huaweicloud.ResourceDNSZoneV2(),
+			"g42cloud_enterprise_project":              eps.ResourceEnterpriseProject(),
 			"g42cloud_evs_snapshot":                    huaweicloud.ResourceEvsSnapshotV2(),
 			"g42cloud_evs_volume":                      evs.ResourceEvsVolume(),
 			"g42cloud_fgs_function":                    fgs.ResourceFgsFunctionV2(),

--- a/g42cloud/services/acceptance/eps/data_source_g42cloud_enterprise_project_test.go
+++ b/g42cloud/services/acceptance/eps/data_source_g42cloud_enterprise_project_test.go
@@ -1,0 +1,35 @@
+package eps
+
+import (
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEnterpriseProjectDataSource_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_enterprise_project.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProjectDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "default"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccEnterpriseProjectDataSource_basic = `
+data "g42cloud_enterprise_project" "test" {
+  name = "default"
+}
+`

--- a/g42cloud/services/acceptance/eps/resource_g42cloud_enterprise_project_test.go
+++ b/g42cloud/services/acceptance/eps/resource_g42cloud_enterprise_project_test.go
@@ -1,0 +1,108 @@
+package eps
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
+)
+
+func getResourceEnterpriseProject(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	epsClient, err := config.EnterpriseProjectClient(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create G42Cloud EPS client : %s", err)
+	}
+
+	return enterpriseprojects.Get(epsClient, state.Primary.ID).Extract()
+
+}
+
+func TestAccEnterpriseProject_basic(t *testing.T) {
+	var project enterpriseprojects.Project
+	rName := acceptance.RandomAccResourceName()
+	updateName := rName + "update"
+	resourceName := "g42cloud_enterprise_project.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&project,
+		getResourceEnterpriseProject,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckEnterpriseProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProject_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "status", "1"),
+				),
+			},
+			{
+				Config: testAccEnterpriseProject_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test update"),
+					resource.TestCheckResourceAttr(resourceName, "status", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEnterpriseProjectDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	epsClient, err := config.EnterpriseProjectClient(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Unable to create G42Cloud EPS client : %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_enterprise_project" {
+			continue
+		}
+
+		project, err := enterpriseprojects.Get(epsClient, rs.Primary.ID).Extract()
+		if err == nil {
+			if project.Status != 2 {
+				return fmt.Errorf("Project still active")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccEnterpriseProject_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_enterprise_project" "test" {
+  name        = "%s"
+  description = "terraform test"
+}`, rName)
+}
+
+func testAccEnterpriseProject_update(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_enterprise_project" "test" {
+  name        = "%s"
+  description = "terraform test update"
+}`, rName)
+}


### PR DESCRIPTION
add EPS resources in G42 cloud

**Test results**:
```
make testacc TEST='./g42cloud/services/acceptance/eps' TESTARGS='-run TestAccEnterpriseProjectDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/eps -v -run TestAccEnterpriseProjectDataSource_basic -timeout 360m -parallel=4
=== RUN   TestAccEnterpriseProjectDataSource_basic
=== PAUSE TestAccEnterpriseProjectDataSource_basic
=== CONT  TestAccEnterpriseProjectDataSource_basic
--- PASS: TestAccEnterpriseProjectDataSource_basic (16.16s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/eps      16.215s

make testacc TEST='./g42cloud/services/acceptance/eps' TESTARGS='-run TestAccEnterpriseProject_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/eps -v -run TestAccEnterpriseProject_basic -timeout 360m -parallel=4
=== RUN   TestAccEnterpriseProject_basic
=== PAUSE TestAccEnterpriseProject_basic
=== CONT  TestAccEnterpriseProject_basic
--- PASS: TestAccEnterpriseProject_basic (33.69s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/eps      33.746s
```