### PR TITLE
feat(waf): add waf resources

### DIFF
--- a/docs/data-sources/waf_certificate.md
+++ b/docs/data-sources/waf_certificate.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_certificate
+
+Get the certificate in the WAF, including the one pushed from SCM.
+
+## Example Usage
+
+```hcl
+data "g42cloud_waf_certificate" "certificate_1" {
+  name = "certificate name"
+}
+
+resource "g42cloud_waf_domain" "domain_1" {
+  domain           = "www.domainname.com"
+  certificate_id   = data.g42cloud_waf_certificate.certificate_1.id
+  certificate_name = data.g42cloud_waf_certificate.certificate_1.name
+  keep_policy      = false
+  proxy            = false
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "192.168.10.1"
+    port            = 8080
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the WAF. If omitted, the provider-level region will be
+  used.
+
+* `name` - (Required, String) The name of certificate. The value is case sensitive and supports fuzzy matching.
+
+  -> **NOTE:** The certificate name is not unique. Only returns the last created one when matched multiple certificates.
+
+* `expire_status` - (Optional, Int) The expire status of certificate. Defaults is `0`. The value can be:
+  + `0`: not expire
+  + `1`: has expired
+  + `2`: wil expired soon
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The certificate ID in UUID format.
+
+* `expiration` - Indicates the time when the certificate expires.

--- a/docs/data-sources/waf_dedicated_instances.md
+++ b/docs/data-sources/waf_dedicated_instances.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_dedicated_instances
+
+Use this data source to get a list of WAF dedicated instances.
+
+## Example Usage
+
+```hcl
+variable instance_name {}
+
+data "g42cloud_waf_dedicated_instances" "instances" {
+  name = var.instance_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the WAF dedicated instance.
+  If omitted, the provider-level region will be used.
+
+* `id` - (Optional, String) The id of WAF dedicated instance.
+
+* `name` - (Optional, String) The name of WAF dedicated instance.
+
+## Attributes Reference
+
+* `id` - The data source ID in UUID format.
+
+The following attributes are exported:
+
+The `instances` block supports:
+
+* `id` - The id of WAF dedicated instance.
+
+* `name` - The name of WAF dedicated instance.
+
+* `available_zone` - The available zone names for the WAF dedicated instances.
+
+* `specification_code` - The specification code of instance.
+  Different specifications have different throughput. Values are:
+  + `waf.instance.professional` - The professional edition, throughput: 100 Mbit/s; QPS: 2,000 (Reference only).
+  +`waf.instance.enterprise` - The enterprise edition, throughput: 500 Mbit/s; QPS: 10,000 (Reference only).
+
+* `cpu_architecture` - The ECS cpu architecture of WAF dedicated instance.
+
+* `ecs_flavor` - The flavor of the ECS used by the WAF instance.
+
+* `vpc_id` - The VPC id of WAF dedicated instance.
+
+* `subnet_id` - The subnet id of WAF dedicated instance VPC.
+
+* `security_group` - The security group of the instance. This is an array of security group ids.
+
+* `server_id` - The service of the instance.
+
+* `service_ip` - The service ip of the instance.
+
+* `run_status` - The running status of the instance. Values are:
+  + `0` - Instance is creating.
+  + `1` - Instance has created.
+  + `2` - Instance is deleting.
+  + `3` - Instance has deleted.
+  + `4` - Instance create failed.
+
+* `access_status` - The access status of the instance. `0`: inaccessible, `1`: accessible.
+
+* `upgradable` - The instance is to support upgrades. `0`: Cannot be upgraded, `1`: Can be upgraded.
+
+* `group_id` - The instance group ID used by the WAF dedicated instance in ELB mode.

--- a/docs/data-sources/waf_policies.md
+++ b/docs/data-sources/waf_policies.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_policies
+
+Use this data source to get a list of WAF policies.
+
+## Example Usage
+
+```hcl
+variable "policy_name" {}
+data "g42cloud_waf_policies" "policies" {
+  name = var.policy_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the WAF policies. If omitted, the provider-level region
+  will be used.
+
+* `name` - (Optional, String) Policy name used for matching. The value is case sensitive and supports fuzzy matching.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `policies` - A list of WAF policies.
+
+The `policies` block supports:
+
+* `id` - The WAF Policy ID.
+
+* `name` - The WAF policy name.
+
+* `protection_mode` - Specifies the protective action after a rule is matched. Valid values are:
+  + `block`: WAF blocks and logs detected attacks.
+  + `log`: WAF logs detected attacks only.
+
+* `level` - Specifies the protection level. Valid values are:
+  + `1`: low
+  + `2`: medium
+  + `3`: high
+
+* `full_detection` - The detection mode in Precise Protection.
+  + `true`: full detection. Full detection finishes all threat detections before blocking requests that meet Precise
+    Protection specified conditions.
+  + `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that
+    meets Precise Protection specified conditions.
+
+* `options` - The protection switches. The options object structure is documented below.
+
+The `options` block supports:
+
+* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
+
+* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
+
+* `crawler` - Indicates whether the master crawler detection switch in Basic Web Protection is enabled.
+
+* `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
+
+* `crawler_scanner` - Indicates whether the Scanner switch in Basic Web Protection is enabled.
+
+* `crawler_script` - Indicates whether the Script Tool switch in Basic Web Protection is enabled.
+
+* `crawler_other` - Indicates whether detection of other crawlers in Basic Web Protection is enabled.
+
+* `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
+
+* `cc_attack_protection` - Indicates whether CC Attack Protection is enabled.
+
+* `precise_protection` - Indicates whether Precise Protection is enabled.
+
+* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
+
+* `data_masking` - Indicates whether Data Masking is enabled.
+
+* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
+
+* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.

--- a/docs/data-sources/waf_reference_tables.md
+++ b/docs/data-sources/waf_reference_tables.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_reference_tables
+
+Use this data source to get a list of WAF reference tables.
+
+## Example Usage
+
+```hcl
+data "g42cloud_waf_reference_tables" "reftables" {
+  name = "reference_table_name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to create the WAF reference table resource.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) The name of the reference table. The value is case sensitive and matches exactly.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `tables` - A list of WAF reference tables.
+
+The `tables` block supports:
+
+* `id` - The id of the reference table.
+
+* `name` - The name of the reference table. The maximum length is 64 characters.
+
+* `type` - The type of the reference table, The options are: `url`, `user-agent`, `ip`, `params`, `cookie`, `referer`
+  and `header`.
+
+* `conditions` - The conditions of the reference table.
+
+* `description` - The description of the reference table.
+
+* `creation_time` - The server time when reference table was created.

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -173,8 +173,6 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the RDS instance. Changing this
   parameter creates a new RDS instance.
 
-* `ssl_enable` - (Optional, Bool) Specifies whether to enable the SSL for MySQL database.
-
 * `tags` - (Optional, Map) A mapping of tags to assign to the RDS instance. Each tag is represented by one key-value
   pair.
 

--- a/docs/resources/waf_certificate.md
+++ b/docs/resources/waf_certificate.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_certificate
+
+Manages a WAF certificate resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The certificate resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_waf_certificate" "certificate_1" {
+  name        = "cert_1"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIFmQl5dh2QUAeo39TIKtadgAgh4zHx09kSgayS9Wph9LEqq7MA+2042L3J9aOa
+DAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUR+SosWwALt6PkP0J9iOIxA6RW8gVsLwq
+...
++HhDvD/VeOHytX3RAs2GeTOtxyAV5XpKY5r+PkyUqPJj04t3d0Fopi0gNtLpMF=
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIJwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAM
+ATAwMC4GCCsGAQUFBwIBFiJodHRwOi8vY3BzLnJvb3QteDEubGV0c2VuY3J5cHQu
+...
+he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
+1qoJFlcDyqSMo5iHq3HLjs
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF certificate resource. If omitted, the
+  provider-level region will be used. Changing this setting will push a new certificate.
+
+* `name` - (Required, String, ForceNew) Specifies the certificate name. The maximum length is 256 characters. Only digits,
+  letters, underscores(`_`), and hyphens(`-`) are allowed. Changing this setting will push a new certificate.
+
+* `certificate` - (Required, String, ForceNew) Specifies the certificate content. Changing this creates a new
+  certificate.
+
+* `private_key` - (Required, String, ForceNew) Specifies the private key. Changing this creates a new certificate.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The certificate ID in UUID format.
+
+* `expiration` - Indicates the time when the certificate expires.
+
+## Import
+
+Certificates can be imported using the `id`, e.g.
+
+```sh
+terraform import g42cloud_waf_certificate.certificate_2 3ebd3201238d41f9bfc3623b61435954
+```
+
+Note that the imported state is not identical to your resource definition, due to security reason. The missing
+attributes include `certificate`, and `private_key`. You can ignore changes as below.
+
+```
+resource "g42cloud_waf_certificate" "certificate_2" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      certificate, private_key
+    ]
+  }
+}
+```

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -1,0 +1,121 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_dedicated_domain
+
+Manages a dedicated mode domain resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The dedicated mode domain name resource can be used in Dedicated Mode and ELB Mode.
+
+## Example Usage
+
+```hcl
+variable certificated_id {}
+variable vpc_id {}
+variable dedicated_engine_id {}
+
+resource "g42cloud_waf_dedicated_domain" "domain_1" {
+  domain         = "www.example.com"
+  certificate_id = g42cloud_waf_certificate.certificate_1.id
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "192.168.1.100"
+    port            = 8080
+    type            = "ipv4"
+    vpc_id          = var.vpc_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the dedicated mode domain resource. If omitted,
+  the provider-level region will be used. Changing this setting will push a new domain.
+
+* `domain` - (Required, String, ForceNew) Specifies the domain name to be protected. For example, www.example.com or
+  *.example.com. Changing this creates a new domain.
+
+* `server` - (Required, List, ForceNew) The server configuration list of the domain. A maximum of 80 can be configured.
+  The object structure is documented below.
+
+* `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
+  is set to HTTPS.
+
+* `policy_id` - (Optional, String) Specifies the policy ID associated with the domain. If not specified, a new policy
+  will be created automatically.
+
+* `proxy` - (Optional, Bool) Specifies whether a proxy is configured. Default value is `false`.
+
+  -> **NOTE:** WAF forwards only HTTP/S traffic. So WAF cannot serve your non-HTTP/S traffic, such as UDP, SMTP, FTP,
+  and basically all other non-HTTP/S traffic. If a proxy such as public network ELB (or Nginx) has been used, set
+  proxy `true` to ensure that the WAF security policy takes effect for the real source IP address.
+
+* `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
+  Defaults to `true`.
+
+* `protect_status` - (Optional, Int) The protection status of domain, `0`: suspended, `1`: enabled.
+  Default value is `1`.
+
+The `server` block supports:
+
+* `client_protocol` - (Required, String, ForceNew) Protocol type of the client. The options include `HTTP` and `HTTPS`.
+  Changing this creates a new service.
+
+* `server_protocol` - (Required, String, ForceNew) Protocol used by WAF to forward client requests to the server. The
+  options include `HTTP` and `HTTPS`. Changing this creates a new service.
+
+* `vpc_id` - (Required, String, ForceNew) The id of the vpc used by the server. Changing this creates a service.
+
+* `type` - (Required, String, ForceNew) Server network type, IPv4 or IPv6. Valid values are: `ipv4` and `ipv6`. Changing
+  this creates a new service.
+
+* `address` - (Required, String, ForceNew) IP address or domain name of the web server that the client accesses. For
+  example, 192.168.1.1 or www.example.com. Changing this creates a new service.
+
+* `port` - (Required, Int, ForceNew) Port number used by the web server. The value ranges from 0 to 65535. Changing this
+  creates a new service.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID of the domain.
+
+* `certificate_name` - The name of the certificate used by the domain name.
+
+* `access_status` - Whether a domain name is connected to WAF. Valid values are:
+  + `0` - The domain name is not connected to WAF,
+  + `1` - The domain name is connected to WAF.
+
+* `protocol` - The protocol type of the client. The options are `HTTP` and `HTTPS`.
+
+* `tls` - The TLS configuration of domain.
+
+* `cihper` - The cipher suite of domain.
+
+* `compliance_certification` - The compliance certifications of the domain, values are:
+  + `pci_dss` - The status of domain PCI DSS, `true`: enabled, `false`: disabled.
+  + `pci_3ds` - The status of domain PCI 3DS, `true`: enabled, `false`: disabled.
+
+* `alarm_page` - The alarm page of domain. Valid values are:
+  + `template_name` - The template of alarm page, values are: `default`, `custom` and `redirection`.
+  + `redirect_url` - The redirection URL when `template_name` is set to `redirection`.
+
+* `traffic_identifier` - The traffic identifier of domain. Valid values are:
+  + `ip_tag` - The IP tag of traffic identifier.
+  + `session_tag` - The session tag of traffic identifier.
+  + `user_tag` - The user tag of traffic identifier.
+
+## Import
+
+Dedicated mode domain can be imported using the `id`, e.g.
+
+```sh
+terraform import g42cloud_waf_dedicated_domain.domain_1 69e9a86becb4424298cc6bdeacbf69d5
+```

--- a/docs/resources/waf_dedicated_instance.md
+++ b/docs/resources/waf_dedicated_instance.md
@@ -1,0 +1,105 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_dedicated_instance
+
+Manages a WAF dedicated instance resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable az_name {}
+variable ecs_flavor_id {}
+variable vpc_id {}
+variable subnet_id {}
+variable security_group_id {}
+
+resource "g42cloud_waf_dedicated_instance" "instance_1" {
+  name               = "instance_1"
+  available_zone     = var.az_name
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = var.ecs_flavor_id
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+
+  security_group = [
+    var.security_group_id
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF dedicated instance. If omitted, the
+  provider-level region will be used. Changing this setting will create a new instance.
+
+* `name` - (Required, String) The name of WAF dedicated instance. Duplicate names are allowed, we suggest to keeping the
+  name unique.
+
+* `available_zone` - (Required, String, ForceNew) The available zone names for the dedicated instances. It can be
+  obtained through this data source `g42cloud_availability_zones`. Changing this will create a new instance.
+
+* `specification_code` - (Required, String, ForceNew) The specification code of instance. Different specifications have
+  different throughput. Changing this will create a new instance. Values are:
+  + `waf.instance.professional` - The professional edition, throughput: 100 Mbit/s; QPS: 2,000 (Reference only).
+  + `waf.instance.enterprise` - The enterprise edition, throughput: 500 Mbit/s; QPS: 10,000 (Reference only).
+
+* `ecs_flavor` - (Required, String, ForceNew) The flavor of the ECS used by the WAF instance. Flavors can be obtained
+  through this data source `g42cloud_compute_flavors`. Changing this will create a new instance.
+
+  -> **NOTE:** If the instance specification is the professional edition, the ECS specification should be 2U4G. If the
+  instance specification is the enterprise edition, the ECS specification should be 8U16G.
+
+* `vpc_id` - (Required, String, ForceNew) The VPC id of WAF dedicated instance. Changing this will create a new
+  instance.
+
+* `subnet_id` - (Required, String, ForceNew) The subnet id of WAF dedicated instance VPC. Changing this will create a
+  new instance.
+
+* `security_group` - (Required, List, ForceNew) The security group of the instance. This is an array of security group
+  ids. Changing this will create a new instance.
+
+* `cpu_architecture` - (Optional, String, ForceNew) The ECS cpu architecture of instance, Default value is `x86`.
+  Changing this will create a new instance.
+
+* `group_id` - (Optional, String, ForceNew) The instance group ID used by the WAF dedicated instance in ELB mode.
+  Changing this will create a new instance.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The id of the instance.
+
+* `server_id` - The id of the instance server.
+
+* `service_ip` - The ip of the instance service.
+
+* `run_status` - The running status of the instance. Values are:
+  + `0` - Instance is creating.
+  + `1` - Instance has created.
+  + `2` - Instance is deleting.
+  + `3` - Instance has deleted.
+  + `4` - Instance create failed.
+
+* `access_status` - The access status of the instance. `0`: inaccessible, `1`: accessible.
+
+* `upgradable` - The instance is to support upgrades. `0`: Cannot be upgraded, `1`: Can be upgraded.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minute.
+* `delete` - Default is 20 minute.
+
+## Import
+
+WAF dedicated instance can be imported using the `id`, e.g.
+
+```sh
+terraform import g42cloud_waf_dedicated_instance.instance_1 2f87641090206b821f07e0f6bd6
+```

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -1,0 +1,108 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_domain
+
+Manages a WAF domain resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The domain name resource can be used in Cloud Mode.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_waf_certificate" "certificate_1" {
+  name        = "cert_1"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIFmQl5dh2QUAeo39TIKtadgAgh4zHx09kSgayS9Wph9LEqq7MA+2042L3J9aOa
+DAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUR+SosWwALt6PkP0J9iOIxA6RW8gVsLwq
+...
++HhDvD/VeOHytX3RAs2GeTOtxyAV5XpKY5r+PkyUqPJj04t3d0Fopi0gNtLpMF=
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIJwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAM
+ATAwMC4GCCsGAQUFBwIBFiJodHRwOi8vY3BzLnJvb3QteDEubGV0c2VuY3J5cHQu
+...
+he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
+1qoJFlcDyqSMo5iHq3HLjs
+-----END PRIVATE KEY-----
+EOT
+}
+
+resource "g42cloud_waf_domain" "domain_1" {
+  domain           = "www.example.com"
+  certificate_id   = g42cloud_waf_certificate.certificate_1.id
+  certificate_name = g42cloud_waf_certificate.certificate_1.name
+  proxy            = true
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.13"
+    port            = "8080"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF domain resource. If omitted, the
+  provider-level region will be used. Changing this setting will push a new certificate.
+
+* `domain` - (Required, String, ForceNew) Specifies the domain name to be protected. For example, www.example.com or
+  *.example.com. Changing this creates a new domain.
+
+* `server` - (Required, List) Specifies an array of origin web servers. The object structure is documented below.
+
+* `certificate_id` - (Required, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
+  is set to HTTPS.
+
+* `certificate_name` - (Required, String) Specifies the certificate name. This parameter is mandatory
+  when `client_protocol` is set to HTTPS.
+
+* `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain. If not specified, a new
+  policy will be created automatically. Changing this create a new domain.
+
+* `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
+  Defaults to true.
+
+* `proxy` - (Optional, Bool) Specifies whether a proxy is configured.
+
+The `server` block supports:
+
+* `client_protocol` - (Required, String) Protocol type of the client. The options include `HTTP` and `HTTPS`.
+
+* `server_protocol` - (Required, String) Protocol used by WAF to forward client requests to the server. The options
+  include `HTTP` and `HTTPS`.
+
+* `address` - (Required, String) IP address or domain name of the web server that the client accesses. For example,
+  192.168.1.1 or www.a.com.
+
+* `port` - (Required, Int) Port number used by the web server. The value ranges from 0 to 65535, for example, 8080.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID of the domain.
+
+* `protect_status` - The WAF mode. -1: bypassed, 0: disabled, 1: enabled.
+
+* `access_status` - Whether a domain name is connected to WAF. 0: The domain name is not connected to WAF, 1: The domain
+  name is connected to WAF.
+
+* `protocol` - The protocol type of the client. The options are HTTP, HTTPS, and HTTP&HTTPS.
+
+## Import
+
+Domains can be imported using the `id`, e.g.
+
+```sh
+terraform import g42cloud_waf_domain.domain_2 7902bd9e01104cb794dcb668f235e0c5
+```

--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_policy
+
+Manages a WAF policy resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The policy resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_waf_policy" "policy_1" {
+  name            = "policy_1"
+  protection_mode = "log"
+  level           = 2
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF policy resource. If omitted, the
+  provider-level region will be used. Changing this setting will push a new certificate.
+
+* `name` - (Required, String) Specifies the policy name. The maximum length is 256 characters. Only digits, letters,
+  underscores(_), and hyphens(-) are allowed.
+
+* `protection_mode` - (Optional, String) Specifies the protective action after a rule is matched. Defaults to `log`.
+  Valid values are:
+  + `block`: WAF blocks and logs detected attacks.
+  + `log`: WAF logs detected attacks only.
+
+* `level` - (Optional, Int) Specifies the protection level. Defaults to `2`. Valid values are:
+  + `1`: low
+  + `2`: medium
+  + `3`: high
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The policy ID in UUID format.
+
+* `full_detection` - The detection mode in Precise Protection.
+  + `true`: full detection, Full detection finishes all threat detections before blocking requests that meet Precise
+      Protection specified conditions.
+  + `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that
+      meets Precise Protection specified conditions.
+
+* `options` - The protection switches. The options object structure is documented below.
+
+The `options` block supports:
+
+* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
+
+* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
+
+* `crawler` - Indicates whether the master crawler detection switch in Basic Web Protection is enabled.
+
+* `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
+
+* `crawler_scanner` - Indicates whether the Scanner switch in Basic Web Protection is enabled.
+
+* `crawler_script` - Indicates whether the Script Tool switch in Basic Web Protection is enabled.
+
+* `crawler_other` - Indicates whether detection of other crawlers in Basic Web Protection is enabled.
+
+* `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
+
+* `cc_attack_protection` - Indicates whether CC Attack Protection is enabled.
+
+* `precise_protection` - Indicates whether Precise Protection is enabled.
+
+* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
+
+* `data_masking` - Indicates whether Data Masking is enabled.
+
+* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
+
+* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.
+
+## Import
+
+Policies can be imported using the `id`, e.g.
+
+```sh
+terraform import g42cloud_waf_policy.policy_2 25e1df831bea4022a6e22bebe678915a
+```

--- a/docs/resources/waf_reference_table.md
+++ b/docs/resources/waf_reference_table.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_reference_table
+
+Manages a WAF reference table resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The reference table resource can be used in Cloud Mode (professional version), Dedicated Mode and ELB Mode.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_waf_reference_table" "ref_table" {
+  name = "tf_ref_table_demo"
+  type = "url"
+
+  conditions = [
+    "/admin",
+    "/manage"
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF reference table resource. If omitted,
+  the provider-level region will be used. Changing this setting will push a new reference table.
+
+* `name` - (Required, String) The name of the reference table. Only letters, digits, and underscores(_) are allowed. The
+  maximum length is 64 characters.
+
+* `type` - (Required, String, ForceNew) The type of the reference table, The options are `url`, `user-agent`, `ip`,
+  `params`, `cookie`, `referer` and `header`. Changing this setting will push a new reference table.
+
+* `conditions` - (Required, List) The conditions of the reference table. The maximum length is 30. The maximum length of
+  condition is 2048 characters.
+
+* `description` - (Optional, String) The description of the reference table. The maximum length is 128 characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The id of the reference table.
+
+* `creation_time` - The server time when reference table was created.
+
+## Import
+
+The reference table can be imported using the `id`, e.g.
+
+```sh
+terraform import g42cloud_waf_reference_table.ref_table 96e46e5e702b4e2aa5609ad287de4788
+```

--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_rule_blacklist
+
+Manages a WAF blacklist and whitelist rule resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The blacklist and whitelist rule resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "g42cloud_waf_rule_blacklist" "rule_1" {
+  policy_id  = g42cloud_waf_policy.policy_1.id
+  ip_address = "192.168.0.0/24"
+  action     = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF blacklist and whitelist rule resource.
+  If omitted, the provider-level region will be used. Changing this setting will push a new certificate.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule. Please make
+  sure that the region which the policy belongs to be consistent with the `region`.
+
+* `ip_address` - (Required, String) Specifies the IP address or range. For example, 192.168.0.125 or 192.168.0.0/24.
+
+* `action` - (Optional, Int) Specifies the protective action. Defaults is `0`. The value can be:
+  + `0`: block the request.
+  + `1`: allow the request.
+  + `2`: log the request only.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Blacklist and Whiltelist Rules can be imported using the policy ID and rule ID separated by a slash, e.g.:
+
+```sh
+terraform import g42cloud_waf_rule_blacklist.rule_1 d78b439fd5e54ea08886e5f63ee7b3f5/ac01a092d50e4e6ba3cd622c1128ba2c
+```

--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_rule_data_masking
+
+Manages a WAF Data Masking Rule resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The data masking rule resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "g42cloud_waf_rule_data_masking" "rule_1" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "params"
+  subfield  = "password"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF Data Masking rule resource. If omitted,
+  the provider-level region will be used. Changing this setting will create a new rule.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `path` - (Required, String) Specifies the URL to which the data masking rule applies (exact match by default).
+
+* `field` - (Required, String) The position where the masked field stored. Valid values are:
+  + `params`: The field in the parameter.
+  + `header`: The field in the header.
+  + `form`: The field in the form.
+  + `cookie`: The field in the cookie.
+
+* `subfield` - (Required, String) Specifies the name of the masked field, e.g.: password.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Data Masking Rules can be imported using the policy ID and rule ID separated by a slash, e.g.:
+
+```sh
+terraform import g42cloud_waf_rule_data_masking.rule_1 d78b439fd5e54ea08886e5f63ee7b3f5/ac01a092d50e4e6ba3cd622c1128ba2c
+```

--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# g42cloud_waf_rule_web_tamper_protection
+
+Manages a WAF web tamper protection rule resource within G42Cloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The web tamper protection rule resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "g42cloud_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  domain    = "www.your-domain.com"
+  path      = "/payment"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF web tamper protection rules resource. If
+  omitted, the provider-level region will be used. Changing this creates a new rule.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `domain` - (Required, String, ForceNew) Specifies the domain name. Changing this creates a new rule.
+
+* `path` - (Required, String, ForceNew) Specifies the URL protected by the web tamper protection rule, excluding a
+  domain name. Changing this creates a new rule.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Web Tamper Protection Rules can be imported using the policy ID and rule ID separated by a slash, e.g.:
+
+```sh
+terraform import g42cloud_waf_rule_web_tamper_protection.rule_1 840c6dfdd5604c1781eea033eae2004f/c6dbc13bb7e74788ae53ecc9254b3ea8
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -45,10 +45,15 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/tms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpcep"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
 )
 
 // This is a global MutexKV for use within this plugin.
 var osMutexKV = mutexkv.NewMutexKV()
+
+func init() {
+	waf.PaidType = "postPaid"
+}
 
 // Provider returns a schema.Provider for G42Cloud.
 func Provider() *schema.Provider {
@@ -217,6 +222,11 @@ func Provider() *schema.Provider {
 			"g42cloud_vpc_route":             vpc.DataSourceVpcRouteV2(),
 			"g42cloud_vpc_route_table":       vpc.DataSourceVPCRouteTable(),
 			"g42cloud_vpcep_public_services": vpcep.DataSourceVPCEPPublicServices(),
+
+			"g42cloud_waf_certificate":         waf.DataSourceWafCertificateV1(),
+			"g42cloud_waf_policies":            waf.DataSourceWafPoliciesV1(),
+			"g42cloud_waf_dedicated_instances": waf.DataSourceWafDedicatedInstancesV1(),
+			"g42cloud_waf_reference_tables":    waf.DataSourceWafReferenceTablesV1(),
 			// Legacy
 			"g42cloud_identity_role_v3": iam.DataSourceIdentityRoleV3(),
 		},
@@ -349,6 +359,15 @@ func Provider() *schema.Provider {
 			"g42cloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"g42cloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"g42cloud_vpc_subnet":                      vpc.ResourceVpcSubnetV1(),
+			"g42cloud_waf_certificate":                 waf.ResourceWafCertificateV1(),
+			"g42cloud_waf_domain":                      waf.ResourceWafDomainV1(),
+			"g42cloud_waf_policy":                      waf.ResourceWafPolicyV1(),
+			"g42cloud_waf_rule_blacklist":              waf.ResourceWafRuleBlackListV1(),
+			"g42cloud_waf_rule_data_masking":           waf.ResourceWafRuleDataMaskingV1(),
+			"g42cloud_waf_rule_web_tamper_protection":  waf.ResourceWafRuleWebTamperProtectionV1(),
+			"g42cloud_waf_dedicated_instance":          waf.ResourceWafDedicatedInstance(),
+			"g42cloud_waf_dedicated_domain":            waf.ResourceWafDedicatedDomainV1(),
+			"g42cloud_waf_reference_table":             waf.ResourceWafReferenceTableV1(),
 			"g42cloud_networking_eip_associate":        eip.ResourceEIPAssociate(),
 			"g42cloud_networking_secgroup":             huaweicloud.ResourceNetworkingSecGroup(),
 			"g42cloud_networking_secgroup_rule":        huaweicloud.ResourceNetworkingSecGroupRule(),

--- a/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_certificate_test.go
+++ b/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_certificate_test.go
@@ -1,0 +1,62 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccDataSourceWafCertificateV1_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_waf_certificate.cert_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafCertificateListV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafCertDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWafCertDataSourceID(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmtp.Errorf("Can't find waf data source: %s ", r)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("The Waf Certificate data source ID not set ")
+		}
+		return nil
+	}
+}
+
+func testAccWafCertificateListV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_waf_certificate" "cert_1" {
+  name = g42cloud_waf_certificate.certificate_1.name
+
+  depends_on = [
+    g42cloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf(name))
+}

--- a/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_dedicated_instances_test.go
+++ b/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_dedicated_instances_test.go
@@ -1,0 +1,74 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDataSourceWafDedicatedInstances_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	resourceName1 := "data.g42cloud_waf_dedicated_instances.instance_1"
+	resourceName2 := "data.g42cloud_waf_dedicated_instances.instance_2"
+
+	dc := acceptance.InitDataSourceCheck(resourceName1)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedInstances_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName1, "name", name),
+					resource.TestCheckResourceAttr(resourceName1, "instances.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.available_zone"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.cpu_flavor"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.cpu_architecture"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.security_group.#"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.server_id"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.service_ip"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.run_status"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.access_status"),
+					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.upgradable"),
+
+					resource.TestCheckResourceAttr(resourceName2, "instances.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName2, "name"),
+					resource.TestCheckResourceAttrSet(resourceName2, "instances.0.available_zone"),
+				),
+			},
+		},
+	})
+}
+
+func testAccWafDedicatedInstances_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_waf_dedicated_instances" "instance_1" {
+  name = g42cloud_waf_dedicated_instance.instance_1.name
+
+  depends_on = [
+    g42cloud_waf_dedicated_instance.instance_1
+  ]
+}
+
+data "g42cloud_waf_dedicated_instances" "instance_2" {
+  id   = g42cloud_waf_dedicated_instance.instance_1.id
+  name = g42cloud_waf_dedicated_instance.instance_1.name
+
+  depends_on = [
+    g42cloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstanceV1_conf(name))
+}

