### PR TITLE
feat(AS): import AS resource, unit test and document

### DIFF
--- a/docs/data-sources/as_configurations.md
+++ b/docs/data-sources/as_configurations.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud_as_configurations
+
+Use this data source to get a list of AS configurations.
+
+```hcl
+data "g42cloud_as_configurations" "configurations" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the AS configurations.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the AS configuration name. Supports fuzzy search.
+
+* `image_id` - (Optional, String) Specifies the image ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the list.
+
+* `configurations` - A list of AS configurations. The [configurations](#as_configurations) object structure is
+  documented below.
+
+<a name="as_configurations"></a>
+The `configurations` block supports:
+
+* `scaling_configuration_name` - The AS configuration name.
+
+* `instance_config` - The list of information about instance configurations.
+  The [instance_config](#as_instance_config) object structure is documented below.
+
+* `status` - The AS configuration status, the value can be **Bound** or **Unbound**.
+
+<a name="as_instance_config"></a>
+The `instance_config` block supports:
+
+* `instance_id` - The ECS instance ID when using its specification as the template to create AS configurations.
+
+* `flavor` - The ECS flavor name.
+
+* `image` - The ECS image ID.
+
+* `disk` - The list of disk group information. The [disk](#as_disk) object structure is documented below.
+
+* `key_name` - The name of the SSH key pair used to log in to the instance.
+
+* `security_group_ids` - An array of one or more security group IDs.
+
+* `charging_mode` - The billing mode for ECS, the value can be **postPaid** or **spot**.
+
+* `flavor_priority_policy` - The priority policy used when there are multiple flavors
+  and instances to be created using an AS configuration. The value can be `PICK_FIRST` and `COST_FIRST`.
+
+* `ecs_group_id` - The ECS group ID.
+
+* `user_data` - The user data to provide when launching the instance.
+
+* `public_ip` - The EIP list of the ECS instance.
+  The [public_ip](#as_public_ip) object structure is documented below.
+
+* `metadata` - The key/value pairs to make available from within the instance.
+
+* `personality` - The list of information about the injected file.
+  The [personality](#as_personality) object structure is documented below.
+
+<a name="as_disk"></a>
+The `disk` block supports:
+
+* `size` - The disk size. The unit is GB.
+
+* `volume_type` - The volume type.
+
+* `disk_type` - The disk type.
+
+* `kms_id` - The encryption KMS ID of the **DATA** disk.
+
+<a name="as_public_ip"></a>
+The `public_ip` block supports:
+
+* `eip` - The list of EIP configuration that will be automatically assigned to the instance.
+  The [eip](#as_eip) object structure is documented below.
+
+<a name="as_eip"></a>
+The `eip` block supports:
+
+* `ip_type` - The EIP type.
+
+* `bandwidth` - The list of bandwidth information. The [bandwidth](#as_bandwidth) object structure is documented below.
+
+<a name="as_bandwidth"></a>
+The `bandwidth` block supports:
+
+* `share_type` - The bandwidth sharing type.
+
+* `charging_mode` - The bandwidth billing mode, the value can be **traffic** or **bandwidth**.
+
+* `size` - The bandwidth (Mbit/s).
+
+<a name="as_personality"></a>
+The `personality` block supports:
+
+* `path` - The path of the injected file.
+
+* `content` - The content of the injected file.

--- a/docs/data-sources/as_groups.md
+++ b/docs/data-sources/as_groups.md
@@ -1,0 +1,136 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud_as_groups
+
+Use this data source to get a list of AS groups.
+
+```hcl
+data "g42cloud_as_groups" "groups" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the AS groups.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the AS group name. Fuzzy search is supported.
+
+* `scaling_configuration_id` - (Optional, String) Specifies the AS configuration ID, which can be obtained using
+  the API for listing AS configurations.
+
+* `status` - (Optional, String) Specifies the AS group status. The options are as follows:
+  - **INSERVICE**: indicates that the AS group is functional.
+  - **PAUSED**: indicates that the AS group is paused.
+  - **ERROR**: indicates that the AS group malfunctions.
+  - **DELETING**: indicates that the AS group is being deleted.
+  - **FREEZED**: indicates that the AS group has been frozen.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the list.
+
+* `groups` - A list of AS groups. The [groups](#as_groups) object structure is documented below.
+
+<a name="as_groups"></a>
+The `groups` block supports:
+
+* `scaling_group_name` - The name of the AS group.
+
+* `scaling_group_id` - The AS group ID.
+
+* `status` - The AS group status.
+
+* `scaling_configuration_id` - The AS configuration ID.
+
+* `scaling_configuration_name` - The AS configuration name.
+
+* `current_instance_number` - The number of current instances in the AS group.
+
+* `desire_instance_number` - The expected number of instances in the AS group.
+
+* `min_instance_number` - The minimum number of instances in the AS group.
+
+* `max_instance_number` - The maximum number of instances in the AS group.
+
+* `cool_down_time` - The cooling duration, in seconds.
+
+* `lbaas_listeners` - The enhanced load balancers.
+  The [lbaas_listeners](#as_lbaas_listeners) object structure is documented below.
+
+* `availability_zones` - The AZ information.
+
+* `networks` - The network information.
+  The [networks](#as_networks) object structure is documented below.
+
+* `security_groups` - The security group information.
+  The [security_groups](#as_security_groups) object structure is documented below.
+
+* `created_at` - The time when an AS group was created. The time format complies with UTC.
+
+* `vpc_id` - The ID of the VPC to which the AS group belongs.
+
+* `detail` - Details about the AS group. If a scaling action fails, this parameter is used to record errors.
+
+* `is_scaling` - The scaling flag of the AS group.
+
+* `health_periodic_audit_method` - The health check method.
+
+* `health_periodic_audit_time` - The health check interval.
+
+* `health_periodic_audit_grace_period` - The grace period for health check.
+
+* `instance_terminate_policy` - The instance removal policy.
+
+* `delete_publicip` - Whether to delete the EIP bound to the ECS when deleting the ECS.
+
+* `delete_volume` - Whether to delete the data disks attached to the ECS when deleting the ECS.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `activity_type` - The type of the AS action.
+
+* `multi_az_scaling_policy` - The priority policy used to select target AZs when adjusting the number of
+  instances in an AS group.
+
+* `description` - The description of the AS group.
+
+* `iam_agency_name` - The agency name.
+
+* `tags` - The tag of AS group.
+
+* `instances` - The scaling group instances ids.
+
+<a name="as_lbaas_listeners"></a>
+The `lbaas_listeners` block supports:
+
+* `pool_id` - The backend ECS group ID.
+
+* `protocol_port` - The backend protocol ID, which is the port on which a backend ECS listens for traffic.
+
+* `weight` - The weight, which determines the portion of requests a backend ECS processes
+  compared to other backend ECSs added to the same listener.
+
+<a name="as_networks"></a>
+The `networks` block supports:
+
+* `id` - The subnet ID.
+
+* `ipv6_enable` - Specifies whether to support IPv6 addresses.
+
+* `ipv6_bandwidth_id` - The ID of the shared bandwidth of an IPv6 address.
+
+* `source_dest_check` - Whether processesing only traffic that is destined specifically for it.
+
+<a name="as_security_groups"></a>
+The `security_groups` block supports:
+
+* `id` - The ID of the security group.

--- a/docs/resources/as_bandwidth_policy.md
+++ b/docs/resources/as_bandwidth_policy.md
@@ -1,0 +1,177 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud_as_bandwidth_policy
+
+Manages an AS bandwidth scaling policy resource within G42Cloud.
+
+-> AS cannot scale yearly/monthly bandwidths.
+
+## Example Usage
+
+### AS Recurrence Policy
+
+```hcl
+variable "bandwidth_id" {}
+
+resource "g42cloud_as_bandwidth_policy" "bw_policy" {
+  scaling_policy_name = "bw_policy"
+  scaling_policy_type = "RECURRENCE"
+  bandwidth_id        = var.bandwidth_id
+  cool_down_time      = 600
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time      = "07:00"
+    recurrence_type  = "Weekly"
+    recurrence_value = "1,3,5"
+    start_time       = "2022-09-30T12:00Z"
+    end_time         = "2022-12-30T12:00Z"
+  }
+}
+```
+
+### AS Scheduled Policy
+
+```hcl
+variable "bandwidth_id" {}
+
+resource "g42cloud_as_bandwidth_policy" "bw_policy" {
+  scaling_policy_name = "bw_policy"
+  scaling_policy_type = "SCHEDULED"
+  bandwidth_id        = var.bandwidth_id
+  cool_down_time      = 600
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time = "2022-09-30T12:00Z"
+  }
+}
+```
+
+### AS Alarm Policy
+
+```hcl
+variable "bandwidth_id" {}
+variable "alarm_id" {}
+
+resource "g42cloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "bw_policy"
+  scaling_policy_type = "ALARM"
+  bandwidth_id        = var.bandwidth_id
+  alarm_id            = var.alarm_id
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+    limits    = 300
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `scaling_policy_name` - (Required, String) Specifies the AS policy name. The valid length is limited from can
+  contain 1 to 64, only letters, digits, underscores (_) and hyphens (-) are allowed.
+
+* `scaling_policy_type` - (Required, String) Specifies the AS policy type. The options are as follows:
+  - **ALARM** (corresponding to `alarm_id`): indicates that the scaling action is triggered by an alarm.
+  - **SCHEDULED** (corresponding to `scheduled_policy`): indicates that the scaling action is triggered as scheduled.
+  - **RECURRENCE** (corresponding to `scheduled_policy`): indicates that the scaling action is triggered periodically.
+
+* `bandwidth_id` - (Required, String) Specifies the scaling bandwidth ID.
+
+* `alarm_id` - (Optional, String) Specifies the alarm rule ID.
+  This parameter is mandatory when `scaling_policy_type` is set to ALARM.
+
+* `cool_down_time` - (Optional, Int) Specifies the cooldown period (in seconds).
+  The value ranges from 0 to 86400 and is 300 by default.
+
+* `description` - (Optional, String) Specifies the description of the AS policy.
+  The value can contain 0 to 256 characters.
+
+* `scaling_policy_action` - (Optional, List) Specifies the scaling action of the AS policy.
+  The [scaling_policy_action](#as_scaling_policy_action) object structure is documented below.
+
+* `scheduled_policy` - (Optional, List) Specifies the periodic or scheduled AS policy.
+  This parameter is mandatory when `scaling_policy_type` is set to SCHEDULED or RECURRENCE.
+  The [scheduled_policy](#as_scheduled_policy) object structure is documented below.
+
+<a name="as_scaling_policy_action"></a>
+The `scaling_policy_action` block supports:
+
+* `operation` - (Optional, String) Specifies the operation to be performed. The default operation is **ADD**.
+  The options are as follows:
+  - **ADD**: indicates adding the bandwidth size.
+  - **REDUCE**: indicates reducing the bandwidth size.
+  - **SET**: indicates setting the bandwidth size to a specified value.
+
+* `size` - (Optional, Int) Specifies the bandwidth (Mbit/s).
+  The value is an integer from 1 to 2000. The default value is 1.
+
+* `limits` - (Optional, Int) Specifies the operation restrictions.
+  - If operation is not SET, this parameter takes effect and the unit is Mbit/s.
+  - If operation is set to ADD, this parameter indicates the maximum bandwidth allowed.
+  - If operation is set to REDUCE, this parameter indicates the minimum bandwidth allowed.
+
+<a name="as_scheduled_policy"></a>
+The `scheduled_policy` block supports:
+
+* `launch_time` - (Required, String) Specifies the time when the scaling action is triggered.
+  The time format complies with UTC.
+  - If scaling_policy_type is set to **SCHEDULED**, the time format is YYYY-MM-DDThh:mmZ.
+  - If scaling_policy_type is set to **RECURRENCE**, the time format is hh:mm.
+
+* `recurrence_type` - (Optional, String) Specifies the periodic triggering type.
+  This parameter is mandatory when scaling_policy_type is set to **RECURRENCE**. The options are as follows:
+  - **Daily**: indicates that the scaling action is triggered once a day.
+  - **Weekly**: indicates that the scaling action is triggered once a week.
+  - **Monthly**: indicates that the scaling action is triggered once a month.
+
+* `recurrence_value` - (Optional, String) Specifies the day when a periodic scaling action is triggered.
+  This parameter is mandatory when scaling_policy_type is set to **RECURRENCE**.
+  - If recurrence_type is set to **Daily**, the value is null, indicating that the scaling action is triggered
+    once a day.
+  - If recurrence_type is set to **Weekly**, the value ranges from 1 (Sunday) to 7 (Saturday).
+    The digits refer to dates in each week and separated by a comma, such as 1,3,5.
+  - If recurrence_type is set to **Monthly**, the value ranges from 1 to 31.
+    The digits refer to the dates in each month and separated by a comma, such as 1,10,13,28.
+
+* `start_time` - (Optional, String) Specifies the start time of the scaling action triggered periodically.
+  The time format complies with UTC. The default value is the local time.
+  The time format is YYYY-MM-DDThh:mmZ.
+
+* `end_time` - (Optional, String) Specifies the end time of the scaling action triggered periodically.
+  The time format complies with UTC. This parameter is mandatory when scaling_policy_type is set to **RECURRENCE**.
+  When the scaling action is triggered periodically, the end time cannot be earlier than the current and start time.
+  The time format is YYYY-MM-DDThh:mmZ.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `scaling_resource_type` - The scaling resource type. The value is fixed to **BANDWIDTH**.
+
+* `status` - The AS policy status. The value can be **INSERVICE**, **PAUSED** and **EXECUTING**.
+
+## Import
+
+The bandwidth scaling policies can be imported using the `id`, e.g.
+
+```shell
+terraform import g42cloud.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/docs/resources/as_instance_attach.md
+++ b/docs/resources/as_instance_attach.md
@@ -1,0 +1,110 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud_as_instance_attach
+
+Manages an AS instance attachment resource within G42Cloud.
+
+## Example Usage
+
+### Add an instance
+
+```hcl
+variable "scaling_group_id" {}
+variable "ecs_id" {}
+
+resource "g42cloud_as_instance_attach" "test" {
+  scaling_group_id = var.scaling_group_id
+  instance_id      = var.ecs_id
+}
+```
+
+### Add an instance with protection
+
+```hcl
+variable "scaling_group_id" {}
+variable "ecs_id" {}
+
+resource "g42cloud_as_instance_attach" "test" {
+  scaling_group_id = var.scaling_group_id
+  instance_id      = var.ecs_id
+  protected        = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the AS group ID.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ECS instance ID.
+  Changing this creates a new resource.
+
+  <!--markdownlint-disable MD033-->
+  -> Before adding instances to an AS group, ensure that the following conditions are met:
+  <br/>1. The instance is not in other AS groups.
+  <br/>2. The instance is in the same VPC as the AS group.
+  <br/>3. The instance is in the AZs used by the AS group.
+  <br/>4. After the instance is added, the total number of instances is less than or equal to the maximum number of
+  instances allowed.
+
+* `protected` - (Optional, Bool) Specifies whether the instance can be removed **automatically** from the AS group.
+  Once configured, when AS automatically scales in the AS group, the instance that is protected will not be removed.
+
+* `standby` - (Optional, Bool) Specifies whether to stop distributing traffic to the instance but do not want to remove
+  it from the AS group. You can stop or restart the instance without worrying about it will be removed from the AS group.
+
+* `append_instance` - (Optional, Bool) Specifies whether to add a new instance when the instance enter standby mode.
+  This parameter takes effect only when `standby` is set to true.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format of `scaling_group_id`/`instance_id`.
+
+* `instance_name` - The ECS instance name.
+
+* `health_status` - The instance health status. The value can be `INITIALIZING`, `NORMAL` or `ERROR`.
+
+* `status` - The instance lifecycle status in the AS group. The value can be `INSERVICE`, `STANDBY`,
+  `PENDING` or `REMOVING`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The AS instances can be imported by the `scaling_group_id` and `instance_id`, separated by a slash, e.g.
+
+```shell
+terraform import g42cloud_as_instance_attach.test <scaling_group_id>/<instance_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to `append_instance` is missing from
+the API response.
+
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "g42cloud_as_instance_attach" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [append_instance]
+  }
+}
+```

--- a/docs/resources/as_lifecycle_hook.md
+++ b/docs/resources/as_lifecycle_hook.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud_as_lifecycle_hook
+
+Manages an AS Lifecycle Hook resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "hook_name" {}
+variable "as_group_id" {}
+variable "smn_topic_urn" {}
+
+resource "g42cloud_as_lifecycle_hook" "test" {
+  scaling_group_id       = var.as_group_id
+  name                   = var.hook_name
+  type                   = "ADD"
+  default_result         = "ABANDON"
+  notification_topic_urn = var.smn_topic_urn
+  notification_message   = "This is a test message"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the AS lifecycle hook.
+  If omitted, the provider-level region will be used. Changing this creates a new AS lifecycle hook.
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the ID of the AS group in UUID format.
+  Changing this creates a new AS lifecycle hook.
+
+* `name` - (Required, String, ForceNew) Specifies the lifecycle hook name. This parameter can contain a maximum of
+  32 characters, which may consist of letters, digits, underscores (_) and hyphens (-).
+  Changing this creates a new AS lifecycle hook.
+
+* `type` - (Required, String) Specifies the lifecycle hook type. The valid values are following strings:
+  + `ADD`: The hook suspends the instance when the instance is started.
+  + `REMOVE`: The hook suspends the instance when the instance is terminated.
+
+* `notification_topic_urn` - (Required, String) Specifies a unique topic in SMN.
+
+* `default_result` - (Optional, String) Specifies the default lifecycle hook callback operation. This operation is
+  performed when the timeout duration expires. The valid values are *ABANDON* and *CONTINUE*, default to *ABANDON*.
+
+* `timeout` - (Optional, Int) Specifies the lifecycle hook timeout duration, which ranges from 300 to 86400 in the unit
+  of second, default to **3600**.
+
+* `notification_message` - (Optional, String) Specifies a customized notification. This parameter can contain a maximum
+  of 256 characters, which cannot contain the following characters: <>&'().
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `notification_topic_name` - The topic name in SMN.
+
+* `create_time` - The server time in UTC format when the lifecycle hook is created.
+
+## Import
+
+Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.
+
+```shell
+terraform import g42cloud_as_lifecycle_hook.test <AS group ID> <Lifecycle hook ID>
+```

--- a/docs/resources/as_notification.md
+++ b/docs/resources/as_notification.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# g42cloud_as_notification
+
+Manages an AS notification resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "scaling_group_id" {}
+variable "topic_urn" {}
+variable "events" {
+  type = list(string)
+}
+
+resource "g42cloud_as_notification" "test" {
+  scaling_group_id = var.scaling_group_id
+  topic_urn        = var.topic_urn
+  events           = var.events
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the AS group ID.
+  Changing this creates a new AS notification.
+
+* `topic_urn` - (Required, String, ForceNew) Specifies the unique topic URN of the SMN.
+  Changing this creates a new AS notification.
+
+* `events` - (Required, List) Specifies the topic scene of AS group. The events include `SCALING_UP`,
+  `SCALING_UP_FAIL`, `SCALING_DOWN`, `SCALING_DOWN_FAIL`, `SCALING_GROUP_ABNORMAL`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique topic URN in SMN.
+
+* `topic_name` - The topic name in SMN.
+
+## Import
+
+The as notification can be imported using `scaling_group_id`, `topic_urn`, separated by a slash, e.g.
+
+```shell
+terraform import g42cloud_as_notification.test <scaling_group_id>/<topic_urn>
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -183,7 +183,11 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"g42cloud_apig_environments":    apig.DataSourceEnvironments(),
+			"g42cloud_apig_environments": apig.DataSourceEnvironments(),
+
+			"g42cloud_as_configurations": as.DataSourceASConfigurations(),
+			"g42cloud_as_groups":         as.DataSourceASGroups(),
+
 			"g42cloud_availability_zones":   huaweicloud.DataSourceAvailabilityZones(),
 			"g42cloud_bms_flavors":          bms.DataSourceBmsFlavors(),
 			"g42cloud_cbr_vaults":           cbr.DataSourceVaults(),
@@ -269,9 +273,14 @@ func Provider() *schema.Provider {
 			"g42cloud_apig_throttling_policy":           apig.ResourceApigThrottlingPolicyV2(),
 			"g42cloud_apig_vpc_channel":                 deprecated.ResourceApigVpcChannelV2(),
 
-			"g42cloud_as_configuration":          as.ResourceASConfiguration(),
-			"g42cloud_as_group":                  as.ResourceASGroup(),
-			"g42cloud_as_policy":                 as.ResourceASPolicy(),
+			"g42cloud_as_bandwidth_policy": as.ResourceASBandWidthPolicy(),
+			"g42cloud_as_configuration":    as.ResourceASConfiguration(),
+			"g42cloud_as_group":            as.ResourceASGroup(),
+			"g42cloud_as_instance_attach":  as.ResourceASInstanceAttach(),
+			"g42cloud_as_lifecycle_hook":   as.ResourceASLifecycleHook(),
+			"g42cloud_as_notification":     as.ResourceAsNotification(),
+			"g42cloud_as_policy":           as.ResourceASPolicy(),
+
 			"g42cloud_bms_instance":              bms.ResourceBmsInstance(),
 			"g42cloud_cbr_policy":                cbr.ResourcePolicy(),
 			"g42cloud_cbr_vault":                 cbr.ResourceVault(),

--- a/g42cloud/services/acceptance/as/data_source_g42cloud_as_configurations_test.go
+++ b/g42cloud/services/acceptance/as/data_source_g42cloud_as_configurations_test.go
@@ -1,0 +1,80 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDataSourceASConfiguration_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_as_configurations.configurations"
+	name := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceASConfiguration_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "configurations.0.scaling_configuration_name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccASV1Configuration_basic(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "g42cloud_compute_flavors" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+}
+
+resource "g42cloud_compute_keypair" "hth_key" {
+  name       = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_as_configuration" "hth_as_config" {
+  scaling_configuration_name = "%s"
+  instance_config {
+    image  = data.g42cloud_images_image.test.id
+    flavor = data.g42cloud_compute_flavors.test.ids[0]
+    disk {
+      size        = 40
+      volume_type = "SAS"
+      disk_type   = "SYS"
+    }
+    key_name = "${g42cloud_compute_keypair.hth_key.id}"
+  }
+}
+`, rName, rName)
+}
+
+func testAccDataSourceASConfiguration_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_as_configurations" "configurations" {
+  name     = g42cloud_as_configuration.hth_as_config.scaling_configuration_name
+  image_id = g42cloud_as_configuration.hth_as_config.instance_config.0.image
+
+  depends_on = [g42cloud_as_configuration.hth_as_config]
+}
+`, testAccASV1Configuration_basic(name))
+}

--- a/g42cloud/services/acceptance/as/data_source_g42cloud_as_groups_test.go
+++ b/g42cloud/services/acceptance/as/data_source_g42cloud_as_groups_test.go
@@ -1,0 +1,46 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDataSourceASGroup_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_as_groups.groups"
+	name := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceASGroup_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "groups.0.scaling_group_name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceASGroup_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_as_groups" "groups" {
+  name                  = g42cloud_as_group.hth_as_group.scaling_group_name
+  status                = "INSERVICE"
+  enterprise_project_id = "0"
+
+  depends_on = [g42cloud_as_group.hth_as_group]
+}
+`, testAsGroup_base(name))
+}

--- a/g42cloud/services/acceptance/as/resource_g42cloud_as_bandwidth_policy_test.go
+++ b/g42cloud/services/acceptance/as/resource_g42cloud_as_bandwidth_policy_test.go
@@ -1,0 +1,272 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getASBandWidthPolicyResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getBandwidthPolicy: Query the AS bandwidth scaling policy
+	var (
+		getBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy/{id}"
+		getBandwidthPolicyProduct = "autoscaling"
+	)
+	getBandwidthPolicyClient, err := conf.NewServiceClient(getBandwidthPolicyProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ASBandWidthPolicy Client: %s", err)
+	}
+
+	getBandwidthPolicyPath := getBandwidthPolicyClient.Endpoint + getBandwidthPolicyHttpUrl
+	getBandwidthPolicyPath = strings.ReplaceAll(getBandwidthPolicyPath, "{project_id}", getBandwidthPolicyClient.ProjectID)
+	getBandwidthPolicyPath = strings.ReplaceAll(getBandwidthPolicyPath, "{id}", state.Primary.ID)
+
+	getBandwidthPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getBandwidthPolicyResp, err := getBandwidthPolicyClient.Request("GET", getBandwidthPolicyPath, &getBandwidthPolicyOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving ASBandWidthPolicy: %s", err)
+	}
+	return utils.FlattenResponse(getBandwidthPolicyResp)
+}
+
+func TestAccASBandWidthPolicy_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_as_bandwidth_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getASBandWidthPolicyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testASBandWidthPolicy_scheduled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_resource_type", "BANDWIDTH"),
+					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "300"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.size", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "g42cloud_vpc_bandwidth.test", "id"),
+				),
+			},
+			{
+				Config: testASBandWidthPolicy_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName+"-updated"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "900"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.limits", "300"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testASBandWidthPolicy_recurrence(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "RECURRENCE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "600"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_policy.0.launch_time", "07:00"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_policy.0.recurrence_type", "Weekly"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccASBandWidthPolicy_alarm(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_as_bandwidth_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getASBandWidthPolicyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testASBandWidthPolicy_alarm(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "ALARM"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_resource_type", "BANDWIDTH"),
+					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "g42cloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "alarm_id", "g42cloud_ces_alarmrule.alarmrule_1", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testASBandWidthPolicy_scheduled(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "g42cloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s"
+  scaling_policy_type = "SCHEDULED"
+  bandwidth_id        = g42cloud_vpc_bandwidth.test.id
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time = "2088-09-30T12:00Z"
+  }
+}
+`, name)
+}
+
+func testASBandWidthPolicy_update(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "g42cloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s-updated"
+  scaling_policy_type = "SCHEDULED"
+  bandwidth_id        = g42cloud_vpc_bandwidth.test.id
+  cool_down_time      = 900
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 2
+    limits    = 300
+  }
+  scheduled_policy {
+    launch_time = "2099-09-30T12:00Z"
+  }
+}
+`, name)
+}
+
+func testASBandWidthPolicy_recurrence(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "g42cloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s"
+  scaling_policy_type = "RECURRENCE"
+  bandwidth_id        = g42cloud_vpc_bandwidth.test.id
+  cool_down_time      = 600
+
+  scaling_policy_action {
+    operation = "SET"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time      = "07:00"
+    recurrence_type  = "Weekly"
+    recurrence_value = "1,3,5"
+    start_time       = "2022-09-30T12:00Z"
+    end_time         = "2122-12-30T12:00Z"
+  }
+}
+`, name)
+}
+
+func testASBandWidthPolicy_alarm(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "g42cloud_ces_alarmrule" "alarmrule_1" {
+  alarm_name           = "rule-%[1]s"
+  alarm_description    = "autoScaling"
+  alarm_action_enabled = true
+  alarm_enabled        = true
+
+  metric {
+    namespace   = "SYS.VPC"
+    metric_name = "downstream_bandwidth"
+
+    dimensions {
+      name  = "bandwidth_id"
+      value = g42cloud_vpc_bandwidth.test.id
+    }
+  }
+
+  condition  {
+    period              = 300
+    filter              = "max"
+    comparison_operator = ">"
+    value               = 3600
+    unit                = "bit/s"
+    count               = 2
+    suppress_duration   = 300
+  }
+
+  alarm_actions {
+    type              = "autoscaling"
+    notification_list = []
+  }
+}
+
+resource "g42cloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s"
+  scaling_policy_type = "ALARM"
+  bandwidth_id        = g42cloud_vpc_bandwidth.test.id
+  alarm_id            = g42cloud_ces_alarmrule.alarmrule_1.id
+
+  scaling_policy_action {
+    operation = "REDUCE"
+    size      = 2
+    limit     = 300
+  }
+}
+`, name)
+}

--- a/g42cloud/services/acceptance/as/resource_g42cloud_as_instance_attach_test.go
+++ b/g42cloud/services/acceptance/as/resource_g42cloud_as_instance_attach_test.go
@@ -1,0 +1,208 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/instances"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getASInstanceAttachResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	client, err := cfg.AutoscalingV1Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating autoscaling client: %s", err)
+	}
+
+	groupID := state.Primary.Attributes["scaling_group_id"]
+	instanceID := state.Primary.Attributes["instance_id"]
+	page, err := instances.List(client, groupID, nil).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	allInstances, err := page.(instances.InstancePage).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetching instances in AS group %s: %s", groupID, err)
+	}
+
+	for _, ins := range allInstances {
+		if ins.ID == instanceID {
+			return &ins, nil
+		}
+	}
+
+	return nil, fmt.Errorf("can not find the instance %s in AS group %s", instanceID, groupID)
+}
+
+func TestAccASInstanceAttach_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_as_instance_attach.test0"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getASInstanceAttachResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testASInstanceAttach_conf(name, "false", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "scaling_group_id", "g42cloud_as_group.hth_as_group", "id"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id", "g42cloud_compute_instance.test.0", "id"),
+					resource.TestCheckResourceAttr(rName, "protected", "false"),
+					resource.TestCheckResourceAttr(rName, "standby", "false"),
+					resource.TestCheckResourceAttr(rName, "status", "INSERVICE"),
+				),
+			},
+			{
+				Config: testASInstanceAttach_conf(name, "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "protected", "true"),
+					resource.TestCheckResourceAttr(rName, "standby", "false"),
+					resource.TestCheckResourceAttr(rName, "status", "INSERVICE"),
+				),
+			},
+			{
+				Config: testASInstanceAttach_conf(name, "true", "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "protected", "true"),
+					resource.TestCheckResourceAttr(rName, "standby", "true"),
+					resource.TestCheckResourceAttr(rName, "status", "STANDBY"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"append_instance"},
+			},
+		},
+	})
+}
+
+func testAsGroup_base(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "g42cloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "g42cloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "g42cloud_compute_flavors" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+}
+
+resource "g42cloud_networking_secgroup" "secgroup" {
+  name        = "%[1]s"
+  description = "This is a terraform test security group"
+}
+
+resource "g42cloud_compute_keypair" "hth_key" {
+  name       = "%[1]s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_lb_loadbalancer" "loadbalancer_1" {
+  name          = "%[1]s"
+  vip_subnet_id = data.g42cloud_vpc_subnet.test.subnet_id
+}
+
+resource "g42cloud_lb_listener" "listener_1" {
+  name            = "%[1]s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = g42cloud_lb_loadbalancer.loadbalancer_1.id
+}
+
+resource "g42cloud_lb_pool" "pool_1" {
+  name        = "%[1]s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = g42cloud_lb_listener.listener_1.id
+}
+
+resource "g42cloud_as_configuration" "hth_as_config"{
+  scaling_configuration_name = "%[1]s"
+  instance_config {
+    image    = data.g42cloud_images_image.test.id
+    flavor   = data.g42cloud_compute_flavors.test.ids[0]
+    key_name = g42cloud_compute_keypair.hth_key.id
+
+    disk {
+      size        = 40
+      volume_type = "SAS"
+      disk_type   = "SYS"
+    }
+  }
+}
+
+resource "g42cloud_as_group" "hth_as_group"{
+  scaling_group_name       = "%[1]s"
+  scaling_configuration_id = g42cloud_as_configuration.hth_as_config.id
+  vpc_id                   = data.g42cloud_vpc.test.id
+  max_instance_number      = 3
+
+  networks {
+    id = data.g42cloud_vpc_subnet.test.id
+  }
+  security_groups {
+    id = g42cloud_networking_secgroup.secgroup.id
+  }
+  lbaas_listeners {
+    pool_id       = g42cloud_lb_pool.pool_1.id
+    protocol_port = g42cloud_lb_listener.listener_1.protocol_port
+  }
+}
+`, rName)
+}
+
+func testASInstanceAttach_conf(name, protection, standby string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_compute_instance" "test" {
+  count              = 2
+  name               = "%s-${count.index}"
+  description        = "instance for AS attach"
+  image_id           = data.g42cloud_images_image.test.id
+  flavor_id          = data.g42cloud_compute_flavors.test.ids[0]
+  security_group_ids = [g42cloud_networking_secgroup.secgroup.id]
+
+  network {
+    uuid = data.g42cloud_vpc_subnet.test.id
+  }
+}
+
+resource "g42cloud_as_instance_attach" "test0" {
+  scaling_group_id = g42cloud_as_group.hth_as_group.id
+  instance_id      = g42cloud_compute_instance.test[0].id
+  protected        = %[3]s
+  standby          = %[4]s
+}
+`, testAsGroup_base(name), name, protection, standby)
+}

--- a/g42cloud/services/acceptance/as/resource_g42cloud_as_lifecycle_hook_test.go
+++ b/g42cloud/services/acceptance/as/resource_g42cloud_as_lifecycle_hook_test.go
@@ -1,0 +1,182 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccASLifecycleHook_basic(t *testing.T) {
+	var hook lifecyclehooks.Hook
+	rName := acceptance.RandomAccResourceName()
+	resourceGroupName := "g42cloud_as_group.hth_as_group"
+	resourceHookName := "g42cloud_as_lifecycle_hook.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckASLifecycleHookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testASLifecycleHook_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASLifecycleHookExists(resourceGroupName, resourceHookName, &hook),
+					resource.TestCheckResourceAttr(resourceHookName, "name", rName),
+					resource.TestCheckResourceAttr(resourceHookName, "type", "ADD"),
+					resource.TestCheckResourceAttr(resourceHookName, "default_result", "ABANDON"),
+					resource.TestCheckResourceAttr(resourceHookName, "timeout", "3600"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_message", "This is a test message"),
+					resource.TestMatchResourceAttr(resourceHookName, "notification_topic_urn",
+						regexp.MustCompile(fmt.Sprintf(`^(urn:smn:%s:[0-9a-z]{32}:%s)$`, acceptance.G42_REGION_NAME, rName))),
+				),
+			},
+			{
+				Config: testASLifecycleHook_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASLifecycleHookExists(resourceGroupName, resourceHookName, &hook),
+					resource.TestCheckResourceAttr(resourceHookName, "name", rName),
+					resource.TestCheckResourceAttr(resourceHookName, "type", "REMOVE"),
+					resource.TestCheckResourceAttr(resourceHookName, "default_result", "CONTINUE"),
+					resource.TestCheckResourceAttr(resourceHookName, "timeout", "600"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_message", "This is a update message"),
+					resource.TestMatchResourceAttr(resourceHookName, "notification_topic_urn",
+						regexp.MustCompile(fmt.Sprintf(`^(urn:smn:%s:[0-9a-z]{32}:%s-update)$`, acceptance.G42_REGION_NAME, rName))),
+				),
+			},
+			{
+				ResourceName:      resourceHookName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccASLifecycleHookImportStateIdFunc(resourceGroupName, resourceHookName),
+			},
+		},
+	})
+}
+
+func testAccCheckASLifecycleHookDestroy(s *terraform.State) error {
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := conf.AutoscalingV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating autoscaling client: %s", err)
+	}
+
+	var groupID string
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "g42cloud_as_group" {
+			groupID = rs.Primary.ID
+			break
+		}
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "g42cloud_as_lifecycle_hook" {
+			continue
+		}
+
+		_, err := lifecyclehooks.Get(asClient, groupID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("AS lifecycle hook still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckASLifecycleHookExists(resGroup, resHook string, hook *lifecyclehooks.Hook) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resGroup]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resGroup)
+		}
+		groupID := rs.Primary.ID
+
+		rs, ok = s.RootModule().Resources[resHook]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resHook)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		asClient, err := config.AutoscalingV1Client(acceptance.G42_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating autoscaling client: %s", err)
+		}
+		found, err := lifecyclehooks.Get(asClient, groupID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		hook = found
+
+		return nil
+	}
+}
+
+func testAccASLifecycleHookImportStateIdFunc(groupRes, hookRes string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		group, ok := s.RootModule().Resources[groupRes]
+		if !ok {
+			return "", fmt.Errorf("Auto Scaling group not found: %s", group)
+		}
+		hook, ok := s.RootModule().Resources[hookRes]
+		if !ok {
+			return "", fmt.Errorf("Auto Scaling lifecycle hook not found: %s", hook)
+		}
+		if group.Primary.ID == "" || hook.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", group.Primary.ID, hook.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", group.Primary.ID, hook.Primary.ID), nil
+	}
+}
+
+func testASLifecycleHook_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_smn_topic" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_smn_topic" "update" {
+  name = "%s-update"
+}
+`, testAsGroup_base(rName), rName, rName)
+}
+
+func testASLifecycleHook_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_as_lifecycle_hook" "test" {
+  name                   = "%s"
+  type                   = "ADD"
+  scaling_group_id       = g42cloud_as_group.hth_as_group.id
+  notification_topic_urn = g42cloud_smn_topic.test.topic_urn
+  notification_message   = "This is a test message"
+}
+`, testASLifecycleHook_base(rName), rName)
+}
+
+func testASLifecycleHook_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_as_lifecycle_hook" "test" {
+  name                   = "%s"
+  type                   = "REMOVE"
+  scaling_group_id       = g42cloud_as_group.hth_as_group.id
+  default_result         = "CONTINUE"
+  notification_topic_urn = g42cloud_smn_topic.update.topic_urn
+  notification_message   = "This is a update message"
+  timeout                = 600
+}
+`, testASLifecycleHook_base(rName), rName)
+}

