### PR TITLE
feat(cts): add new cts resources

### DIFF
--- a/docs/resources/cts_data_tracker.md
+++ b/docs/resources/cts_data_tracker.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+# g42cloud_cts_data_tracker
+
+Manages CTS **data** tracker resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "data_bucket" {}
+variable "transfer_bucket" {}
+
+resource "g42cloud_cts_data_tracker" "tracker" {
+  name        = "data-tracker"
+  data_bucket = var.data_bucket
+  bucket_name = var.transfer_bucket
+  file_prefix = "cloudTrace"
+  lts_enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CTS data tracker resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the data tracker name. The name cannot be system or ststem-trace.
+  Changing this creates a new resource.
+
+* `data_bucket` - (Required, String, ForceNew) Specifies the OBS bucket tracked by the data tracker.
+  Changing this creates a new resource.
+
+* `data_operation` - (Optional, List) Specifies an array of operation types tracked by the data tracker,
+  the value of operation can be **WRITE** or **READ**.
+
+* `bucket_name` - (Optional, String) Specifies the OBS bucket to which traces will be transferred.
+
+* `file_prefix` - (Optional, String) Specifies the file name prefix to mark trace files that need to be stored
+  in an OBS bucket. The value contains 0 to 64 characters. Only letters, numbers, hyphens (-), underscores (_),
+  and periods (.) are allowed.
+
+* `obs_retention_period` - (Optional, Int) Specifies the retention period that traces are stored in `bucket_name`,
+  the value can be **0**(permanent), **30**, **60**, **90**, **180** or **1095**.
+
+* `lts_enabled` - (Optional, Bool) Specifies whether trace analysis is enabled.
+
+* `validate_file` - (Optional, Bool) Specifies whether trace file verification is enabled during trace transfer.
+
+* `enabled` - (Optional, Bool) Specifies whether tracker is enabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the tracker name.
+* `type` - The tracker type, only **data** is available.
+* `transfer_enabled` - Whether traces will be transferred.
+* `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+CTS data tracker can be imported using `name`, e.g.:
+
+```
+$ terraform import g42cloud_cts_data_tracker.tracker your_tracker_name
+```

--- a/docs/resources/cts_tracker.md
+++ b/docs/resources/cts_tracker.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+# g42cloud_cts_tracker
+
+Manages CTS **system** tracker resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "bucket_name" {}
+
+resource "g42cloud_cts_tracker" "tracker" {
+  bucket_name = var.bucket_name
+  file_prefix = "cts"
+  lts_enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CTS system tracker resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `bucket_name` - (Optional, String) Specifies the OBS bucket to which traces will be transferred.
+
+* `file_prefix` - (Optional, String) Specifies the file name prefix to mark trace files that need to be stored
+  in an OBS bucket. The value contains 0 to 64 characters. Only letters, numbers, hyphens (-), underscores (_),
+  and periods (.) are allowed.
+
+* `lts_enabled` - (Optional, Bool) Specifies whether trace analysis is enabled.
+
+* `validate_file` - (Optional, Bool) Specifies whether trace file verification is enabled during trace transfer.
+
+* `kms_id` - (Optional, String) Specifies the ID of KMS key used for trace file encryption.
+
+* `enabled` - (Optional, Bool) Specifies whether tracker is enabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+* `name` - The tracker name, only **system** is available.
+* `type` - The tracker type, only **system** is available.
+* `transfer_enabled` - Whether traces will be transferred.
+* `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+CTS tracker can be imported using `name`, only **system** is available. e.g.
+
+```
+$ terraform import g42cloud_cts_tracker.tracker system
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/as"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ces"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cts"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dcs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
@@ -210,6 +211,8 @@ func Provider() *schema.Provider {
 			"g42cloud_compute_servergroup":             huaweicloud.ResourceComputeServerGroupV2(),
 			"g42cloud_compute_eip_associate":           huaweicloud.ResourceComputeFloatingIPAssociateV2(),
 			"g42cloud_compute_volume_attach":           ecs.ResourceComputeVolumeAttach(),
+			"g42cloud_cts_tracker":                     cts.ResourceCTSTracker(),
+			"g42cloud_cts_data_tracker":                cts.ResourceCTSDataTracker(),
 			"g42cloud_dcs_instance":                    dcs.ResourceDcsInstance(),
 			"g42cloud_dds_instance":                    dds.ResourceDdsInstanceV3(),
 			"g42cloud_dli_queue":                       dli.ResourceDliQueue(),

--- a/g42cloud/services/acceptance/cts/resource_g42cloud_cts_data_tracker_test.go
+++ b/g42cloud/services/acceptance/cts/resource_g42cloud_cts_data_tracker_test.go
@@ -1,0 +1,137 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getCTSDataTrackerResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcCtsV3Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CTS client: %s", err)
+	}
+
+	name := state.Primary.ID
+	trackerType := cts.GetListTrackersRequestTrackerTypeEnum().DATA
+	listOpts := &cts.ListTrackersRequest{
+		TrackerName: &name,
+		TrackerType: &trackerType,
+	}
+
+	response, err := client.ListTrackers(listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CTS tracker: %s", err)
+	}
+
+	if response.Trackers == nil || len(*response.Trackers) == 0 {
+		return nil, fmt.Errorf("can not find the CTS tracker %s", name)
+	}
+
+	allTrackers := *response.Trackers
+	ctsTracker := allTrackers[0]
+
+	return ctsTracker, nil
+}
+
+func TestAccCTSDataTracker_basic(t *testing.T) {
+	var dataTracker cts.TrackerResponseBody
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_cts_data_tracker.tracker"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&dataTracker,
+		getCTSDataTrackerResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSDataTracker_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transfer_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "type", "data"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "data_operation.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_bucket",
+						"g42cloud_obs_bucket.data_bucket", "bucket"),
+				),
+			},
+			{
+				Config: testAccCTSDataTracker_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "transfer_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket_name",
+						"g42cloud_obs_bucket.trans_bucket", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts"),
+					resource.TestCheckResourceAttr(resourceName, "obs_retention_period", "30"),
+					resource.TestCheckResourceAttr(resourceName, "validate_file", "false"),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCTSDataTracker_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "data_bucket" {
+  bucket = "%[1]s-data"
+  acl    = "public-read"
+}
+
+resource "g42cloud_cts_data_tracker" "tracker" {
+  name        = "%[1]s"
+  data_bucket = g42cloud_obs_bucket.data_bucket.bucket
+  lts_enabled = true
+}
+`, rName)
+}
+
+func testAccCTSDataTracker_update(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "data_bucket" {
+  bucket = "%[1]s-data"
+  acl    = "public-read"
+}
+
+resource "g42cloud_obs_bucket" "trans_bucket" {
+  bucket        = "%[1]s-log"
+  acl           = "private"
+  force_destroy = true
+
+  lifecycle {
+    ignore_changes = [lifecycle_rule]
+  }
+}
+
+resource "g42cloud_cts_data_tracker" "tracker" {
+  name                 = "%[1]s"
+  data_bucket          = g42cloud_obs_bucket.data_bucket.bucket
+  bucket_name          = g42cloud_obs_bucket.trans_bucket.bucket
+  obs_retention_period = 30
+  file_prefix          = "cts"
+  validate_file        = false
+  lts_enabled          = false
+}
+`, rName)
+}

--- a/g42cloud/services/acceptance/cts/resource_g42cloud_cts_tracker_test.go
+++ b/g42cloud/services/acceptance/cts/resource_g42cloud_cts_tracker_test.go
@@ -1,0 +1,141 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCTSTracker_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_cts_tracker.tracker"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCTSTrackerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSTracker_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCTSTrackerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts"),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", "system"),
+					resource.TestCheckResourceAttr(resourceName, "type", "system"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+				),
+			},
+			{
+				Config: testAccCTSTracker_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts-updated"),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCTSTrackerImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCTSTrackerImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		tracker, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("CTS tracker not found")
+		}
+
+		name := tracker.Primary.Attributes["name"]
+		if name == "" {
+			return "", fmt.Errorf("CTS tracker resource %s not found", tracker.Primary.ID)
+		}
+		return name, nil
+	}
+}
+
+func testAccCheckCTSTrackerDestroy(s *terraform.State) error {
+	// the system tracker always exists
+	return nil
+}
+
+func testAccCheckCTSTrackerExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		ctsClient, err := cfg.HcCtsV3Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating CTS client: %s", err)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		listOpts := &cts.ListTrackersRequest{
+			TrackerName: &name,
+		}
+
+		response, err := ctsClient.ListTrackers(listOpts)
+		if err != nil {
+			return fmt.Errorf("error retrieving CTS tracker: %s", err)
+		}
+
+		if response.Trackers == nil || len(*response.Trackers) == 0 {
+			return fmt.Errorf("can not find the CTS tracker %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCTSTracker_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "public-read"
+  force_destroy = true
+}
+
+resource "g42cloud_cts_tracker" "tracker" {
+  bucket_name = g42cloud_obs_bucket.bucket.bucket
+  file_prefix = "cts"
+  lts_enabled = true
+}
+`, rName)
+}
+
+func testAccCTSTracker_update(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "public-read"
+  force_destroy = true
+}
+
+resource "g42cloud_cts_tracker" "tracker" {
+  bucket_name = g42cloud_obs_bucket.bucket.bucket
+  file_prefix = "cts-updated"
+  lts_enabled = false
+  enabled     = false
+}
+`, rName)
+}


### PR DESCRIPTION
add resources:
g42cloud_cts_data_tracker
g42cloud_cts_tracker

Test result:
```
make testacc TEST='./g42cloud/services/acceptance/cts' TESTARGS='-run TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/cts -v -run TestAcc -timeout 360m -parallel=4
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== RUN   TestAccCTSTracker_basic
=== PAUSE TestAccCTSTracker_basic
=== CONT  TestAccCTSDataTracker_basic
=== CONT  TestAccCTSTracker_basic
--- PASS: TestAccCTSTracker_basic (49.45s)
--- PASS: TestAccCTSDataTracker_basic (51.79s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/cts      51.881s
```