### PR TITLE
feat(swr): add swr resources in G42 cloud

### DIFF
--- a/docs/resources/swr_organization.md
+++ b/docs/resources/swr_organization.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+---
+
+# g42cloud_swr_organization
+
+Manages a SWR organization resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_swr_organization" "test" {
+  name = "terraform-test"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the organization. The organization name must be globally
+  unique.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the organization.
+
+* `creator` - The creator user name of the organization.
+
+* `permission` - The permission of the organization, the value can be Manage, Write, and Read.
+
+* `login_server` - The URL that can be used to log into the container registry.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+Organizations can be imported using the `name`, e.g.
+
+```
+$ terraform import g42cloud_swr_organization.test org-name
+```

--- a/docs/resources/swr_organization_permissions.md
+++ b/docs/resources/swr_organization_permissions.md
@@ -1,0 +1,86 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+---
+
+# g42cloud_swr_organization_permissions
+
+Manages user permissions for the SWR organization resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "organization_name" {}
+variable "user_1" {}
+variable "user_2" {}
+
+resource "g42cloud_swr_organization_permissions" "test" {
+  organization = var.organization_name
+
+  users {
+    user_name  = var.user_1.name
+    user_id    = var.user_1.id
+    permission = "Read"
+  }
+
+  users {
+    user_name  = var.user_2.name
+    user_id    = var.user_2.id
+    permission = "Read"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `organization` - (Required, String, ForceNew) Specifies the name of the organization (namespace) to be accessed.
+  Changing this creates a new resource.
+
+* `users` - (Required, List) Specifies the users to access to the organization (namespace).
+  Structure is documented below.
+
+The `users` block supports:
+
+* `user_id` - (Required, String) Specifies the ID of the existing G42Cloud user.
+
+* `user_name` - (Optional, String) Specifies the name of the existing G42Cloud user.
+
+* `permission` - (Required, String) Specifies the permission of the existing G42Cloud user.
+  The values can be **Manage**, **Write** and **Read**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the permissions. The value is the name of the organization.
+
+* `creator` - The creator user name of the organization.
+
+* `self_permission` - The permission informations of current user.
+
+The `self_permission` block supports:
+
+* `user_name` - The name of current user.
+
+* `user_id` - The ID of current user.
+
+* `permission` - The permission of current user.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+Organization Permissions can be imported using the `id` (organization name), e.g.
+
+```
+$ terraform import g42cloud_swr_organization_permissions.test terraform-test
+```

--- a/docs/resources/swr_repository.md
+++ b/docs/resources/swr_repository.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+---
+
+# g42cloud_swr_repository
+
+Manages a SWR repository resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "organization_name" {} 
+
+resource "g42cloud_swr_repository" "test" {
+  organization = var.organization_name
+  name         = "%s"
+  description  = "Test repository"
+  category     = "linux"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `organization` - (Required, String, ForceNew) Specifies the name of the organization (namespace) the repository belongs.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the repository. Changing this creates a new resource.
+
+* `is_public` - (Optional, Bool) Specifies whether the repository is public. Default is false.
+  + `true` - Indicates the repository is public.
+  + `false` - Indicates the repository is private.
+
+* `description` - (Optional, String) Specifies the description of the repository.
+
+* `category` - (Optional, String) Specifies the category of the repository.
+  The value can be `app_server`, `linux`, `framework_app`, `database`, `lang`, `other`, `windows`, `arm`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the repository. The value is the name of the repository.
+
+* `repository_id` - Numeric ID of the repository
+
+* `path` - Image address for docker pull.
+
+* `internal_path` - Intra-cluster image address for docker pull.
+
+* `num_images` - Number of image tags in a repository.
+
+* `size` - Repository size.
+
+## Import
+
+Repository can be imported using the organization name and repository name separated by a slash, e.g.:
+
+```
+$ terraform import g42cloud_swr_repository.test org-name/repo-name
+```

--- a/docs/resources/swr_repository_sharing.md
+++ b/docs/resources/swr_repository_sharing.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+---
+
+# g42cloud_swr_repository_sharing
+
+Manages a SWR repository sharing resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "organization_name" {} 
+variable "repository_name" {}
+variable "sharing_account" {}
+
+resource "g42cloud_swr_repository_sharing" "test" {
+  organization    = var.organization_name
+  repository      = var.repository_name
+  sharing_account = var.sharing_account
+  permission      = "pull"
+  deadline        = "forever"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `organization` - (Required, String, ForceNew) Specifies the name of the organization (namespace) the repository belongs.
+  Changing this creates a new resource.
+
+* `repository` - (Required, String, ForceNew) Specifies the name of the repository to be shared.
+  Changing this creates a new resource.
+
+* `sharing_account` - (Required, String, ForceNew) Specifies the name of the account for repository sharing.
+  Changing this creates a new resource
+  -> **NOTE:** `sharing_account` should be an existing G42Cloud account.
+
+* `deadline` - (Required, String) Specifies the end date of image sharing (UTC time in YYYY-MM-DD format,
+  for example `2021-10-01`). When the value is set to forever, the image will be permanently available for the domain.
+  The validity period is calculated by day. The shared images expire at 00:00:00 on the day after the end date.
+
+* `permission` - (Optional, String) Specifies the permission to be granted. Currently, only the **pull** permission is supported.
+  Default value is **pull**.
+
+* `description` - (Optional, String) Specifies the description of the repository sharing.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the repository sharing. The value is the value of `sharing_account`.
+
+* `status` - Indicates the repository sharing is valid (true) or expired (false).
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minute.
+* `update` - Default is 2 minute.
+* `delete` - Default is 2 minute.
+
+## Import
+
+Repository sharing can be imported using the organization name, repository name and sharing account
+separated by a slash, e.g.:
+
+```
+$ terraform import g42cloud_swr_repository_sharing.test org-name/repo-name/sharing-account
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 )
 
@@ -245,6 +246,10 @@ func Provider() *schema.Provider {
 			"g42cloud_sfs_turbo":                       huaweicloud.ResourceSFSTurbo(),
 			"g42cloud_smn_subscription":                huaweicloud.ResourceSubscription(),
 			"g42cloud_smn_topic":                       huaweicloud.ResourceTopic(),
+			"g42cloud_swr_organization":                swr.ResourceSWROrganization(),
+			"g42cloud_swr_organization_permissions":    swr.ResourceSWROrganizationPermissions(),
+			"g42cloud_swr_repository":                  swr.ResourceSWRRepository(),
+			"g42cloud_swr_repository_sharing":          swr.ResourceSWRRepositorySharing(),
 			"g42cloud_vpc_bandwidth":                   eip.ResourceVpcBandWidthV2(),
 			"g42cloud_vpc_eip":                         eip.ResourceVpcEIPV1(),
 			"g42cloud_vpc_eip_associate":               eip.ResourceEIPAssociate(),

--- a/g42cloud/services/acceptance/acceptance.go
+++ b/g42cloud/services/acceptance/acceptance.go
@@ -28,6 +28,7 @@ var (
 	G42_DOMAIN_ID                  = os.Getenv("G42_DOMAIN_ID")
 	G42_DOMAIN_NAME                = os.Getenv("G42_DOMAIN_NAME")
 	G42_ENTERPRISE_PROJECT_ID_TEST = os.Getenv("G42_ENTERPRISE_PROJECT_ID_TEST")
+	G42_SWR_SHARING_ACCOUNT        = os.Getenv("G42_SWR_SHARING_ACCOUNT")
 
 	G42_FLAVOR_ID        = os.Getenv("G42_FLAVOR_ID")
 	G42_FLAVOR_NAME      = os.Getenv("G42_FLAVOR_NAME")
@@ -370,5 +371,13 @@ func TestAccPreCheckOBS(t *testing.T) {
 func TestAccPreCheckChargingMode(t *testing.T) {
 	if G42_CHARGING_MODE != "prePaid" {
 		t.Skip("This environment does not support prepaid tests")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckSWRDomian(t *testing.T) {
+	if G42_SWR_SHARING_ACCOUNT == "" {
+		t.Skip("HW_SWR_SHARING_ACCOUNT must be set for swr domian tests, " +
+			"the value of G42_SWR_SHARING_ACCOUNT should be another IAM user name")
 	}
 }

--- a/g42cloud/services/acceptance/swr/resource_g42cloud_swr_organization_permissions_test.go
+++ b/g42cloud/services/acceptance/swr/resource_g42cloud_swr_organization_permissions_test.go
@@ -1,0 +1,133 @@
+package swr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/swr/v2/namespaces"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getResourcePermissions(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	swrClient, err := conf.SwrV2Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating G42Cloud SWR client: %s", err)
+	}
+
+	return namespaces.GetAccess(swrClient, state.Primary.ID).Extract()
+}
+
+func TestAccSwrOrganizationPermissions_basic(t *testing.T) {
+	var permissions namespaces.Access
+	organizationName := acceptance.RandomAccResourceName()
+	userName1 := acceptance.RandomAccResourceName()
+	userName2 := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_swr_organization_permissions.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&permissions,
+		getResourcePermissions,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccswrOrganizationPermissions_basic(organizationName, userName1, userName2),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "organization",
+						"${g42cloud_swr_organization.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "users.0.user_name", userName1),
+					resource.TestCheckResourceAttr(resourceName, "users.0.permission", "Read"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccswrOrganizationPermissions_update(organizationName, userName1, userName2),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "organization",
+						"${g42cloud_swr_organization.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "users.0.user_name", userName1),
+					resource.TestCheckResourceAttr(resourceName, "users.0.permission", "Write"),
+					resource.TestCheckResourceAttr(resourceName, "users.1.user_name", userName2),
+					resource.TestCheckResourceAttr(resourceName, "users.1.permission", "Read"),
+				),
+			},
+		},
+	})
+}
+
+func testAccswrOrganizationPermissions_basic(organizationName, userName1, userName2 string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_swr_organization" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_identity_user" "user_1" {
+  name     = "%s"
+  enabled  = true
+  password = "password12345!"
+}
+
+resource "g42cloud_swr_organization_permissions" "test" {
+  organization = g42cloud_swr_organization.test.name
+
+  users {
+    user_name  = g42cloud_identity_user.user_1.name
+    user_id    = g42cloud_identity_user.user_1.id
+    permission = "Read"
+  }
+}
+`, organizationName, userName1)
+}
+
+func testAccswrOrganizationPermissions_update(organizationName, userName1, userName2 string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_swr_organization" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_identity_user" "user_1" {
+  name     = "%s"
+  enabled  = true
+  password = "password12345!"
+}
+
+resource "g42cloud_identity_user" "user_2" {
+  name     = "%s"
+  enabled  = true
+  password = "password12345!"
+}
+
+resource "g42cloud_swr_organization_permissions" "test" {
+  organization = g42cloud_swr_organization.test.name
+
+  users {
+    user_name  = g42cloud_identity_user.user_1.name
+    user_id    = g42cloud_identity_user.user_1.id
+    permission = "Write"
+  }
+
+  users {
+    user_name  = g42cloud_identity_user.user_2.name
+    user_id    = g42cloud_identity_user.user_2.id
+    permission = "Read"
+  }
+}
+`, organizationName, userName1, userName2)
+}

--- a/g42cloud/services/acceptance/swr/resource_g42cloud_swr_organization_test.go
+++ b/g42cloud/services/acceptance/swr/resource_g42cloud_swr_organization_test.go
@@ -1,0 +1,65 @@
+package swr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/swr/v2/namespaces"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getResourceOrganization(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	swrClient, err := conf.SwrV2Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating G42Cloud SWR client: %s", err)
+	}
+
+	return namespaces.Get(swrClient, state.Primary.ID).Extract()
+}
+
+func TestAccSWROrganization_basic(t *testing.T) {
+	var org namespaces.Namespace
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_swr_organization.test"
+	loginServer := fmt.Sprintf("swr.%s.g42cloud.com", acceptance.G42_REGION_NAME)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&org,
+		getResourceOrganization,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSWROrganization_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "permission", "Manage"),
+					resource.TestCheckResourceAttr(resourceName, "login_server", loginServer),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSWROrganization_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_swr_organization" "test" {
+  name = "%s"
+}
+`, rName)
+}

--- a/g42cloud/services/acceptance/swr/resource_g42cloud_swr_repository_sharing_test.go
+++ b/g42cloud/services/acceptance/swr/resource_g42cloud_swr_repository_sharing_test.go
@@ -1,0 +1,127 @@
+package swr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/chnsz/golangsdk/openstack/swr/v2/domains"
+)
+
+func getResourceRepositorySharing(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	swrClient, err := conf.SwrV2Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating G42Cloud SWR client: %s", err)
+	}
+
+	return domains.Get(swrClient, state.Primary.Attributes["organization"],
+		state.Primary.Attributes["repository"], state.Primary.ID).Extract()
+}
+
+func TestAccSWRRepositorySharing_basic(t *testing.T) {
+	var domain domains.AccessDomain
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_swr_repository_sharing.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&domain,
+		getResourceRepositorySharing,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSWRDomian(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSWRRepositorySharing_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "organization",
+						"${g42cloud_swr_organization.test.name}"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "repository",
+						"${g42cloud_swr_repository.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "sharing_account", acceptance.G42_SWR_SHARING_ACCOUNT),
+					resource.TestCheckResourceAttr(resourceName, "deadline", "forever"),
+					resource.TestCheckResourceAttr(resourceName, "permission", "pull"),
+				),
+			},
+			{
+				Config: testAccSWRRepositorySharing_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "organization",
+						"${g42cloud_swr_organization.test.name}"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "repository",
+						"${g42cloud_swr_repository.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "sharing_account", acceptance.G42_SWR_SHARING_ACCOUNT),
+					resource.TestCheckResourceAttr(resourceName, "deadline", "2099-12-31"),
+					resource.TestCheckResourceAttr(resourceName, "permission", "pull"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSWRRepositorySharingImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccSWRRepositorySharingImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var organization string
+		var repositoryID string
+		var sharingAccount string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "g42cloud_swr_organization" {
+				organization = rs.Primary.Attributes["name"]
+			} else if rs.Type == "g42cloud_swr_repository" {
+				repositoryID = rs.Primary.ID
+			} else if rs.Type == "g42cloud_swr_repository_sharing" {
+				sharingAccount = rs.Primary.ID
+			}
+		}
+		if organization == "" || repositoryID == "" || sharingAccount == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", organization, repositoryID, sharingAccount)
+		}
+		return fmt.Sprintf("%s/%s/%s", organization, repositoryID, sharingAccount), nil
+	}
+}
+
+func testAccSWRRepositorySharing_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_swr_repository_sharing" "test" {
+  organization    = g42cloud_swr_organization.test.name
+  repository      = g42cloud_swr_repository.test.name
+  sharing_account = "%s"
+  permission      = "pull"
+  deadline        = "forever"
+}
+`, testAccSWRRepository_basic(rName), acceptance.G42_SWR_SHARING_ACCOUNT)
+}
+
+func testAccSWRRepositorySharing_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_swr_repository_sharing" "test" {
+  organization    = g42cloud_swr_organization.test.name
+  repository      = g42cloud_swr_repository.test.name
+  sharing_account = "%s"
+  permission      = "pull"
+  deadline        = "2099-12-31"
+}
+`, testAccSWRRepository_basic(rName), acceptance.G42_SWR_SHARING_ACCOUNT)
+}