--- a/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_policies_test.go
+++ b/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_policies_test.go
@@ -1,0 +1,63 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccDataSourceWafPoliciesV1_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_waf_policies.policies_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafPoliciesV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPoliciesID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "policies.0.name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.options.0.blacklist"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWafPoliciesID(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmtp.Errorf("Can't find WAF policies data source: %s.", r)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("The WAF policies data source ID does not set.")
+		}
+		return nil
+	}
+}
+
+func testAccWafPoliciesV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_waf_policies" "policies_1" {
+  name = g42cloud_waf_policy.policy_1.name
+
+  depends_on = [
+    g42cloud_waf_policy.policy_1
+  ]
+}
+`, testAccWafPolicyV1_basic(name))
+}

--- a/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_reference_table_test.go
+++ b/g42cloud/services/acceptance/waf/data_source_g42cloud_waf_reference_table_test.go
@@ -1,0 +1,58 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccDataSourceReferenceTablesV1_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_waf_reference_tables.ref_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReferenceTablesV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReferenceTablesId(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.conditions.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckReferenceTablesId(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmtp.Errorf("Can't find WAF reference tables data source: %s.", r)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("The WAF reference tables data source ID not set.")
+		}
+		return nil
+	}
+}
+
+func testAccReferenceTablesV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_waf_reference_tables" "ref_table" {
+  depends_on = [g42cloud_waf_reference_table.ref_table]
+}
+`, testAccWafReferenceTableV1_conf(name))
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_certificate_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_certificate_test.go
@@ -1,0 +1,125 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.WafV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating G42cloud WAF client: %s", err)
+	}
+	return certificates.Get(client, state.Primary.ID).Extract()
+}
+
+func TestAccWafCertificateV1_basic(t *testing.T) {
+	var certificate certificates.Certificate
+	resourceName := "g42cloud_waf_certificate.certificate_1"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&certificate,
+		getResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafCertificateV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate", "private_key"},
+			},
+		},
+	})
+}
+
+func testAccWafCertificateV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_certificate" "certificate_1" {
+  name = "%s"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+
+  depends_on = [
+    g42cloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstanceV1_conf(name), name)
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_dedicated_domain_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_dedicated_domain_test.go
@@ -1,0 +1,182 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	domains "github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_domains"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccWafDedicateDomainV1_basic(t *testing.T) {
+	var domain domains.PremiumHost
+	resourceName := "g42cloud_waf_dedicated_domain.domain_1"
+	randName := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedDomainV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedDomainV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "server.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "protect_status"),
+					resource.TestCheckResourceAttrSet(resourceName, "protocol"),
+					resource.TestCheckResourceAttrSet(resourceName, "tls"),
+					resource.TestCheckResourceAttrSet(resourceName, "cipher"),
+					resource.TestCheckResourceAttrSet(resourceName, "alarm_page.template_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_3ds"),
+					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_dss"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedDomainV1_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.address", "119.8.0.15"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"keep_policy"},
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedDomainV1Destroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	c, err := config.WafDedicatedV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating G42cloud WAF dedicated client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_waf_dedicated_domain" {
+			continue
+		}
+
+		_, err := domains.Get(c, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("WAF dedicated mode domain still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDedicatedDomainV1Exists(n string, domain *domains.PremiumHost) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		c, err := config.WafDedicatedV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating G42cloud WAF dedicated client: %s", err)
+		}
+		found, err := domains.Get(c, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF dedicated domain not found")
+		}
+		*domain = *found
+		return nil
+	}
+}
+
+func testAccWafDedicatedDomainV1_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_dedicated_domain" "domain_1" {
+  domain         = "www.%s.com"
+  certificate_id = g42cloud_waf_certificate.certificate_1.id
+  keep_policy    = false
+  proxy          = false
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+    type            = "ipv4"
+    vpc_id          = g42cloud_vpc.vpc_1.id
+  }
+
+  depends_on = [
+    g42cloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf(name), name)
+}
+
+func testAccWafDedicatedDomainV1_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_dedicated_domain" "domain_1" {
+  domain         = "www.%s.com"
+  certificate_id = g42cloud_waf_certificate.certificate_1.id
+  keep_policy    = false
+  proxy          = true
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = g42cloud_vpc.vpc_1.id
+  }
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.15"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = g42cloud_vpc.vpc_1.id
+  }
+
+  depends_on = [
+    g42cloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf(name), name)
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_dedicated_instance_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_dedicated_instance_test.go
@@ -1,0 +1,225 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	instances "github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_instances"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func getWafDedicatedInstanceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.WafDedicatedV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("error creating G42cloud WAF dedicated client : %s", err)
+	}
+	return instances.GetInstance(client, state.Primary.ID)
+}
+
+func TestAccWafDedicatedInstance_basic(t *testing.T) {
+	var instance instances.DedicatedInstance
+	resourceName := "g42cloud_waf_dedicated_instance.instance_1"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&instance,
+		getWafDedicatedInstanceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedInstanceV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
+					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
+					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
+					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
+					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedInstance_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_updated"),
+					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
+					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
+					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
+					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
+					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccWafDedicatedInstance_elb_model(t *testing.T) {
+	var instance instances.DedicatedInstance
+	resourceName := "g42cloud_waf_dedicated_instance.instance_1"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&instance,
+		getWafDedicatedInstanceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedInstance_elb_model(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
+					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
+					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
+					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
+					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "group_id",
+						"${g42cloud_waf_instance_group.group_1.id}"),
+				),
+			},
+		},
+	})
+}
+
+func baseDependResource(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "vpc_1" {
+  name = "%s_waf"
+  cidr = "192.168.0.0/24"
+}
+
+resource "g42cloud_vpc_subnet" "vpc_subnet_1" {
+  name       = "%s_waf"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = g42cloud_vpc.vpc_1.id
+}
+
+resource "g42cloud_networking_secgroup" "secgroup" {
+  name        = "%s_waf"
+  description = "terraform security group acceptance test"
+}
+
+data "g42cloud_availability_zones" "zones" {}
+
+data "g42cloud_compute_flavors" "flavors" {
+  availability_zone = data.g42cloud_availability_zones.zones.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+}
+`, name, name, name)
+}
+
+func testAccWafDedicatedInstanceV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_dedicated_instance" "instance_1" {
+  name               = "%s"
+  available_zone     = data.g42cloud_availability_zones.zones.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.g42cloud_compute_flavors.flavors.ids[0]
+  vpc_id             = g42cloud_vpc.vpc_1.id
+  subnet_id          = g42cloud_vpc_subnet.vpc_subnet_1.id
+  
+  security_group = [
+    g42cloud_networking_secgroup.secgroup.id
+  ]
+}
+`, baseDependResource(name), name)
+}
+
+func testAccWafDedicatedInstance_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_dedicated_instance" "instance_1" {
+  name               = "%s_updated"
+  available_zone     = data.g42cloud_availability_zones.zones.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.g42cloud_compute_flavors.flavors.ids[0]
+  vpc_id             = g42cloud_vpc.vpc_1.id
+  subnet_id          = g42cloud_vpc_subnet.vpc_subnet_1.id
+  
+  security_group = [
+    g42cloud_networking_secgroup.secgroup.id
+  ]
+}
+`, baseDependResource(name), name)
+}
+
+func testAccWafDedicatedInstance_elb_model(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_instance_group" "group_1" {
+  name   = "%s"
+  vpc_id = g42cloud_vpc.vpc_1.id
+}
+
+resource "g42cloud_waf_dedicated_instance" "instance_1" {
+  name               = "%s"
+  available_zone     = data.g42cloud_availability_zones.zones.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.g42cloud_compute_flavors.flavors.ids[0]
+  vpc_id             = g42cloud_vpc.vpc_1.id
+  subnet_id          = g42cloud_vpc_subnet.vpc_subnet_1.id
+  group_id           = g42cloud_waf_instance_group.group_1.id
+  
+  security_group = [
+    g42cloud_networking_secgroup.secgroup.id
+  ]
+}
+`, baseDependResource(name), name, name)
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_domain_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_domain_test.go
@@ -1,0 +1,241 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains"
+)
+
+func getResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.WafV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating G42cloud WAF client: %s", err)
+	}
+	return domains.Get(c, state.Primary.ID).Extract()
+}
+
+func TestAccWafDomainV1_basic(t *testing.T) {
+	var domain domains.Domain
+	resourceName := "g42cloud_waf_domain.domain_1"
+	randName := acceptance.RandomAccResourceName()
+	domainName := fmt.Sprintf("%s.g42.com", randName)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&domain,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDomainV1_basic(randName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain", domainName),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+				),
+			},
+			{
+				Config: testAccWafDomainV1_update(randName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"keep_policy", "charging_mode"},
+			},
+		},
+	})
+}
+
+func TestAccWafDomainV1_policy(t *testing.T) {
+	var domain domains.Domain
+	resourceName := "g42cloud_waf_domain.domain_1"
+	randName := acceptance.RandomAccResourceName()
+	domainName := fmt.Sprintf("%s.g42.com", randName)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&domain,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDomainV1_policy(randName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain", domainName),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "policy_id",
+						"${g42cloud_waf_policy.policy_1.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccWafDomainV1_base(randName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_waf_certificate" "certificate_1" {
+  name = "%s"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+}
+`, randName)
+}
+
+func testAccWafDomainV1_basic(randName, domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_domain" "domain_1" {
+  domain           = "%s"
+  certificate_id   = g42cloud_waf_certificate.certificate_1.id
+  certificate_name = g42cloud_waf_certificate.certificate_1.name
+  keep_policy      = false
+  proxy            = false
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+  }
+}
+`, testAccWafDomainV1_base(randName), domainName)
+}
+
+func testAccWafDomainV1_update(randName, domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_domain" "domain_1" {
+  domain           = "%s"
+  certificate_id   = g42cloud_waf_certificate.certificate_1.id
+  certificate_name = g42cloud_waf_certificate.certificate_1.name
+  keep_policy      = false
+  proxy            = true
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8443
+  }
+
+}
+`, testAccWafDomainV1_base(randName), domainName)
+}
+
+func testAccWafDomainV1_policy(randName, domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_policy" "policy_1" {
+  name = "%s"
+}
+
+resource "g42cloud_waf_domain" "domain_1" {
+  domain           = "%s"
+  certificate_id   = g42cloud_waf_certificate.certificate_1.id
+  certificate_name = g42cloud_waf_certificate.certificate_1.name
+  policy_id        = g42cloud_waf_policy.policy_1.id
+  proxy            = true
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+  }
+}
+`, testAccWafDomainV1_base(randName), randName, domainName)
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_policy_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_policy_test.go
@@ -1,0 +1,124 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/policies"
+)
+
+func TestAccWafPolicyV1_basic(t *testing.T) {
+	var policy policies.Policy
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_waf_policy.policy_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafPolicyV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafPolicyV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPolicyV1Exists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "level", "1"),
+					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
+				),
+			},
+			{
+				Config: testAccWafPolicyV1_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPolicyV1Exists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"_updated"),
+					resource.TestCheckResourceAttr(resourceName, "protection_mode", "block"),
+					resource.TestCheckResourceAttr(resourceName, "level", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckWafPolicyV1Destroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("error creating G42cloud WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_waf_policy" {
+			continue
+		}
+		_, err := policies.Get(wafClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmtp.Errorf("Waf policy still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckWafPolicyV1Exists(n string, policy *policies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("error creating g42cloud WAF client: %s", err)
+		}
+
+		found, err := policies.Get(wafClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmtp.Errorf("Waf policy not found")
+		}
+
+		*policy = *found
+		return nil
+	}
+}
+
+func testAccWafPolicyV1_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_waf_policy" "policy_1" {
+  name  = "%s"
+  level = 1
+}
+`, name)
+}
+
+func testAccWafPolicyV1_update(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_waf_policy" "policy_1" {
+  name            = "%s_updated"
+  protection_mode = "block"
+  level           = 3
+}
+`, name)
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_reference_table_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_reference_table_test.go
@@ -1,0 +1,140 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccWafReferenceTableV1_basic(t *testing.T) {
+	var referencTable valuelists.WafValueList
+	resourceName := "g42cloud_waf_reference_table.ref_table"
+	name := acceptance.RandomAccResourceName()
+	updateName := name + "_update"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafReferenceTableV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafReferenceTableV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafReferenceTableV1Exists(resourceName, &referencTable),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "tf acc"),
+					resource.TestCheckResourceAttr(resourceName, "type", "url"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "2"),
+				),
+			},
+			{
+				Config: testAccWafReferenceTableV1_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafReferenceTableV1Exists(resourceName, &referencTable),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "type", "url"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckWafReferenceTableV1Destroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_waf_reference_table" {
+			continue
+		}
+
+		_, err := valuelists.Get(wafClient, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("WAF reference table still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafReferenceTableV1Exists(n string, valueList *valuelists.WafValueList) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+		}
+
+		found, err := valuelists.Get(wafClient, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF reference table not found")
+		}
+
+		*valueList = *found
+
+		return nil
+	}
+}
+
+func testAccWafReferenceTableV1_conf(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_waf_reference_table" "ref_table" {
+  name        = "%s"
+  type        = "url"
+  description = "tf acc"
+
+  conditions = [
+    "/admin",
+    "/manage"
+  ]
+}
+`, name)
+}
+
+func testAccWafReferenceTableV1_update(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_waf_reference_table" "ref_table" {
+  name        = "%s"
+  type        = "url"
+  description = ""
+
+  conditions = [
+    "/bill",
+    "/sql"
+  ]
+}
+`, name)
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_rule_blacklist_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_rule_blacklist_test.go
@@ -1,0 +1,172 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	rules "github.com/chnsz/golangsdk/openstack/waf_hw/v1/whiteblackip_rules"
+)
+
+func TestAccWafRuleBlackList_basic(t *testing.T) {
+	var rule rules.WhiteBlackIP
+	randName := acceptance.RandomAccResourceName()
+	rName1 := "g42cloud_waf_rule_blacklist.rule_1"
+	rName2 := "g42cloud_waf_rule_blacklist.rule_2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafRuleBlackListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleBlackList_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(rName1, &rule),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.0/24"),
+					resource.TestCheckResourceAttr(rName1, "action", "0"),
+
+					testAccCheckWafRuleBlackListExists(rName2, &rule),
+					resource.TestCheckResourceAttr(rName2, "ip_address", "192.165.0.0/24"),
+					resource.TestCheckResourceAttr(rName2, "action", "1"),
+				),
+			},
+			{
+				Config: testAccWafRuleBlackList_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(rName1, &rule),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.125"),
+					resource.TestCheckResourceAttr(rName1, "action", "2"),
+
+					testAccCheckWafRuleBlackListExists(rName2, &rule),
+					resource.TestCheckResourceAttr(rName2, "ip_address", "192.150.0.0/24"),
+					resource.TestCheckResourceAttr(rName2, "action", "0"),
+				),
+			},
+			{
+				ResourceName:      rName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(rName1),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleBlackListDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_waf_rule_blacklist" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Waf rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleBlackListExists(n string, rule *rules.WhiteBlackIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF black list rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+// testAccWafRuleImportStateIdFunc is used to test exporting rule information from the G42cloud to terraform.
+// It is also called by other rules unit tests.
+func testAccWafRuleImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		policy, ok := s.RootModule().Resources["g42cloud_waf_policy.policy_1"]
+		if !ok {
+			return "", fmt.Errorf("WAF policy not found")
+		}
+		rule, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("WAF rule not found")
+		}
+
+		if policy.Primary.ID == "" || rule.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", policy.Primary.ID, rule.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", policy.Primary.ID, rule.Primary.ID), nil
+	}
+}
+
+func testAccWafRuleBlackList_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_rule_blacklist" "rule_1" {
+  policy_id  = g42cloud_waf_policy.policy_1.id
+  ip_address = "192.168.0.0/24"
+}
+
+resource "g42cloud_waf_rule_blacklist" "rule_2" {
+  policy_id  = g42cloud_waf_policy.policy_1.id
+  ip_address = "192.165.0.0/24"
+  action     = 1
+}
+`, testAccWafPolicyV1_basic(name))
+}
+
+func testAccWafRuleBlackList_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_rule_blacklist" "rule_1" {
+  policy_id  = g42cloud_waf_policy.policy_1.id
+  ip_address = "192.168.0.125"
+  action     = 2
+}
+
+resource "g42cloud_waf_rule_blacklist" "rule_2" {
+  policy_id  = g42cloud_waf_policy.policy_1.id
+  ip_address = "192.150.0.0/24"
+  action     = 0
+}
+`, testAccWafPolicyV1_basic(name))
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_rule_data_masking_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_rule_data_masking_test.go
@@ -1,0 +1,180 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	rules "github.com/chnsz/golangsdk/openstack/waf_hw/v1/datamasking_rules"
+)
+
+func TestAccWafRuleDataMasking_basic(t *testing.T) {
+	var rule rules.DataMasking
+	policyName := acceptance.RandomAccResourceName()
+	resourceName1 := "g42cloud_waf_rule_data_masking.rule_1"
+	resourceName2 := "g42cloud_waf_rule_data_masking.rule_2"
+	resourceName3 := "g42cloud_waf_rule_data_masking.rule_3"
+	resourceName4 := "g42cloud_waf_rule_data_masking.rule_4"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafRuleDataMaskingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleDataMasking_basic(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName1, &rule),
+					resource.TestCheckResourceAttr(resourceName1, "path", "/login"),
+					resource.TestCheckResourceAttr(resourceName1, "subfield", "password"),
+					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName2, "field", "header"),
+					resource.TestCheckResourceAttr(resourceName3, "field", "form"),
+					resource.TestCheckResourceAttr(resourceName4, "field", "cookie"),
+				),
+			},
+			{
+				Config: testAccWafRuleDataMasking_update(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName1, &rule),
+					resource.TestCheckResourceAttr(resourceName1, "path", "/login_new"),
+					resource.TestCheckResourceAttr(resourceName1, "subfield", "secret"),
+					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName2, "field", "header"),
+					resource.TestCheckResourceAttr(resourceName3, "field", "form"),
+					resource.TestCheckResourceAttr(resourceName4, "field", "cookie"),
+				),
+			},
+			{
+				ResourceName:      resourceName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName1),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleDataMaskingDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_waf_rule_data_masking" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF data masking rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleDataMaskingExists(n string, rule *rules.DataMasking) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF data masking rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRuleDataMasking_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_rule_data_masking" "rule_1" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "params"
+  subfield  = "password"
+}
+resource "g42cloud_waf_rule_data_masking" "rule_2" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "header"
+  subfield  = "password"
+}
+resource "g42cloud_waf_rule_data_masking" "rule_3" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "form"
+  subfield  = "password"
+}
+resource "g42cloud_waf_rule_data_masking" "rule_4" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "cookie"
+  subfield  = "password"
+}
+`, testAccWafPolicyV1_basic(name))
+}
+
+func testAccWafRuleDataMasking_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_rule_data_masking" "rule_1" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login_new"
+  field     = "params"
+  subfield  = "secret"
+}
+resource "g42cloud_waf_rule_data_masking" "rule_2" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "header"
+  subfield  = "secret"
+}
+resource "g42cloud_waf_rule_data_masking" "rule_3" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "form"
+  subfield  = "secret"
+}
+resource "g42cloud_waf_rule_data_masking" "rule_4" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "cookie"
+  subfield  = "secret"
+}
+`, testAccWafPolicyV1_basic(name))
+}

