### PR TITLE
fix(server_group): use v2 api as the GET func of v1 dose not exist

### DIFF
--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -240,7 +240,7 @@ func Provider() *schema.Provider {
 			"g42cloud_compute_instance":          ResourceComputeInstanceV2(),
 			"g42cloud_compute_interface_attach":  huaweicloud.ResourceComputeInterfaceAttachV2(),
 			"g42cloud_compute_keypair":           huaweicloud.ResourceComputeKeypairV2(),
-			"g42cloud_compute_servergroup":       huaweicloud.ResourceComputeServerGroupV2(),
+			"g42cloud_compute_servergroup":       ResourceComputeServerGroupV2(),
 			"g42cloud_compute_eip_associate":     huaweicloud.ResourceComputeFloatingIPAssociateV2(),
 			"g42cloud_compute_volume_attach":     ecs.ResourceComputeVolumeAttach(),
 			"g42cloud_css_cluster":               css.ResourceCssCluster(),

--- a/g42cloud/resource_g42cloud_compute_servergroup.go
+++ b/g42cloud/resource_g42cloud_compute_servergroup.go
@@ -1,0 +1,191 @@
+package g42cloud
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/compute/v2/extensions/servergroups"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func ResourceComputeServerGroupV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeServerGroupCreate,
+		Read:   resourceComputeServerGroupRead,
+		Update: resourceComputeServerGroupUpdate,
+		Delete: resourceComputeServerGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"members": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"fault_domains": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceComputeServerGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	computeClient, err := config.ComputeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating G42Cloud compute v2 client: %s", err)
+	}
+	ecsClient, err := config.ComputeV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating G42Cloud compute v1 client: %s", err)
+	}
+
+	createOpts := servergroups.CreateOpts{
+		Name:     d.Get("name").(string),
+		Policies: resourceServerGroupPolicies(d),
+	}
+
+	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	newSG, err := servergroups.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error creating ServerGroup: %s", err)
+	}
+
+	d.SetId(newSG.ID)
+
+	membersToAdd := d.Get("members").(*schema.Set)
+	for _, v := range membersToAdd.List() {
+		var addMemberOpts servergroups.MemberOpts
+		addMemberOpts.InstanceUUid = v.(string)
+		if err := servergroups.UpdateMember(ecsClient, addMemberOpts, "add_member", d.Id()).ExtractErr(); err != nil {
+			return fmtp.Errorf("Error to add an instance to ECS server group, err=%s", err)
+		}
+	}
+
+	return resourceComputeServerGroupRead(d, meta)
+}
+
+func resourceComputeServerGroupRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	computeClient, err := config.ComputeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating G42Cloud compute client: %s", err)
+	}
+
+	sg, err := servergroups.Get(computeClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "server group")
+	}
+
+	logp.Printf("[DEBUG] Retrieved ServerGroup %s: %+v", d.Id(), sg)
+
+	policies := make([]string, len(sg.Policies))
+	for i, p := range sg.Policies {
+		policies[i] = p
+	}
+	d.Set("policies", policies)
+	d.Set("name", sg.Name)
+	d.Set("members", sg.Members)
+	d.Set("fault_domains", sg.FaultDomain.Names)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}
+
+func resourceComputeServerGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	ecsClient, err := config.ComputeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating G42Cloud compute V1 client: %s", err)
+	}
+
+	if d.HasChange("members") {
+		oldMembers, newMembers := d.GetChange("members")
+		oldMemberSet, newMemberSet := oldMembers.(*schema.Set), newMembers.(*schema.Set)
+		membersToAdd := newMemberSet.Difference(oldMemberSet)
+		membersToRemove := oldMemberSet.Difference(newMemberSet)
+
+		for _, v := range membersToAdd.List() {
+			var addMemberOpts servergroups.MemberOpts
+			addMemberOpts.InstanceUUid = v.(string)
+			if err := servergroups.UpdateMember(ecsClient, addMemberOpts, "add_member", d.Id()).ExtractErr(); err != nil {
+				return fmtp.Errorf("Error to add a instance to ECS server group, err=%s", err)
+			}
+		}
+
+		for _, v := range membersToRemove.List() {
+			instanceID := v.(string)
+			server, err := cloudservers.Get(ecsClient, instanceID).Extract()
+			if err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					logp.Printf("[WARN] the compute %s is not exist, ignore to remove it from the group", instanceID)
+					continue
+				}
+				logp.Printf("[WARN] failed to retrieve compute %s: %s, try to remove it from the group", instanceID, err)
+			} else {
+				if server.Status == "DELETED" {
+					logp.Printf("[WARN] the compute %s was removed, ignore to remove it from the group", instanceID)
+					continue
+				}
+			}
+
+			var removeMemberOpts servergroups.MemberOpts
+			removeMemberOpts.InstanceUUid = instanceID
+			if err := servergroups.UpdateMember(ecsClient, removeMemberOpts, "remove_member", d.Id()).ExtractErr(); err != nil {
+				return fmtp.Errorf("Error to remove a instance from ECS server group, err=%s", err)
+			}
+		}
+	}
+
+	return resourceComputeServerGroupRead(d, meta)
+}
+
+func resourceComputeServerGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	computeClient, err := config.ComputeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating G42Cloud compute client: %s", err)
+	}
+
+	logp.Printf("[DEBUG] Deleting ServerGroup %s", d.Id())
+	if err := servergroups.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
+		return fmtp.Errorf("Error deleting ServerGroup: %s", err)
+	}
+
+	return nil
+}
+
+func resourceServerGroupPolicies(d *schema.ResourceData) []string {
+	rawPolicies := d.Get("policies").([]interface{})
+	policies := make([]string, len(rawPolicies))
+	for i, raw := range rawPolicies {
+		policies[i] = raw.(string)
+	}
+	return policies
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

use v2 api as the GET func of v1 dose not exist

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
use v2 api as the GET func of v1 dose not exist
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccComputeServerGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccComputeServerGroup_basic -timeout 360m -parallel=4
=== RUN   TestAccComputeServerGroup_basic
=== PAUSE TestAccComputeServerGroup_basic
=== CONT  TestAccComputeServerGroup_basic
--- PASS: TestAccComputeServerGroup_basic (19.05s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      19.137s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccComputeServerGroup_scheduler'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccComputeServerGroup_scheduler -timeout 360m -parallel=4
=== RUN   TestAccComputeServerGroup_scheduler
=== PAUSE TestAccComputeServerGroup_scheduler
=== CONT  TestAccComputeServerGroup_scheduler
--- PASS: TestAccComputeServerGroup_scheduler (156.98s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      157.064s

make testacc TEST='./g42cloud' TESTARGS='-run TestAccComputeServerGroup_members'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccComputeServerGroup_members -timeout 360m -parallel=4
=== RUN   TestAccComputeServerGroup_members
=== PAUSE TestAccComputeServerGroup_members
=== CONT  TestAccComputeServerGroup_members
--- PASS: TestAccComputeServerGroup_members (154.69s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      154.773s
```
