### PR TITLE
feat(ecs): use v1 api to reset the password

### DIFF
--- a/g42cloud/resource_g42cloud_compute_instance.go
+++ b/g42cloud/resource_g42cloud_compute_instance.go
@@ -1056,7 +1056,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 
 	if d.HasChange("admin_pass") {
 		if newPwd, ok := d.Get("admin_pass").(string); ok {
-			err := servers.ChangeAdminPassword(computeClient, d.Id(), newPwd).ExtractErr()
+			err := cloudservers.ChangeAdminPassword(ecsClient, d.Id(), newPwd).ExtractErr()
 			if err != nil {
 				return diag.Errorf("error changing admin password of server (%s): %s", d.Id(), err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/g42cloud-terraform/terraform-provider-g42cloud
 go 1.12
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20220816121712-c2c3003e9e4d
+	github.com/chnsz/golangsdk v0.0.0-20220826060937-d49168741ce0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.102

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,9 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220816121712-c2c3003e9e4d h1:kwcXHIQP7ebq/AmYjYr83Ee0Z67/qvrd8wesBhjIinA=
 github.com/chnsz/golangsdk v0.0.0-20220816121712-c2c3003e9e4d/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220826060937-d49168741ce0 h1:ca2Lkp9MUxCGZHpmmRhBONU7jutrHggRhJTF2qV75ho=
+github.com/chnsz/golangsdk v0.0.0-20220826060937-d49168741ce0/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

use v1 api to reset the password

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
use v1 api to reset the password
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./g42cloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud       70.796s
```