--- a/g42cloud/services/acceptance/waf/resource_g42cloud_waf_rule_web_tamper_protection_test.go
+++ b/g42cloud/services/acceptance/waf/resource_g42cloud_waf_rule_web_tamper_protection_test.go
@@ -1,0 +1,112 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	rules "github.com/chnsz/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules"
+)
+
+func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
+	var rule rules.WebTamper
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_waf_rule_web_tamper_protection.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleWebTamperProtection_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_waf_rule_web_tamper_protection" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleWebTamperProtectionExists(n string, rule *rules.WebTamper) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating G42cloud WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF web tamper protection rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRuleWebTamperProtection_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id = g42cloud_waf_policy.policy_1.id
+  domain    = "www.abc.com"
+  path      = "/a"
+}
+`, testAccWafPolicyV1_basic(name))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/g42cloud-terraform/terraform-provider-g42cloud
 go 1.18
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20230116070640-a00589724847
+	github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.44.1-0.20230120072827-f06b372f9fb3
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.44.2-0.20230203081853-b57de5da71a3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230116070640-a00589724847 h1:GOiIXAjJ5beLf61NCg/cKaET0ge3oT1OpYtUJjhqLzY=
-github.com/chnsz/golangsdk v0.0.0-20230116070640-a00589724847/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225 h1:hiD6ICQq6spHKB4E8SGIrYURYrYhVuC+BthrKanauaI=
+github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -139,8 +139,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20 h1:Pyz8ZjJEAel4axFfL3bvPJ0nXg2IAMW2ksZbepyM7KE=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20/go.mod h1:QpZ96CRqyqd5fEODVmnzDNp3IWi5W95BFmWz1nfkq+s=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.44.1-0.20230120072827-f06b372f9fb3 h1:QqojcZWcSXZBN/pdGdR0+siQ+jt0qQnHPxfHWp7+SF0=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.44.1-0.20230120072827-f06b372f9fb3/go.mod h1:nSwmrbtd9QuphcOYiXPOc1TucS1ejz5IT+FbwFK7+OI=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.44.2-0.20230203081853-b57de5da71a3 h1:Vv4zncnEgRBRLILHQOZMoYxrKpTYpxLyXiyySoMgQcM=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.44.2-0.20230203081853-b57de5da71a3/go.mod h1:gqnAbLBKojcs/z5ibIE+s8R+An67qKmRTNPhQjQTIJ4=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new data_sources:
waf_certificate
waf_dedicated_instances
waf_policies
waf_reference_tables

2. new resources
waf_certificate
waf_dedicated_domain
waf_dedicated_instance
waf_domain
waf_policy
waf_reference_table
waf_rule_blacklist
waf_rule_data_masking
waf_rule_web_tamper_protection
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicatedInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_basic -timeout 360m -parallel=4
=== RUN   TestAccWafDedicatedInstance_basic
=== PAUSE TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_basic
--- PASS: TestAccWafDedicatedInstance_basic (385.73s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      385.810s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafCertificateV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafCertificateV1_basic -timeout 360m -parallel=4
=== RUN   TestAccWafCertificateV1_basic
=== PAUSE TestAccWafCertificateV1_basic
=== CONT  TestAccWafCertificateV1_basic
--- PASS: TestAccWafCertificateV1_basic (515.77s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      515.872s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_basic -timeout 360m -parallel=4
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_basic
--- PASS: TestAccWafDedicateDomainV1_basic (374.96s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      375.029s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel=4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (39.25s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      39.373s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafPolicyV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafPolicyV1_basic -timeout 360m -parallel=4
=== RUN   TestAccWafPolicyV1_basic
=== PAUSE TestAccWafPolicyV1_basic
=== CONT  TestAccWafPolicyV1_basic
--- PASS: TestAccWafPolicyV1_basic (32.95s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      33.016s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafReferenceTableV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafReferenceTableV1_basic -timeout 360m -parallel=4
=== RUN   TestAccWafReferenceTableV1_basic
=== PAUSE TestAccWafReferenceTableV1_basic
=== CONT  TestAccWafReferenceTableV1_basic
--- PASS: TestAccWafReferenceTableV1_basic (37.57s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      37.651s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleBlackList_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_basic -timeout 360m -parallel=4
=== RUN   TestAccWafRuleBlackList_basic
=== PAUSE TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_basic
--- PASS: TestAccWafRuleBlackList_basic (33.38s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      33.472s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleDataMasking_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_basic -timeout 360m -parallel=4
=== RUN   TestAccWafRuleDataMasking_basic
=== PAUSE TestAccWafRuleDataMasking_basic
=== CONT  TestAccWafRuleDataMasking_basic
--- PASS: TestAccWafRuleDataMasking_basic (36.83s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      36.914s

make testacc TEST='./g42cloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleWebTamperProtection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_basic -timeout 360m -parallel=4
=== RUN   TestAccWafRuleWebTamperProtection_basic
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_basic
--- PASS: TestAccWafRuleWebTamperProtection_basic (18.59s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/waf      18.660s
```
