### PR TITLE
feat(css): add new css resources

### DIFF
--- a/docs/data-sources/css_flavors.md
+++ b/docs/data-sources/css_flavors.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+---
+
+# g42cloud_css_flavors
+
+Use this data source to get available flavors of G42Cloud CSS node instance.
+
+## Example Usage
+
+```hcl
+data "g42cloud_css_flavors" "test" {
+  type    = "ess"
+  version = "7.9.3"
+  vcpus   = 4
+  memory  = 32
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the CSS flavors. If omitted, the
+  provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the node instance type. The options are `ess`, `ess-cold`, `ess-master`
+ and `ess-client`.
+
+* `version` - (Optional, String) Specifies the engine version. The options are `5.5.1`, `6.2.3`, `6.5.4`, `7.1.1`,
+ `7.6.2` and `7.9.3`.
+
+* `name` - (Optional, String) Specifies the name of the CSS flavor.
+
+* `vcpus` - (Optional, Int) Specifies the number of vCPUs in the CSS flavor.
+
+* `memory` - (Optional, Int) Specifies the memory size(GB) in the CSS flavor.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID in UUID format.
+
+* `flavors` - Indicates the flavors information. Structure is documented below.
+
+The `flavors` block contains:
+
+* `name` - The name of the CSS flavor. It is referenced by `node_config.flavor` in `g42cloud_css_cluster`.
+* `id` - The ID of CSS flavor.
+* `region` - The region where the node resides.
+* `type` - The node instance type.
+* `version` - The engine version.
+* `vcpus` - The number of vCPUs.
+* `memory` - The memory size in GB.
+* `disk_range` - The disk capacity range of an instance, in GB.

--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -1,0 +1,184 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+---
+
+# g42cloud_css_cluster
+
+Manages CSS cluster resource within G42Cloud
+
+## Example Usage
+
+### create a cluster
+
+```hcl
+variable "availability_zone" {}
+variable "network_id" {}
+variable "vpc_id" {}
+
+resource "g42cloud_networking_secgroup" "secgroup" {
+  name        = "terraform_test_security_group"
+  description = "terraform security group acceptance test"
+}
+
+resource "g42cloud_css_cluster" "cluster" {
+  expect_node_num = 1
+  name            = "terraform_test_cluster"
+  engine_version  = "7.1.1"
+
+  node_config {
+    flavor = "ess.spec-4u8g"
+    availability_zone = var.availability_zone
+
+    network_info {
+      security_group_id = g42cloud_networking_secgroup.secgroup.id
+      subnet_id         =  var.network_id
+      vpc_id            =  var.vpc_id
+    }
+
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the cluster resource. If omitted, the
+  provider-level region will be used. Changing this creates a new cluster resource.
+
+* `name` - (Required, String, ForceNew) Cluster name. It contains 4 to 32 characters. Only letters, digits, hyphens (-),
+  and underscores (_) are allowed. The value must start with a letter. Changing this parameter will create a new
+  resource.
+
+* `engine_type` - (Optional, String, ForceNew) Engine type. The default value is "elasticsearch". Currently, the value
+  can only be "elasticsearch". Changing this parameter will create a new resource.
+
+* `engine_version` - (Required, String, ForceNew) Engine version. Versions 5.5.1, 6.2.3, 6.5.4, 7.1.1, 7.6.2 and 7.9.3
+  are supported. Changing this parameter will create a new resource.
+
+* `expect_node_num` - (Optional, Int) Number of cluster instances. The value range is 1 to 32. Defaults to 1.
+
+* `security_mode` - (Optional, Bool, ForceNew) Whether to enable communication encryption and security authentication.
+  Available values include *true* and *false*. security_mode is disabled by default. Changing this parameter will create
+  a new resource.
+
+* `password` - (Optional, String, ForceNew) Password of the cluster administrator admin in security mode. This parameter
+  is mandatory only when security_mode is set to true. Changing this parameter will create a new resource. The
+  administrator password must meet the following requirements:
+  + The password can contain 8 to 32 characters.
+  + The password must contain at least 3 of the following character types: uppercase letters, lowercase letters, digits,
+    and special characters (~!@#$%^&*()-_=+\\|[{}];:,<.>/?).
+
+* `node_config` - (Required, List, ForceNew) Node configuration. Structure is documented below. Changing this parameter
+  will create a new resource.
+
+* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
+
+* `tags` - (Optional, Map) The key/value pairs to associate with the cluster.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the css cluster, Value 0
+  indicates the default enterprise project. Changing this parameter will create a new resource.
+
+The `node_config` block supports:
+
+* `availability_zone` - (Optional, String, ForceNew) Availability zone (AZ). Changing this parameter will create a new
+  resource.
+
+* `flavor` - (Required, String, ForceNew) Instance flavor name. For example: value range of flavor ess.spec-2u8g:
+  40 GB to 800 GB, value range of flavor ess.spec-4u8g: 40 GB to 1600 GB, value range of flavor ess.spec-8u32g: 80 GB
+  to 3200 GB, value range of flavor ess.spec-16u64g: 100 GB to 6400 GB, value range of flavor ess.spec-32u128g: 100 GB
+  to 10240 GB. Changing this parameter will create a new resource.
+
+* `network_info` - (Required, List, ForceNew) Network information. Structure is documented below. Changing this
+  parameter will create a new resource.
+
+* `volume` - (Required, List, ForceNew) Information about the volume. Structure is documented below. Changing this
+  parameter will create a new resource.
+
+The `network_info` block supports:
+
+* `vpc_id` - (Required, String, ForceNew) VPC ID, which is used for configuring cluster network. Changing this parameter
+  will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Subnet ID. All instances in a cluster must have the same subnet which
+  should be configured with a *DNS address*. Changing this parameter will create a new resource.
+
+* `security_group_id` - (Required, String, ForceNew) Security group ID. All instances in a cluster must have the same
+  security group. Changing this parameter will create a new resource.
+
+The `volume` block supports:
+
+* `size` - (Required, Int) Specifies the volume size in GB, which must be a multiple of 10.
+
+* `volume_type` - (Required, String, ForceNew) Specifies the volume type. COMMON: Common I/O. The SATA disk is used.
+  HIGH: High I/O. The SAS disk is used. ULTRAHIGH: Ultra-high I/O. The solid-state drive (SSD) is used. Changing this
+  parameter will create a new resource.
+
+The `backup_strategy` block supports:
+
+* `start_time` - (Required, String) Specifies the time when a snapshot is automatically created everyday. Snapshots can
+  only be created on the hour. The time format is the time followed by the time zone, specifically, **HH:mm z**. In the
+  format, HH:mm refers to the hour time and z refers to the time zone. For example, "00:00 GMT+08:00"
+  and "01:00 GMT+08:00".
+
+* `keep_days` - (Optional, Int) Specifies the number of days to retain the generated snapshots. Snapshots are reserved
+  for seven days by default.
+
+* `prefix` - (Optional, String) Specifies the prefix of the snapshot that is automatically created. The default value
+  is "snapshot".
+
+* `bucket` - (Optional, String) Specifies the OBS bucket used for index data backup. If there is snapshot data in an OBS
+   bucket, only the OBS bucket is used and cannot be changed.
+
+* `backup_path` - (Optional, String) Specifies the storage path of the snapshot in the OBS bucket.
+
+* `agency` - (Optional, String) Specifies the IAM agency used to access OBS.
+
+  -> **NOTE:**  If the `bucket`, `backup_path`, and `agency` parameters are empty at the same time, the system will
+  automatically create an OBS bucket and IAM agent, otherwise the configured parameter values will be used.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `endpoint` - Indicates the IP address and port number.
+
+* `created` - Time when a cluster is created. The format is ISO8601:
+  CCYY-MM-DDThh:mm:ss.
+
+* `status` - Indicateds the cluster status
+  + `100`: The operation, such as instance creation, is in progress.
+  + `200`: The cluster is available.
+  + `303`: The cluster is unavailable.
+
+* `nodes` - List of node objects. Structure is documented below.
+
+  The `nodes` block contains:
+
+  + `id` - Instance ID.
+
+  + `name` - Instance name.
+
+  + `type` - Supported type: ess (indicating the Elasticsearch node).
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minute.
+* `update` - Default is 60 minute.
+* `delete` - Default is 60 minute.
+
+## Import
+
+CSS cluster can be imported by `id`. For example,
+
+```
+terraform import g42cloud_css_cluster.example 6d793124-3d5d-47be-bf09-f694fdf2d9ed
+```

--- a/docs/resources/css_snapshot.md
+++ b/docs/resources/css_snapshot.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+---
+
+# g42cloud_css_snapshot
+
+CSS cluster snapshot management
+
+## Example Usage
+
+### Create a snapshot
+
+```hcl
+resource "g42cloud_css_snapshot" "snapshot" {
+  name        = "snapshot_001"
+  description = "a snapshot created by manual"
+  cluster_id  = var.css_cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) Specifies the snapshot name. The snapshot name must start with a letter and
+  contains 4 to 64 characters consisting of only lowercase letters, digits, hyphens (-), and underscores (_). Changing
+  this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies ID of the CSS cluster where index data is to be backed up.
+  Changing this parameter will create a new resource.
+
+* `index` - (Optional, String, ForceNew) Specifies the name of the index to be backed up. Multiple index names are
+  separated by commas (,). By default, data of all indices is backed up. You can use the asterisk (*) to back up data of
+  certain indices. For example, if you enter 2020-06*, then data of indices with the name prefix of 2020-06 will be
+  backed up. The value contains 0 to 1024 characters. Uppercase letters, spaces, and certain special characters (
+  including "\\<|>/?) are not allowed. Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of a snapshot. The value contains 0 to 256
+  characters, and angle brackets (<) and (>) are not allowed. Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `status` - Indicates the snapshot status.
+
+* `cluster_name` - Indicates the CSS cluster name.
+
+* `backup_type` - Indicates the snapshot creation mode, the value should be "manual" or "automated".
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+This resource can be imported by specifying the CSS cluster ID and snapshot ID separated by a slash, e.g.:
+
+```
+$ terraform import g42cloud_css_snapshot.snapshot_1 < cluster_id >/< snapshot_id >
+```

--- a/docs/resources/css_thesaurus.md
+++ b/docs/resources/css_thesaurus.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+---
+
+# g42cloud_css_thesaurus
+
+Manages CSS thesaurus resource within G42Cloud
+
+-> Only one thesaurus resource can be created for the specified cluster
+
+## Example Usage
+
+### Create a thesaurus
+
+```hcl
+resource "g42cloud_css_thesaurus" "test" {
+  cluster_id  = {{ css_cluster_id }}
+  bucket_name = {{ bucket_name }}
+  main_object = {{ bucket_obj_key }}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the thesaurus resource. If omitted, the
+  provider-level region will be used. Changing this creates a new thesaurus resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the CSS cluster ID for configuring the thesaurus.
+  Changing this parameter will create a new resource.
+
+* `bucket_name` - (Required, String, ForceNew) Specifies the OBS bucket where the thesaurus files are stored
+ (the bucket type must be standard storage or low-frequency storage, and archive storage is not supported).
+
+* `main_object` - (Optional, String) Specifies the path of the main thesaurus file object.
+
+* `stop_object` - (Optional, String) Specifies the path of the stop word library file object.
+
+* `synonym_object` - (Optional, String) Specifies the path of the synonyms thesaurus file object.
+
+-> Specifies at least one of `main_object`,`stop_object`,`synonym_object`
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a resource ID in UUID format.
+
+* `status` - Indicates the status of the thesaurus loading
+
+* `update_time` - Specifies the time (UTC) when the thesaurus was modified. The format is ISO8601:YYYY-MM-DDThh:mm:ssZ
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+CSS thesaurus can be imported by `id`. For example,
+
+```
+terraform import g42cloud_css_thesaurus.example e9ee3f48-f097-406a-aa74-cfece0af3e31
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/bms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ces"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/css"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cts"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dcs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
@@ -165,6 +166,7 @@ func Provider() *schema.Provider {
 			"g42cloud_cce_addon_template":    huaweicloud.DataSourceCCEAddonTemplateV3(),
 			"g42cloud_cce_node_pool":         huaweicloud.DataSourceCCENodePoolV3(),
 			"g42cloud_compute_flavors":       huaweicloud.DataSourceEcsFlavors(),
+			"g42cloud_css_flavors":           css.DataSourceCssFlavors(),
 			"g42cloud_dds_flavors":           dds.DataSourceDDSFlavorV3(),
 			"g42cloud_dcs_az":                deprecated.DataSourceDcsAZV1(),
 			"g42cloud_dcs_flavors":           dcs.DataSourceDcsFlavorsV2(),
@@ -214,6 +216,9 @@ func Provider() *schema.Provider {
 			"g42cloud_compute_servergroup":             huaweicloud.ResourceComputeServerGroupV2(),
 			"g42cloud_compute_eip_associate":           huaweicloud.ResourceComputeFloatingIPAssociateV2(),
 			"g42cloud_compute_volume_attach":           ecs.ResourceComputeVolumeAttach(),
+			"g42cloud_css_cluster":                     css.ResourceCssCluster(),
+			"g42cloud_css_snapshot":                    css.ResourceCssSnapshot(),
+			"g42cloud_css_thesaurus":                   css.ResourceCssthesaurus(),
 			"g42cloud_cts_tracker":                     cts.ResourceCTSTracker(),
 			"g42cloud_cts_data_tracker":                cts.ResourceCTSDataTracker(),
 			"g42cloud_dcs_instance":                    dcs.ResourceDcsInstance(),

--- a/g42cloud/services/acceptance/css/data_source_g42cloud_css_flavors_test.go
+++ b/g42cloud/services/acceptance/css/data_source_g42cloud_css_flavors_test.go
@@ -1,0 +1,81 @@
+package css
+
+import (
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccCssFlavorsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_css_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCssFlavors_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.type", "ess"),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.version", "7.9.3"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.region"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.memory"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.vcpus"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.disk_range"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCssFlavors_basic = `
+data "g42cloud_css_flavors" "test" {
+  type    = "ess"
+  version = "7.9.3"
+}
+`
+
+func TestAccCssFlavorsDataSource_all(t *testing.T) {
+	dataSourceName := "data.g42cloud_css_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCssFlavors_all,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.type", "ess"),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.version", "7.9.3"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.id"),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.region", "ae-ad-1"),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.name", "ess.spec-ds.8xlarge.8"),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.memory", "256"),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.vcpus", "32"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.disk_range"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCssFlavors_all = `
+data "g42cloud_css_flavors" "test" {
+  type    = "ess"
+  version = "7.9.3"
+  vcpus   = 32
+  memory  = 256
+  region  = "ae-ad-1"
+  name    = "ess.spec-ds.8xlarge.8"
+}
+`

--- a/g42cloud/services/acceptance/css/resource_g42cloud_css_cluster_test.go
+++ b/g42cloud/services/acceptance/css/resource_g42cloud_css_cluster_test.go
@@ -1,0 +1,216 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/css/v1/cluster"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccCssCluster_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_css_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCssClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssCluster_basic(rName, 1, 7, "bar"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "expect_node_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccCssCluster_basic(rName, 2, 8, "bar_update"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "expect_node_num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "8"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCssCluster_security(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_css_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCssClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssCluster_security(rName, 1, "bar"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "expect_node_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "security_mode", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpc(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  vpc_id     = g42cloud_vpc.test.id
+  gateway_ip = "192.168.0.1"
+}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name        = "%s"
+  description = "terraform security group acceptance test"
+}
+
+data "g42cloud_availability_zones" "test" {}
+`, rName, rName, rName)
+}
+
+func testAccCssCluster_basic(rName string, nodeNum int, keepDays int, tag string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_css_cluster" "test" {
+  name            = "%s"
+  engine_version  = "7.9.3"
+  expect_node_num = %d
+
+  node_config {
+    flavor            = "ess.spec-4u8g"
+    availability_zone = data.g42cloud_availability_zones.test.names[0]
+
+    network_info {
+      security_group_id = g42cloud_networking_secgroup.test.id
+      subnet_id         = g42cloud_vpc_subnet.test.id
+      vpc_id            = g42cloud_vpc.test.id
+    }
+
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }
+  }
+
+  backup_strategy {
+    keep_days  = %d
+    start_time = "00:00 GMT+08:00"
+    prefix     = "snapshot"
+  }
+
+  tags = {
+    foo = "%s"
+    key = "value"
+  }
+}
+
+`, testAccVpc(rName), rName, nodeNum, keepDays, tag)
+}
+
+func testAccCssCluster_security(rName string, nodeNum int, tag string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_css_cluster" "test" {
+  name            = "%s"
+  engine_version  = "7.9.3"
+  expect_node_num = %d
+  security_mode   = true
+  password        = "Test@passw0rd"
+
+  node_config {
+    flavor            = "ess.spec-4u8g"
+    availability_zone = data.g42cloud_availability_zones.test.names[0]
+
+    network_info {
+      security_group_id = g42cloud_networking_secgroup.test.id
+      subnet_id         = g42cloud_vpc_subnet.test.id
+      vpc_id            = g42cloud_vpc.test.id
+    }
+
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }  
+  }
+
+  tags = {
+    foo = "%s"
+    key = "value"
+  }
+}
+
+`, testAccVpc(rName), rName, nodeNum, tag)
+}
+
+func testAccCheckCssClusterDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.CssV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("error creating CSS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_css_cluster" {
+			continue
+		}
+
+		_, err := cluster.Get(client, rs.Primary.ID)
+		if err == nil {
+			return fmtp.Errorf("css cluster still exists, cluster_id:%s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCssClusterExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.CssV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("error creating CSS client: %s", err)
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmtp.Errorf("Error checking g42cloud_css_cluster exist, err=not found this resource")
+		}
+
+		_, errQueryDetail := cluster.Get(client, rs.Primary.ID)
+		if errQueryDetail != nil {
+			if _, ok := errQueryDetail.(golangsdk.ErrDefault404); ok {
+				return fmtp.Errorf("g42cloud_css_cluster is not exist")
+			}
+			return fmtp.Errorf("checking g42cloud_css_cluster exist,err=send request failed:%s", errQueryDetail)
+		}
+		return nil
+	}
+}

