### PR TITLE
feat(tms): add tms_tags resource in g42cloud

### DIFF
--- a/docs/resources/tms_tags.md
+++ b/docs/resources/tms_tags.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Tag Management Service (TMS)"
+---
+
+# g42cloud_tms_tags
+
+Manages TMS tags resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_tms_tags" "test" {
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `tags` - (Required, List, ForceNew) Specifies an array of one or more predefined tags. The tags object
+  structure is documented below. Changing this will create a new resource.
+
+The `tags` block supports:
+
+* `key` - (Required, String, ForceNew) Specifies the tag key. The value can contain up to 36 characters.
+  Only letters, digits, hyphens (-), underscores (_), and Unicode characters from \u4e00 to \u9fff are allowed.
+  Changing this will create a new resource.
+
+* `value` - (Required, String, ForceNew) Specifies the tag value. The value can contain up to 43 characters.
+  Only letters, digits, periods (.), hyphens (-), and underscores (_), and Unicode characters from \u4e00 to \u9fff
+  are allowed. Changing this will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 3 minute.
+* `delete` - Default is 3 minute.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/tms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 )
 
@@ -258,6 +259,7 @@ func Provider() *schema.Provider {
 			"g42cloud_swr_organization_permissions":    swr.ResourceSWROrganizationPermissions(),
 			"g42cloud_swr_repository":                  swr.ResourceSWRRepository(),
 			"g42cloud_swr_repository_sharing":          swr.ResourceSWRRepositorySharing(),
+			"g42cloud_tms_tags":                        tms.ResourceTmsTag(),
 			"g42cloud_vpc_bandwidth":                   eip.ResourceVpcBandWidthV2(),
 			"g42cloud_vpc_eip":                         eip.ResourceVpcEIPV1(),
 			"g42cloud_vpc_eip_associate":               eip.ResourceEIPAssociate(),

--- a/g42cloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
+++ b/g42cloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
@@ -1,0 +1,98 @@
+package tms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccTmsTag_basic(t *testing.T) {
+	resourceName := "g42cloud_tms_tags.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckTmsTagDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testTmsTag_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTmsTagExists("foo", "bar"),
+					testAccCheckTmsTagExists("k", "v"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTmsTagDestroy(s *terraform.State) error {
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := conf.HcTmsV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating TMS client: %s", err)
+	}
+
+	tags := map[string]string{"foo": "bar", "k": "v"}
+	for key, value := range tags {
+		request := &model.ListPredefineTagsRequest{
+			Key:   &key,
+			Value: &value,
+		}
+
+		response, err := client.ListPredefineTags(request)
+		if err != nil {
+			return err
+		}
+		tagsFromResponse := *response.Tags
+		if len(tagsFromResponse) != 0 {
+			return fmt.Errorf("g42cloud_tms_tags %s/%s still exists", key, value)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckTmsTagExists(key, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := conf.HcTmsV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating TMS client: %s", err)
+		}
+
+		request := &model.ListPredefineTagsRequest{
+			Key:   &key,
+			Value: &value,
+		}
+
+		response, err := client.ListPredefineTags(request)
+		if err != nil {
+			return err
+		}
+		tags := *response.Tags
+		if len(tags) != 0 {
+			return nil
+		}
+
+		return fmt.Errorf("g42cloud_tms_tags %s/%s does not exist", key, value)
+	}
+}
+
+const testTmsTag_basic = `
+resource "g42cloud_tms_tags" "test" {
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+  tags {
+    key   = "k"
+    value = "v"
+  }
+}
+`

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.12
 require (
 	github.com/chnsz/golangsdk v0.0.0-20220402015046-523087b23e78
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220406033609-915fc20c2b2c
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.80
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220409104350-0bd489cd9d17
 )

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.80 h1:Xq9WC4DdigWodVe1hMDwcsOQKKEv6NJoRP2i0PIiHkM=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.80/go.mod h1:IvF+Pe06JMUivVgN6B4wcsPEoFvVa40IYaOPZyUt5HE=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220406033609-915fc20c2b2c h1:aQKtpIE2p2LbRwv1JOafb9Ejd9Un5vTqAeomPrLM/Lw=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220406033609-915fc20c2b2c/go.mod h1:+1ScCG5N5tC3pXKfwLu+9qhPUtzeCRfMwjrEM80uoEw=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220409104350-0bd489cd9d17 h1:X3mS8bW31MpUSZ7Vsy5FdNGVvGhRY2I385iXEPPXk6Y=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.35.1-0.20220409104350-0bd489cd9d17/go.mod h1:+1ScCG5N5tC3pXKfwLu+9qhPUtzeCRfMwjrEM80uoEw=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=


### PR DESCRIPTION
The following resource are added:
**resources**:
g42cloud_tms_tags

**Test results**:
```
make testacc TEST='./g42cloud/services/acceptance/tms' TESTARGS='-run TestAccTmsTag_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/tms -v -run TestAccTmsTag_basic -timeout 360m -parallel=4
=== RUN   TestAccTmsTag_basic
--- PASS: TestAccTmsTag_basic (17.82s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/tms      17.879s
```