--- a/g42cloud/services/acceptance/swr/resource_g42cloud_swr_repository_test.go
+++ b/g42cloud/services/acceptance/swr/resource_g42cloud_swr_repository_test.go
@@ -1,0 +1,116 @@
+package swr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/chnsz/golangsdk/openstack/swr/v2/repositories"
+)
+
+func getResourceRepository(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	swrClient, err := conf.SwrV2Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating g42cloud SWR client: %s", err)
+	}
+
+	return repositories.Get(swrClient, state.Primary.Attributes["organization"], state.Primary.ID).Extract()
+}
+
+func TestAccSWRRepository_basic(t *testing.T) {
+	var repo repositories.ImageRepository
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_swr_repository.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&repo,
+		getResourceRepository,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSWRRepository_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "organization",
+						"${g42cloud_swr_organization.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "category", "linux"),
+					resource.TestCheckResourceAttr(resourceName, "is_public", "false"),
+				),
+			},
+			{
+				Config: testAccSWRRepository_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "organization",
+						"${g42cloud_swr_organization.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "category", "windows"),
+					resource.TestCheckResourceAttr(resourceName, "is_public", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSWRRepositoryImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccSWRRepositoryImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var organization string
+		var repositoryID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "g42cloud_swr_organization" {
+				organization = rs.Primary.Attributes["name"]
+			} else if rs.Type == "g42cloud_swr_repository" {
+				repositoryID = rs.Primary.ID
+			}
+		}
+		if organization == "" || repositoryID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", organization, repositoryID)
+		}
+		return fmt.Sprintf("%s/%s", organization, repositoryID), nil
+	}
+}
+
+func testAccSWRRepository_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_swr_repository" "test" {
+  organization = g42cloud_swr_organization.test.name
+  name         = "%s"
+  description  = "Test repository"
+  category     = "linux"
+  is_public    = false
+}
+`, testAccSWROrganization_basic(rName), rName)
+}
+
+func testAccSWRRepository_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_swr_repository" "test" {
+  organization = g42cloud_swr_organization.test.name
+  name         = "%s"
+  description  = "Test repository"
+  category     = "windows"
+  is_public    = true
+}
+`, testAccSWROrganization_basic(rName), rName)
+}