--- a/g42cloud/services/acceptance/as/resource_g42cloud_as_notification_test.go
+++ b/g42cloud/services/acceptance/as/resource_g42cloud_as_notification_test.go
@@ -1,0 +1,170 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAsNotificationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getASNotification: Query the AS notification.
+	var (
+		getASNotificationHttpUrl = "autoscaling-api/v1/{project_id}/scaling_notification/{scaling_group_id}"
+		getASNotificationProduct = "autoscaling"
+	)
+	getASNotificationClient, err := cfg.NewServiceClient(getASNotificationProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AutoScaling Client: %s", err)
+	}
+
+	getASNotificationPath := getASNotificationClient.Endpoint + getASNotificationHttpUrl
+	getASNotificationPath = strings.ReplaceAll(getASNotificationPath, "{project_id}",
+		getASNotificationClient.ProjectID)
+	getASNotificationPath = strings.ReplaceAll(getASNotificationPath, "{scaling_group_id}",
+		fmt.Sprintf("%v", state.Primary.Attributes["scaling_group_id"]))
+
+	getASNotificationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getASNotificationResp, err := getASNotificationClient.Request("GET", getASNotificationPath,
+		&getASNotificationOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AS notification: %s", err)
+	}
+
+	getASNotificationRespBody, err := utils.FlattenResponse(getASNotificationResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flatten response: %s", err)
+	}
+	return filterTargetASNotificationByTopicUrn(getASNotificationRespBody, state.Primary.ID)
+}
+
+func filterTargetASNotificationByTopicUrn(resp interface{}, topicUrn string) (interface{}, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("resp cannot be nil")
+	}
+
+	curJson := utils.PathSearch("topics", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	for _, v := range curArray {
+		urn := utils.PathSearch("topic_urn", v, "")
+		if topicUrn == urn.(string) {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("the target AS notification: %s not found", topicUrn)
+}
+
+func TestAccAsNotification_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_as_notification.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAsNotificationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAsNotification_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "events.0", "SCALING_UP"),
+					resource.TestCheckResourceAttrSet(rName, "scaling_group_id"),
+					resource.TestCheckResourceAttrSet(rName, "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				Config: testAsNotification_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "events.0", "SCALING_UP_FAIL"),
+					resource.TestCheckResourceAttr(rName, "events.1", "SCALING_DOWN"),
+					resource.TestCheckResourceAttr(rName, "events.2", "SCALING_DOWN_FAIL"),
+					resource.TestCheckResourceAttr(rName, "events.3", "SCALING_GROUP_ABNORMAL"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAsNotificationImportState(rName),
+			},
+		},
+	})
+}
+
+func testAsNotification_base(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_smn_topic" "topic_1" {
+  name         = "%s"
+  display_name = "The display name of %s"
+}
+
+`, testAsGroup_base(name), name, name)
+}
+
+func testAsNotification_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_as_notification" "test" {
+  scaling_group_id = g42cloud_as_group.hth_as_group.id
+  topic_urn        = g42cloud_smn_topic.topic_1.id
+  events           = ["SCALING_UP"]
+}
+`, testAsNotification_base(name))
+}
+
+func testAsNotification_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_as_notification" "test" {
+  scaling_group_id = g42cloud_as_group.hth_as_group.id
+  topic_urn        = g42cloud_smn_topic.topic_1.id
+  events           = ["SCALING_UP_FAIL","SCALING_DOWN","SCALING_DOWN_FAIL", "SCALING_GROUP_ABNORMAL"]
+}
+`, testAsNotification_base(name))
+}
+
+func testAsNotificationImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		var scalingGroupID, topicUrn string
+		if scalingGroupID = rs.Primary.Attributes["scaling_group_id"]; scalingGroupID == "" {
+			return "", fmt.Errorf("attribute (scaling_group_id) of Resource (%s) not found: %s", name, rs)
+		}
+		if topicUrn = rs.Primary.Attributes["topic_urn"]; topicUrn == "" {
+			return "", fmt.Errorf("attribute (topic_urn) of Resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", scalingGroupID, topicUrn), nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import AS resource, unit test and document

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed


```markdown
### resource_g42cloud_as_bandwidth_policy

