### PR TITLE
feat(cbr): add cbr resources in G42 cloud

### DIFF
--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -1,0 +1,104 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# g42cloud_cbr_vaults
+
+Use this data source to get available CBR vaults within G42Cloud.
+
+## Example Usage
+
+### Get vaults for all server type
+
+```hcl
+data "g42cloud_cbr_vaults" "test" {
+  type = "server"
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the CBR vaults.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+  characters, which may consist of letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Optional, String) Specifies the object type of the CBR vault. The vaild values are as follows:
+  + **server** (Cloud Servers)
+  + **disk** (EVS Disks)
+  + **turbo** (SFS Turbo file systems)
+
+* `consistent_level` - (Optional, String) Specifies the backup specifications.
+  The valid values are as follows:
+  + **[crash_consistent](https://docs.g42cloud.com/en-us/bp/cbr/cbr_07_0020.html)**
+  + **[app_consistent](https://docs.g42cloud.com/en-us/bp/cbr/cbr_07_0020.html)**
+
+  Only server type vaults support application consistent.
+
+* `protection_type` - (Optional, String) Specifies the protection type of the CBR vault.
+  The valid values is **backup**.
+
+* `size` - (Optional, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
+
+* `auto_expand_enabled` - (Optional, Bool) Specifies whether to enable automatic expansion of the backup protection
+  type vault. Default to **false**.
+
+* `enterprise_project_id` - (Optional, String) Specifies a unique ID in UUID format of enterprise project.
+
+* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+
+* `status` - (Optional, String) Specifies the CBR vault status, including **available**, **lock**, **frozen** and **error**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in hashcode format.
+
+* `vaults` - List of CBR vault details. The object structure of each CBR vault is documented below.
+
+The `vaults` block supports:
+
+* `id` - The vault ID in UUID format.
+
+* `name` - The CBR vault name.
+
+* `type` - The object type of the CBR vault.
+
+* `consistent_level` - The backup specifications.
+
+* `protection_type` - The protection type of the CBR vault.
+
+* `size` - The vault capacity, in GB.
+
+* `auto_expand_enabled` - Whether to enable automatic expansion of the backup protection type vault.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `policy_id` - The policy associated with the CBR vault.
+
+* `allocated` - The allocated capacity of the vault, in GB.
+
+* `used` - The used capacity, in GB.
+
+* `spec_code` - The specification code.
+
+* `status` - The vault status.
+
+* `storage` - The name of the bucket for the vault.
+
+* `tags` - The key/value pairs to associate with the CBR vault.
+
+* `resources` - An array of one or more resources to attach to the CBR vault.
+  The [object](#cbr_vault_resources) structure is documented below.
+
+The `resources` block supports:
+
+* `server_id` - The ID of the ECS instance to be backed up.
+
+* `excludes` - An array of disk IDs which will be excluded in the backup.
+
+* `includes` - An array of disk or SFS file system IDs which will be included in the backup.

--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -1,0 +1,105 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# g42cloud_cbr_policy
+
+Manages a CBR Policy resource within G42Cloud.
+
+## Example Usage
+
+### create a backup policy
+
+```hcl
+variable "policy_name" {}
+
+resource "g42cloud_cbr_policy" "test" {
+  name        = var.policy_name
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    frequency       = "WEEKLY"
+    days            = "MO,TH"
+    execution_times = ["06:00"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR policy. If omitted, the
+  provider-level region will be used. Changing this will create a new policy.
+
+* `name` - (Required, String) Specifies a unique name of the CBR policy. This parameter can contain a maximum of 64
+  characters, which may consist of chinese charactors, letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Required, String, ForceNew) Specifies the protection type of the CBR policy.
+  Valid values is **backup**. Changing this will create a new policy.
+
+* `backup_cycle` - (Required, List) Specifies the scheduling rule for the CBR policy backup execution.
+  The [object](#cbr_policy_backup_cycle) structure is documented below.
+
+* `enabled` - (Optional, Bool) Specifies whether to enable the CBR policy. Default to **true**.
+
+* `backup_quantity` - (Optional, Int) Specifies the maximum number of retained backups. The value ranges from `2` to
+  `99,999`. This parameter and `time_period` are alternative.
+
+* `time_period` - (Optional, Int) Specifies the duration (in days) for retained backups. The value ranges from `2` to
+  `99,999`.
+
+-> **NOTE:** If this `backup_quantity` and `time_period` are both left blank, the backups will be retained permanently.
+
+* `long_term_retention` - (Optional, List) Specifies the long-term retention rules, which is an advanced options of
+  the `backup_quantity`. The [object](#cbr_policy_long_term_retention) structure is documented below.
+
+-> The configuration of `long_term_retention` and `backup_quantity` will take effect together.
+  When the number of retained backups exceeds the preset value (number of `backup_quantity`), the system automatically
+  deletes the earliest backups. By default, the system automatically clears data every other day.
+
+* `time_zone` - (Optional, String) Specifies the UTC time zone, e.g.: `UTC+08:00`.
+  Required if `long_term_retention` is set.
+
+<a name="cbr_policy_backup_cycle"></a>
+The `backup_cycle` block supports:
+
+* `days` - (Optional, String) Specifies the weekly backup day of backup schedule. It supports seven days a week (MO, TU,
+  WE, TH, FR, SA, SU) and this parameter is separated by a comma (,) without spaces, between date and date during the
+  configuration.
+
+* `interval` - (Optional, Int) Specifies the interval (in days) of backup schedule. The value range is `1` to `30`. This
+  parameter and `days` are alternative.
+
+* `execution_times` - (Required, List) Specifies the backup time. Automated backups will be triggered at the backup
+  time. The current time is in the UTC format (HH:MM). The minutes in the list must be set to **00** and the hours
+  cannot be repeated.
+
+<a name="cbr_policy_long_term_retention"></a>
+The `long_term_retention` block supports:
+
+* `daily` - (Optional, Int) - Specifies the latest backup of each day is saved in the long term.
+
+* `weekly` - (Optional, Int) - Specifies the latest backup of each week is saved in the long term.
+
+* `monthly` - (Optional, Int) - Specifies the latest backup of each month is saved in the long term.
+
+* `yearly` - (Optional, Int) - Specifies the latest backup of each year is saved in the long term.
+
+-> A maximum of 10 backups are retained for failed periodic backup tasks. They are retained for one month and can be
+  manually deleted on the web console.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+## Import
+
+Policies can be imported by their `id`. For example,
+
+```
+terraform import g42cloud_cbr_policy.test 4d2c2939-774f-42ef-ab15-e5b126b11ace
+```

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -1,0 +1,163 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# g42cloud_cbr_vault
+
+Manages a CBR Vault resource within G42Cloud.
+
+## Example Usage
+
+### Create a server type vault
+
+```hcl
+variable "vault_name" {}
+variable "ecs_instance_id" {}
+variable "evs_volume_id" {}
+
+data "g42cloud_compute_instance" "test" {
+  ...
+}
+
+resource "g42cloud_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "server"
+  protection_type  = "backup"
+  consistent_level = "crash_consistent"
+  size             = 100
+
+  resources {
+    server_id = var.ecs_instance_id
+  
+    excludes = [
+      var.evs_volume_id
+    ]
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+### Create a disk type vault
+
+```hcl
+variable "vault_name" {}
+variable "evs_volume_id" {}
+
+resource "g42cloud_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "disk"
+  protection_type  = "backup"
+  consistent_level = "crash_consistent"
+  size             = 50
+  auto_expand      = true
+
+  resources {
+    includes = [
+      var.evs_volume_id
+    ]
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+### Create an SFS turbo type vault
+
+```hcl
+variable "vault_name" {}
+variable "sfs_turbo_id" {}
+
+resource "g42cloud_cbr_vault" "test" {
+  name             = var.vault_name
+  consistent_level = "crash_consistent"
+  type             = "turbo"
+  protection_type  = "backup"
+  size             = 1000
+
+  resources {
+    includes = [
+      var.sfs_turbo_id
+    ]
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR vault. If omitted, the
+  provider-level region will be used. Changing this will create a new vault.
+
+* `name` - (Required, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+  characters, which may consist of letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Required, String, ForceNew) Specifies the object type of the CBR vault.
+  Changing this will create a new vault. Vaild values are as follows:
+  + **server** (Cloud Servers)
+  + **disk** (EVS Disks)
+  + **turbo** (SFS Turbo file systems)
+
+* `consistent_level` - (Required, String, ForceNew) Specifies the backup specifications.
+  The valid values are as follows:
+  + **[crash_consistent](https://docs.g42cloud.com/en-us/bp/cbr/cbr_07_0020.html)**
+  + **[app_consistent](https://docs.g42cloud.com/en-us/bp/cbr/cbr_07_0020.html)**
+
+  Only server type vaults support application consistent. Changing this will create a new vault.
+
+* `protection_type` - (Required, String, ForceNew) Specifies the protection type of the CBR vault.
+  The valid values is **backup**. Changing this will create a new vault.
+
+* `size` - (Required, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
+
+* `auto_expand` - (Optional, Bool) Specifies to enable auto capacity expansion for the backup protection type vault.
+  Default to **false**.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies a unique ID in UUID format of enterprise project.
+  Changing this will create a new vault.
+
+* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+
+* `resources` - (Optional, List) Specifies an array of one or more resources to attach to the CBR vault.
+  The [object](#cbr_vault_resources) structure is documented below.
+
+<a name="cbr_vault_resources"></a>
+The `resources` block supports:
+
+* `server_id` - (Optional, String) Specifies the ID of the ECS instance to be backed up.
+
+* `includes` - (Optional, List) Specifies the array of disk or SFS file system IDs which will be included in the backup.
+  Only **disk** and **turbo** vault support this parameter.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+* `allocated` - The allocated capacity of the vault, in GB.
+
+* `used` - The used capacity, in GB.
+
+* `spec_code` - The specification code.
+
+* `status` - The vault status.
+
+* `storage` - The name of the bucket for the vault.
+
+## Import
+
+Vaults can be imported by their `id`. For example,
+
+```
+$ terraform import g42cloud_cbr_vault.test 01c33779-7c83-4182-8b6b-24a671fcedf8
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/as"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ces"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dcs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
@@ -152,6 +153,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"g42cloud_availability_zones":    huaweicloud.DataSourceAvailabilityZones(),
+			"g42cloud_cbr_vaults":            cbr.DataSourceCbrVaultsV3(),
 			"g42cloud_cce_cluster":           huaweicloud.DataSourceCCEClusterV3(),
 			"g42cloud_cce_node":              huaweicloud.DataSourceCCENodeV3(),
 			"g42cloud_cce_addon_template":    huaweicloud.DataSourceCCEAddonTemplateV3(),
@@ -192,6 +194,8 @@ func Provider() *schema.Provider {
 			"g42cloud_as_configuration":                as.ResourceASConfiguration(),
 			"g42cloud_as_group":                        as.ResourceASGroup(),
 			"g42cloud_as_policy":                       as.ResourceASPolicy(),
+			"g42cloud_cbr_policy":                      cbr.ResourceCBRPolicyV3(),
+			"g42cloud_cbr_vault":                       cbr.ResourceCBRVaultV3(),
 			"g42cloud_cce_cluster":                     huaweicloud.ResourceCCEClusterV3(),
 			"g42cloud_cce_node":                        huaweicloud.ResourceCCENodeV3(),
 			"g42cloud_cce_addon":                       huaweicloud.ResourceCCEAddonV3(),

--- a/g42cloud/services/acceptance/cbr/data_source_g42cloud_cbr_vaults_test.go
+++ b/g42cloud/services/acceptance/cbr/data_source_g42cloud_cbr_vaults_test.go
@@ -1,0 +1,151 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+)
+
+func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.g42cloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "50"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "800"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
+func testAccCbrVaultsV3_serverBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cbr_vaults" "test" {
+  name = g42cloud_cbr_vault.test.name
+
+  depends_on = [
+    g42cloud_cbr_vault.test
+  ]
+}
+`, testAccCBRV3Vault_serverBasic(rName))
+}
+
+func testAccCbrVaultsV3_volumeBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cbr_vaults" "test" {
+  name = g42cloud_cbr_vault.test.name
+
+  depends_on = [
+    g42cloud_cbr_vault.test
+  ]
+}
+`, testAccCBRV3Vault_volumeBasic(rName))
+}
+
+func testAccCbrVaultsV3_turboBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cbr_vaults" "test" {
+  name = g42cloud_cbr_vault.test.name
+
+  depends_on = [
+    g42cloud_cbr_vault.test
+  ]
+}
+`, testAccCBRV3Vault_turboBasic(rName))
+}

--- a/g42cloud/services/acceptance/cbr/resource_g42cloud_cbr_policy_test.go
+++ b/g42cloud/services/acceptance/cbr/resource_g42cloud_cbr_policy_test.go
@@ -1,0 +1,206 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CbrV3Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating G42Cloud CBR client: %s", err)
+	}
+	return policies.Get(c, state.Primary.ID).Extract()
+}
+
+func TestAccCBRV3Policy_basic(t *testing.T) {
+	var asPolicy policies.Policy
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_cbr_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&asPolicy,
+		getResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCBRV3Policy_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "time_period", "20"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "MO,TU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "06:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "18:00"),
+				),
+			},
+			{
+				Config: testCBRV3Policy_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "5"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Policy_retention(t *testing.T) {
+	var asPolicy policies.Policy
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_cbr_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&asPolicy,
+		getResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCBRV3Policy_retention(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "15"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.daily", "10"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.weekly", "10"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.monthly", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				Config: testCBRV3Policy_retention_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "35"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.daily", "20"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.weekly", "20"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.monthly", "6"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.yearly", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCBRV3Policy_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_cbr_policy" "test" {
+  name        = "%s"
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    days            = "MO,TU"
+    execution_times = ["06:00", "18:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_update(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_cbr_policy" "test" {
+  name            = "%s-update"
+  type            = "backup"
+  backup_quantity = 5
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_retention(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_cbr_policy" "test" {
+  name            = "%s"
+  type            = "backup"
+  backup_quantity = 15
+
+  time_zone       = "UTC+08:00"
+  long_term_retention {
+    daily   = 10
+    weekly  = 10
+    monthly = 1
+  }
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_retention_update(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_cbr_policy" "test" {
+  name            = "%s"
+  type            = "backup"
+  backup_quantity = 35
+
+  time_zone       = "UTC+08:00"
+  long_term_retention {
+    daily   = 20
+    weekly  = 20
+    monthly = 6
+    yearly  = 1
+  }
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}

--- a/g42cloud/services/acceptance/cbr/resource_g42cloud_cbr_vault_test.go
+++ b/g42cloud/services/acceptance/cbr/resource_g42cloud_cbr_vault_test.go
@@ -1,0 +1,493 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/vaults"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+)
+
+func getVaultResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CbrV3Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating G42Cloud CBR client: %s", err)
+	}
+	return vaults.Get(c, state.Primary.ID).Extract()
+}
+
+func TestAccCBRV3Vault_BasicServer(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_cbr_vault.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_serverUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "300"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "policy_id",
+						"${g42cloud_cbr_policy.test.id}"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_cbr_vault.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "auto_expand", "false"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.includes.#", "2"),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_volumeUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "auto_expand", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.includes.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_cbr_vault.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&vault,
+		getVaultResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "800"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_turboUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "1000"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCBRV3Vault_policy(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_cbr_policy" "test" {
+  name        = "%s"
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    days            = "MO,TU"
+    execution_times = ["06:00", "18:00"]
+  }
+}
+`, rName)
+}
+
+func testAccEvsVolumeConfiguration_basic() string {
+	return fmt.Sprintf(`
+variable "volume_configuration" {
+  type = list(object({
+    volume_type = string
+    size        = number
+    device_type = string
+  }))
+  default = [
+    {volume_type = "SSD", size = 100, device_type = "VBD"},
+    {volume_type = "SSD", size = 100, device_type = "SCSI"},
+  ]
+}`)
+}
+
+func testAccEvsVolumeConfiguration_update() string {
+	return fmt.Sprintf(`
+variable "volume_configuration" {
+  type = list(object({
+    volume_type = string
+    size        = number
+    device_type = string
+  }))
+  default = [
+    {volume_type = "SSD", size = 100, device_type = "VBD"},
+    {volume_type = "SSD", size = 100, device_type = "SCSI"},
+  ]
+}`)
+}
+
+func testAccCBRV3VaultBasicConfiguration(config, rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_compute_flavors" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "g42cloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/20"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  vpc_id     = g42cloud_vpc.test.id
+  gateway_ip = "192.168.0.1"
+}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name                 = "%s"
+  delete_default_rules = true
+}
+
+resource "g42cloud_compute_keypair" "test" {
+  name = "%s"
+  lifecycle {
+    ignore_changes = [
+      public_key,
+    ]
+  }
+}
+
+resource "g42cloud_compute_instance" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  name              = "%s"
+  image_id          = data.g42cloud_images_image.test.id
+  flavor_id         = data.g42cloud_compute_flavors.test.ids[0]
+  key_pair          = g42cloud_compute_keypair.test.name
+
+  system_disk_type = "SSD"
+  system_disk_size = 50
+
+  security_group_ids = [
+    g42cloud_networking_secgroup.test.id
+  ]
+
+  network {
+    uuid = g42cloud_vpc_subnet.test.id
+  }
+}
+
+resource "g42cloud_evs_volume" "test" {
+  count = length(var.volume_configuration)
+
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  volume_type       = var.volume_configuration[count.index].volume_type
+  name              = "%s_${tostring(count.index)}"
+  size              = var.volume_configuration[count.index].size
+  device_type       = var.volume_configuration[count.index].device_type
+}
+
+resource "g42cloud_compute_volume_attach" "test" {
+  count = length(g42cloud_evs_volume.test)
+
+  instance_id = g42cloud_compute_instance.test.id
+  volume_id   = g42cloud_evs_volume.test[count.index].id
+}`, config, rName, rName, rName, rName, rName, rName)
+}
+
+func testAccCBRV3Vault_serverBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cbr_vault" "test" {
+  name                  = "%s"
+  type                  = "server"
+  consistent_level      = "app_consistent"
+  protection_type       = "backup"
+  size                  = 200
+  enterprise_project_id = "%s"
+
+  resources {
+    server_id = g42cloud_compute_instance.test.id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+		rName, acceptance.G42_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccCBRV3Vault_serverUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "g42cloud_cbr_vault" "test" {
+  name                  = "%s-update"
+  type                  = "server"
+  consistent_level      = "app_consistent"
+  protection_type       = "backup"
+  size                  = 300
+  enterprise_project_id = "%s"
+  policy_id             = g42cloud_cbr_policy.test.id
+
+  resources {
+    server_id = g42cloud_compute_instance.test.id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_update(), rName), testAccCBRV3Vault_policy(rName),
+		rName, acceptance.G42_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccCBRV3Vault_volumeBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cbr_vault" "test" {
+  name                  = "%s"
+  consistent_level      = "crash_consistent"
+  type                  = "disk"
+  protection_type       = "backup"
+  size                  = 50
+  enterprise_project_id = "%s"
+
+  resources {
+    includes = g42cloud_compute_volume_attach.test[*].volume_id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+		rName, acceptance.G42_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccCBRV3Vault_volumeUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "g42cloud_cbr_vault" "test" {
+  name                  = "%s-update"
+  consistent_level      = "crash_consistent"
+  type                  = "disk"
+  protection_type       = "backup"
+  size                  = 100
+  auto_expand           = true
+  enterprise_project_id = "%s"
+  policy_id             = g42cloud_cbr_policy.test.id
+
+  resources {
+    includes = g42cloud_compute_volume_attach.test[*].volume_id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+		testAccCBRV3Vault_policy(rName), rName, acceptance.G42_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+//Vaults of type 'turbo'
+func testAccCBRV3Vault_turboBase(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/20"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/22"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = g42cloud_vpc.test.id
+}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_sfs_turbo" "test1" {
+  name              = "%s-1"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = g42cloud_vpc.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  security_group_id = g42cloud_networking_secgroup.test.id
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+}`, rName, rName, rName, rName)
+}
+
+func testAccCBRV3Vault_turboBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cbr_vault" "test" {
+  name                  = "%s"
+  consistent_level      = "crash_consistent"
+  type                  = "turbo"
+  protection_type       = "backup"
+  size                  = 800
+  enterprise_project_id = "%s"
+
+  resources {
+    includes = [
+      g42cloud_sfs_turbo.test1.id
+    ]
+  }
+}
+`, testAccCBRV3Vault_turboBase(rName), rName, acceptance.G42_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccCBRV3Vault_turboUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "g42cloud_sfs_turbo" "test2" {
+  name              = "%s-2"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = g42cloud_vpc.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  security_group_id = g42cloud_networking_secgroup.test.id
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+}
+
+resource "g42cloud_cbr_vault" "test" {
+  name                  = "%s-update"
+  consistent_level      = "crash_consistent"
+  type                  = "turbo"
+  protection_type       = "backup"
+  size                  = 1000
+  enterprise_project_id = "%s"
+  policy_id             = g42cloud_cbr_policy.test.id
+
+  resources {
+    includes = [
+      g42cloud_sfs_turbo.test1.id,
+      g42cloud_sfs_turbo.test2.id
+    ]
+  }
+}
+`, testAccCBRV3Vault_turboBase(rName), testAccCBRV3Vault_policy(rName), rName, rName,
+		acceptance.G42_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/g42cloud-terraform/terraform-provider-g42cloud
 go 1.12
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20220328032852-6b7cdcd8a506
+	github.com/chnsz/golangsdk v0.0.0-20220402015046-523087b23e78
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.35.0
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220406033609-915fc20c2b2c
 )

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220328032852-6b7cdcd8a506 h1:BMOcL1ic8tnPqbLhKiYvbfG6inAfSDYwyE+sWpFKoXc=
-github.com/chnsz/golangsdk v0.0.0-20220328032852-6b7cdcd8a506/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220402015046-523087b23e78 h1:5vN3OMHjgMGKVAB3jgy2Bf+QdkXh9HtfvErVwB384wk=
+github.com/chnsz/golangsdk v0.0.0-20220402015046-523087b23e78/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -227,8 +227,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.80 h1:Xq9WC4DdigWodVe1hMDwcsOQKKEv6NJoRP2i0PIiHkM=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.80/go.mod h1:IvF+Pe06JMUivVgN6B4wcsPEoFvVa40IYaOPZyUt5HE=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.35.0 h1:FQK4JxYHwdQN9FpsAPtrbRDyR06h/sSrub/wH63QOxg=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.35.0/go.mod h1:L8qsK1q0lvUXXr+dK2YT3gPtA/QdD9AWcpdIVV+jG2k=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220406033609-915fc20c2b2c h1:aQKtpIE2p2LbRwv1JOafb9Ejd9Un5vTqAeomPrLM/Lw=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220406033609-915fc20c2b2c/go.mod h1:+1ScCG5N5tC3pXKfwLu+9qhPUtzeCRfMwjrEM80uoEw=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=