### PR DESCRIPTION
add swr resources in G42 cloud
The following resources are added:
g42cloud_swr_organization_permissions
g42cloud_swr_organization
g42cloud_swr_repository_sharing
g42cloud_swr_repository

**Test results:**:
```
make testacc TEST='./g42cloud/services/acceptance/swr' TESTARGS='-run TestAccSwrOrganizationPermissions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/swr -v -run TestAccSwrOrganizationPermissions_basic -timeout 360m -parallel=4
=== RUN   TestAccSwrOrganizationPermissions_basic
=== PAUSE TestAccSwrOrganizationPermissions_basic
=== CONT  TestAccSwrOrganizationPermissions_basic
--- PASS: TestAccSwrOrganizationPermissions_basic (35.65s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/swr      35.697s

make testacc TEST='./g42cloud/services/acceptance/swr' TESTARGS='-run TestAccSWROrganization_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/swr -v -run TestAccSWROrganization_basic -timeout 360m -parallel=4
=== RUN   TestAccSWROrganization_basic
=== PAUSE TestAccSWROrganization_basic
=== CONT  TestAccSWROrganization_basic
--- PASS: TestAccSWROrganization_basic (18.47s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/swr      18.594s

make testacc TEST='./g42cloud/services/acceptance/swr' TESTARGS='-run TestAccSWRRepository_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/swr -v -run TestAccSWRRepository_basic -timeout 360m -parallel=4
=== RUN   TestAccSWRRepository_basic
=== PAUSE TestAccSWRRepository_basic
=== CONT  TestAccSWRRepository_basic
--- PASS: TestAccSWRRepository_basic (33.91s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/swr      33.970s

We can't run the test case of g42cloud_swr_repository_sharing beacause we only have one account.
```