=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_basic
--- PASS: TestAccASBandWidthPolicy_basic (89.62s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccASBandWidthPolicy_alarm
=== PAUSE TestAccASBandWidthPolicy_alarm
=== CONT  TestAccASBandWidthPolicy_alarm
--- PASS: TestAccASBandWidthPolicy_alarm (49.02s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```markdown
### resource_g42cloud_as_instance_acctach

=== RUN   TestAccASInstanceAttach_basic
=== PAUSE TestAccASInstanceAttach_basic
=== CONT  TestAccASInstanceAttach_basic
--- PASS: TestAccASInstanceAttach_basic (320.64s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...

```


```markdown
### resource_g42cloud_as_lifecycle_hook

=== RUN   TestAccASLifecycleHook_basic
=== PAUSE TestAccASLifecycleHook_basic
=== CONT  TestAccASLifecycleHook_basic
--- PASS: TestAccASLifecycleHook_basic (252.43s)
PASS
coverage: 7.1% of statements in ../../../../../terraform-provider-g42cloud/...

```


```markdown
### resource_g42cloud_as_notification

=== RUN   TestAccAsNotification_basic
=== PAUSE TestAccAsNotification_basic
=== CONT  TestAccAsNotification_basic
--- PASS: TestAccAsNotification_basic (161.15s)

PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```markdown
### data_source_g42cloud_as_configurtions

=== RUN   TestAccDataSourceASConfiguration_basic
=== PAUSE TestAccDataSourceASConfiguration_basic
=== CONT  TestAccDataSourceASConfiguration_basic
--- PASS: TestAccDataSourceASConfiguration_basic (43.79s)
PASS
coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```markdown
### data_source_g42cloud_as_groups
Some dict values of the `status` field can not test

=== RUN   TestAccDataSourceASGroup_basic
=== PAUSE TestAccDataSourceASGroup_basic
=== CONT  TestAccDataSourceASGroup_basic
--- PASS: TestAccDataSourceASGroup_basic (127.15s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