--- a/g42cloud/services/acceptance/css/resource_g42cloud_css_snapshot_test.go
+++ b/g42cloud/services/acceptance/css/resource_g42cloud_css_snapshot_test.go
@@ -1,0 +1,125 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/css/v1/snapshots"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCssSnapshot_basic(t *testing.T) {
+	rand := acctest.RandString(5)
+	resourceName := "g42cloud_css_snapshot.snapshot"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCssSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssSnapshot_basic(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssSnapshotExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("snapshot-%s", rand)),
+					resource.TestCheckResourceAttr(resourceName, "status", "COMPLETED"),
+					resource.TestCheckResourceAttr(resourceName, "backup_type", "manual"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmtp.Errorf("Not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["cluster_id"], rs.Primary.ID), nil
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckCssSnapshotDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.CssV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating css client, err=%s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_css_snapshot" {
+			continue
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		snapList, err := snapshots.List(client, clusterID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+
+			return err
+		}
+
+		for _, v := range snapList {
+			if v.ID == rs.Primary.ID {
+				return fmtp.Errorf("g42cloud css snapshot %s still exists", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCssSnapshotExists() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.CssV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("Error creating css client, err=%s", err)
+		}
+
+		rs, ok := s.RootModule().Resources["g42cloud_css_snapshot.snapshot"]
+		if !ok {
+			return fmtp.Errorf("Error checking g42cloud css snapshot.snapshot exist, err=not found this resource")
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		snapList, err := snapshots.List(client, clusterID).Extract()
+		if err != nil {
+			return err
+		}
+
+		for _, v := range snapList {
+			if v.ID == rs.Primary.ID {
+				return nil
+			}
+		}
+
+		return fmtp.Errorf("g42cloud css snapshot %s is not exist", rs.Primary.ID)
+	}
+}
+
+func testAccCssSnapshot_basic(val string) string {
+	clusterName := acceptance.RandomAccResourceName()
+	clusterString := testAccCssCluster_basic(clusterName, 1, 1, "tag")
+
+	return fmt.Sprintf(`
+%s
+resource "g42cloud_css_snapshot" "snapshot" {
+  name        = "snapshot-%s"
+  description = "a snapshot created by terraform acctest"
+  cluster_id  = g42cloud_css_cluster.test.id
+}
+`, clusterString, val)
+}

--- a/g42cloud/services/acceptance/css/resource_g42cloud_css_thesaurus_test.go
+++ b/g42cloud/services/acceptance/css/resource_g42cloud_css_thesaurus_test.go
@@ -1,0 +1,134 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/css/v1/thesaurus"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccCssThesaurus_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_css_thesaurus.test"
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCssThesaurusDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssThesaurus_basic(rName, bucketName, "main.txt"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssThesaurusExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "main_object", "main.txt"),
+				),
+			},
+			{
+				Config: testAccCssThesaurus_basic(rName, bucketName, "main2.txt"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssThesaurusExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "main_object", "main2.txt"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCssThesaurus_basic(rName string, bucketName string, obsObjectKey string) string {
+	cssClusterBasic := testAccCssCluster_basic(rName, 1, 1, "value")
+
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_obs_bucket" "test" {
+  bucket = "%s"
+  acl    = "private"
+}
+
+
+resource "g42cloud_obs_bucket_object" "test" {
+  bucket       = g42cloud_obs_bucket.test.bucket
+  key          = "%s"
+  content      = "123"
+  content_type = "text/plain"
+}
+
+resource "g42cloud_css_thesaurus" "test" {
+  cluster_id  = g42cloud_css_cluster.test.id
+  bucket_name = g42cloud_obs_bucket.test.bucket
+  main_object = g42cloud_obs_bucket_object.test.key
+}
+
+`, cssClusterBasic, bucketName, obsObjectKey)
+}
+
+func testAccCheckCssThesaurusDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.CssV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("error creating CSS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_css_thesaurus" {
+			continue
+		}
+
+		resp, getErr := thesaurus.Get(client, rs.Primary.ID)
+		if getErr != nil {
+			if _, ok := getErr.(golangsdk.ErrDefault404); !ok {
+				return fmtp.Errorf("Get CSS thesaurus failed.error=%s", getErr)
+			}
+		} else {
+			if resp.Bucket != "" {
+				return fmtp.Errorf("CSS thesaurus still exists, cluster_id:%s", rs.Primary.ID)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckCssThesaurusExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.CssV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("error creating CSS client: %s", err)
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmtp.Errorf("Error checking g42cloud_css_thesaurus exist, err=not found this resource")
+		}
+
+		resp, errQueryDetail := thesaurus.Get(client, rs.Primary.ID)
+		if errQueryDetail != nil {
+			return fmtp.Errorf("error checking g42cloud_css_thesaurus exist,err=send request failed:%s", errQueryDetail)
+		}
+
+		if resp == nil || resp.Bucket == "" {
+			return fmtp.Errorf("CSS thesaurus don't exists, cluster_id:%s", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
new data_source:
  g42cloud_css_flavors
new resources:
  g42cloud_css_cluster
  g42cloud_css_snapshot
  g42cloud_css_thesaurus

Test results:
```
make testacc TEST='./g42cloud/services/acceptance/css' TESTARGS='-run TestAccCssFlavors'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/css -v -run TestAccCssFlavors -timeout 360m -parallel=4
=== RUN   TestAccCssFlavorsDataSource_basic
=== PAUSE TestAccCssFlavorsDataSource_basic
=== RUN   TestAccCssFlavorsDataSource_all
=== PAUSE TestAccCssFlavorsDataSource_all
=== CONT  TestAccCssFlavorsDataSource_basic
=== CONT  TestAccCssFlavorsDataSource_all
--- PASS: TestAccCssFlavorsDataSource_all (16.22s)
--- PASS: TestAccCssFlavorsDataSource_basic (16.31s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/css      16.382s

make testacc TEST='./g42cloud/services/acceptance/css' TESTARGS='-run TestAccCssCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/css -v -run TestAccCssCluster_basic -timeout 360m -parallel=4
=== RUN   TestAccCssCluster_basic
=== PAUSE TestAccCssCluster_basic
=== CONT  TestAccCssCluster_basic
--- PASS: TestAccCssCluster_basic (1671.11s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/css      1671.173s

make testacc TEST='./g42cloud/services/acceptance/css' TESTARGS='-run TestAccCssCluster_security'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/css -v -run TestAccCssCluster_security -timeout 360m -parallel=4
=== RUN   TestAccCssCluster_security
=== PAUSE TestAccCssCluster_security
=== CONT  TestAccCssCluster_security
--- PASS: TestAccCssCluster_security (879.17s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/css      879.238s

make testacc TEST='./g42cloud/services/acceptance/css' TESTARGS='-run TestAccCssSnapshot_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/css -v -run TestAccCssSnapshot_basic -timeout 360m -parallel=4
=== RUN   TestAccCssSnapshot_basic
=== PAUSE TestAccCssSnapshot_basic
=== CONT  TestAccCssSnapshot_basic
--- PASS: TestAccCssSnapshot_basic (924.74s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/css      924.874s

make testacc TEST='./g42cloud/services/acceptance/css' TESTARGS='-run TestAccCssThesaurus_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/css -v -run TestAccCssThesaurus_basic -timeout 360m -parallel=4
=== RUN   TestAccCssThesaurus_basic
=== PAUSE TestAccCssThesaurus_basic
=== CONT  TestAccCssThesaurus_basic
--- PASS: TestAccCssThesaurus_basic (935.08s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/css      935.193s
```