### PR TITLE
feat(dws): add new resource dws cluster

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -1,0 +1,175 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# g42cloud_dws_cluster
+
+Manages Cluster in the Data Warehouse Service.
+
+## Example Usage
+
+### Dws Cluster Example
+
+```hcl
+variable "availability_zone" {}
+variable "network_id" {}
+variable "vpc_id" {}
+variable "user_name" {}
+variable "user_pwd" {}
+variable "dws_cluster_name" {}
+
+resource "g42cloud_networking_secgroup" "secgroup" {
+  name        = "security_group_2"
+  description = "terraform security group"
+}
+
+resource "g42cloud_dws_cluster" "cluster" {
+  node_type         = "dws.m3.xlarge"
+  number_of_node    = 3
+  network_id        = var.network_id
+  vpc_id            = var.vpc_id
+  security_group_id = g42cloud_networking_secgroup.secgroup.id
+  availability_zone = var.availability_zone
+  name              = var.dws_cluster_name
+  user_name         = var.user_name
+  user_pwd          = var.user_pwd
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the cluster resource. If omitted, the
+  provider-level region will be used. Changing this creates a new cluster resource.
+
+* `name` - (Required, String, ForceNew) Cluster name, which must be unique and contains 4 to 64 characters, which
+  consist of letters, digits, hyphens(-), or underscores(_) only and must start with a letter.
+
+* `network_id` - (Required, String, ForceNew) Network ID, which is used for configuring cluster network.
+
+* `node_type` - (Required, String, ForceNew) Node type.
+
+* `number_of_node` - (Required, Int) Number of nodes in a cluster. The value ranges from 3 to 32. When expanding,
+  add at least 3 nodes.
+
+* `security_group_id` - (Required, String, ForceNew) ID of a security group. The ID is used for configuring cluster
+  network.
+
+* `user_name` - (Required, String, ForceNew) Administrator username for logging in to a data warehouse cluster The
+  administrator username must:  Consist of lowercase letters, digits, or underscores. Start with a lowercase letter or
+  an underscore. Contain 1 to 63 characters. Cannot be a keyword of the DWS database.
+
+* `vpc_id` - (Required, String, ForceNew) VPC ID, which is used for configuring cluster network.
+
+* `user_pwd` - (Required, String) Administrator password for logging in to a data warehouse cluster A password
+  must conform to the following rules:  Contains 8 to 32 characters. Cannot be the same as the username or the username
+  written in reverse order. Contains three types of the following:
+  Lowercase letters Uppercase letters Digits Special characters
+  ~!@#%^&*()-_=+|[{}];:,<.>/?
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the dws cluster,
+  Value 0 indicates the default enterprise project.
+  Changing this parameter will create a new resource.
+
+* `availability_zone` - (Optional, String, ForceNew) AZ in a cluster.
+
+* `port` - (Optional, Int) Service port of a cluster (8000 to 10000). The default value is 8000.
+
+* `public_ip` - (Optional, List, ForceNew) A nested object resource Structure is documented below.
+
+The `public_ip` block supports:
+
+* `eip_id` - (Optional, String, ForceNew) EIP ID.
+
+* `public_bind_type` - (Optional, String, ForceNew) Binding type of an EIP. The value can be either of the following:
+  auto_assign not_use bind_existing The default value is not_use.
+
+* `number_of_cn` - (Optional, int, ForceNew) Specifies the number of CN. If you use a large-scale cluster, deploy
+  multiple CNs.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the cluster.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `created` - Cluster creation time. The format is ISO8601:YYYY-MM-DDThh:mm:ssZ
+
+* `endpoints` - View the private network connection information about the cluster. Structure is documented below.
+
+* `id` - Cluster ID
+
+* `public_endpoints` - Public network connection information about the cluster. If the value is not specified, the
+  public network connection information is not used by default Structure is documented below.
+
+* `recent_event` - The recent event number.
+
+* `status` - Cluster status, which can be one of the following:  CREATING AVAILABLE UNAVAILABLE CREATION FAILED.
+
+* `sub_status` - Sub-status of clusters in the AVAILABLE state. The value can be one of the following:  NORMAL READONLY
+  REDISTRIBUTING REDISTRIBUTION-FAILURE UNBALANCED UNBALANCED | READONLY DEGRADED DEGRADED | READONLY DEGRADED |
+  UNBALANCED UNBALANCED | REDISTRIBUTING UNBALANCED | REDISTRIBUTION-FAILURE READONLY | REDISTRIBUTION-FAILURE
+  UNBALANCED | READONLY | REDISTRIBUTION-FAILURE DEGRADED | REDISTRIBUTION-FAILURE DEGRADED | UNBALANCED |
+  REDISTRIBUTION-FAILURE DEGRADED | UNBALANCED | READONLY | REDISTRIBUTION-FAILURE DEGRADED | UNBALANCED | READONLY
+
+* `task_status` - Cluster management task. The value can be one of the following:
+  RESTORING SNAPSHOTTING GROWING REBOOTING SETTING_CONFIGURATION CONFIGURING_EXT_DATASOURCE DELETING_EXT_DATASOURCE
+  REBOOT_FAILURE RESIZE_FAILURE
+
+* `updated` - Last modification time of a cluster. The format is ISO8601:YYYY-MM-DDThh:mm:ssZ
+
+* `version` - Data warehouse version.
+
+* `private_ip` - List of private network IP address.
+
+The `endpoints` block contains:
+
+* `connect_info` - (Optional, String) Private network connection information.
+
+* `jdbc_url` - (Optional, String)
+  JDBC URL. The following is the default format:
+  jdbc:postgresql://< connect_info>/<YOUR_DATABASE_NAME>
+
+The `public_endpoints` block contains:
+
+* `jdbc_url` - (Optional, String)
+  JDBC URL. The following is the default format:
+  jdbc:postgresql://< public_connect_info>/<YOUR_DATABASE_NAME>
+
+* `public_connect_info` - (Optional, String)
+  Public network connection information.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minute.
+* `update` - Default is 60 minute.
+* `delete` - Default is 60 minute.
+
+## Import
+
+Cluster can be imported using the following format:
+
+```
+$ terraform import g42cloud_dws_cluster.test 47ad727e-9dcc-4833-bde0-bb298607c719
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `user_pwd`, `number_of_cn`.
+It is generally recommended running `terraform plan` after importing a cluster.
+You can then decide if changes should be applied to the cluster, or the resource definition
+should be updated to align with the cluster. Also you can ignore changes as below.
+
+```
+resource "g42cloud_dws_cluster" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      user_pwd, number_of_cn,
+    ]
+  }
+}
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ecs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
@@ -226,6 +227,7 @@ func Provider() *schema.Provider {
 			"g42cloud_dns_ptrrecord":                   huaweicloud.ResourceDNSPtrRecordV2(),
 			"g42cloud_dns_recordset":                   huaweicloud.ResourceDNSRecordSetV2(),
 			"g42cloud_dns_zone":                        huaweicloud.ResourceDNSZoneV2(),
+			"g42cloud_dws_cluster":                     dws.ResourceDwsCluster(),
 			"g42cloud_enterprise_project":              eps.ResourceEnterpriseProject(),
 			"g42cloud_evs_snapshot":                    huaweicloud.ResourceEvsSnapshotV2(),
 			"g42cloud_evs_volume":                      evs.ResourceEvsVolume(),

--- a/g42cloud/services/acceptance/dws/resource_g42cloud_dws_cluster_test.go
+++ b/g42cloud/services/acceptance/dws/resource_g42cloud_dws_cluster_test.go
@@ -1,0 +1,103 @@
+package dws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/chnsz/golangsdk/openstack/dws/v1/cluster"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getDwsResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := config.DwsV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("error creating DWS v1 client, err=%s", err)
+	}
+	return cluster.Get(client, state.Primary.ID)
+}
+
+func TestAccResourceDWS_basic(t *testing.T) {
+	var clusterInstance cluster.CreateOpts
+	resourceName := "g42cloud_dws_cluster.test"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&clusterInstance,
+		getDwsResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsCluster_basic(name, 3, cluster.PublicBindTypeAuto, "cluster123@!"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "number_of_node", "3"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn"},
+			},
+		},
+	})
+}
+
+func testAccBaseResource(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  vpc_id     = g42cloud_vpc.test.id
+  gateway_ip = "192.168.0.1"
+}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name        = "%s"
+  description = "terraform security group acceptance test"
+}
+
+data "g42cloud_availability_zones" "test" {}
+`, rName, rName, rName)
+}
+
+func testAccDwsCluster_basic(rName string, numberOfNode int, publicIpBindType string, password string) string {
+	baseResource := testAccBaseResource(rName)
+
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_dws_cluster" "test" {
+  name              = "%s"
+  node_type         = "dws2.olap.4xlarge.i3"
+  number_of_node    = %d
+  vpc_id            = g42cloud_vpc.test.id
+  network_id        = g42cloud_vpc_subnet.test.id
+  security_group_id = g42cloud_networking_secgroup.test.id
+  availability_zone = data.g42cloud_availability_zones.test.names[1]
+  user_name         = "test_cluster_admin"
+  user_pwd          = "%s"
+
+  public_ip {
+    public_bind_type = "%s"
+  }
+}
+`, baseResource, rName, numberOfNode, password, publicIpBindType)
+}


### PR DESCRIPTION
add new resource dws cluster

Test result:
```
make testacc TEST='./g42cloud/services/acceptance/dws' TESTARGS='-run TestAccResourceDWS_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/dws -v -run TestAccResourceDWS_basic -timeout 360m -parallel=4
=== RUN   TestAccResourceDWS_basic
=== PAUSE TestAccResourceDWS_basic
=== CONT  TestAccResourceDWS_basic
--- PASS: TestAccResourceDWS_basic (1098.65s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/dws      1098.726s
```