### PR DESCRIPTION
The following resource are added:

**data_sources**:
g42cloud_cbr_vaults
**resources**:
g42cloud_cbr_policy
g42cloud_cbr_vault

**Test results**:
```
make testacc TEST='./g42cloud/services/acceptance/cbr' TESTARGS='-run TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/cbr -v -run TestAcc -timeout 360m -parallel=4
=== RUN   TestAccCbrVaultsV3_BasicServer
=== PAUSE TestAccCbrVaultsV3_BasicServer
=== RUN   TestAccCbrVaultsV3_BasicVolume
=== PAUSE TestAccCbrVaultsV3_BasicVolume
=== RUN   TestAccCbrVaultsV3_BasicTurbo
=== PAUSE TestAccCbrVaultsV3_BasicTurbo
=== RUN   TestAccCBRV3Policy_basic
=== PAUSE TestAccCBRV3Policy_basic
=== RUN   TestAccCBRV3Policy_retention
=== PAUSE TestAccCBRV3Policy_retention
=== RUN   TestAccCBRV3Vault_BasicServer
=== PAUSE TestAccCBRV3Vault_BasicServer
=== RUN   TestAccCBRV3Vault_BasicVolume
=== PAUSE TestAccCBRV3Vault_BasicVolume
=== RUN   TestAccCBRV3Vault_BasicTurbo
=== PAUSE TestAccCBRV3Vault_BasicTurbo
=== CONT  TestAccCbrVaultsV3_BasicServer
=== CONT  TestAccCBRV3Policy_retention
=== CONT  TestAccCBRV3Vault_BasicVolume
=== CONT  TestAccCbrVaultsV3_BasicTurbo
--- PASS: TestAccCBRV3Policy_retention (37.90s)
=== CONT  TestAccCBRV3Vault_BasicServer
--- PASS: TestAccCbrVaultsV3_BasicServer (238.64s)
=== CONT  TestAccCbrVaultsV3_BasicVolume
--- PASS: TestAccCBRV3Vault_BasicVolume (274.60s)
=== CONT  TestAccCBRV3Vault_BasicTurbo
--- PASS: TestAccCBRV3Vault_BasicServer (264.48s)
=== CONT  TestAccCBRV3Policy_basic
--- PASS: TestAccCbrVaultsV3_BasicTurbo (335.56s)
--- PASS: TestAccCBRV3Policy_basic (35.23s)
--- PASS: TestAccCbrVaultsV3_BasicVolume (229.10s)
--- PASS: TestAccCBRV3Vault_BasicTurbo (531.80s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/cbr      806.473s
```
