### PR TITLE
feat(CCE): import CCE resource, unit test and document

### DIFF
--- a/docs/data-sources/cce_clusters.md
+++ b/docs/data-sources/cce_clusters.md
@@ -1,0 +1,135 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud_cce_clusters
+
+Use this data source to get a list of CCE clusters.
+
+## Example Usage
+
+```hcl
+variable "cluster_name" {}
+
+data "g42cloud_cce_clusters" "clusters" {
+  name   = var.cluster_name
+  status = "Available"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the CCE clusters. If omitted, the
+  provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the cluster.
+
+* `cluster_id` - (Optional, String) Specifies the ID of the cluster.
+
+* `cluster_type` - (Optional, String) Specifies the type of the cluster. Possible values: **VirtualMachine**.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID to which the cluster belongs.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the cluster.
+
+* `status` - (Optional, String) Specifies the status of the cluster.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `ids` - Indicates a list of IDs of all CCE clusters found.
+
+* `clusters` - Indicates a list of CCE clusters found. The [clusters](#cce_clusters) object structure is documented
+  below.
+
+<a name="cce_clusters"></a>
+The `clusters` block supports:
+
+* `name` - The name of the cluster.
+
+* `id` - The ID of the cluster.
+
+* `cluster_type` - The type of the cluster. Possible values: **VirtualMachine**.
+
+* `status` - The status of the cluster.
+
+* `flavor_id` - The specification of the cluster.
+
+* `cluster_version` - The version of the cluster.
+
+* `description` - The description of the cluster.
+
+* `billing_mode` - The charging mode of the cluster.
+
+* `container_network_cidr` - The container network segment.
+
+* `container_network_type` - The container network type: **overlay_l2** , **underlay_ipvlan**, **vpc-router** or **eni**.
+
+* `eni_subnet_id` - The **IPv4 subnet ID** of the subnet where the ENI resides.
+
+* `eni_subnet_cidr` - The ENI network segment.
+
+* `service_network_cidr` - The service network segment.
+
+* `authentication_mode` - The authentication mode of the cluster, possible values are x509 and rbac. Defaults to **rbac**.
+
+* `masters` - The advanced configuration of master nodes. The [masters](#cce_masters) object structure
+  is documented below.
+
+* `security_group_id` - The security group ID of the cluster.
+
+* `vpc_id` - The vpc ID of the cluster.
+
+* `subnet_id` - The ID of the subnet used to create the node.
+
+* `highway_subnet_id` - The ID of the high speed network used to create bare metal nodes.
+
+* `enterprise_project_id` - The enterprise project ID of the CCE cluster.
+
+* `endpoints` - The access addresses of kube-apiserver in the cluster. The [endpoints](#cce_endpoints) object structure
+  is documented below.
+
+* `certificate_clusters` - The certificate clusters. The [certificate_clusters](#cce_certificate_clusters) object
+  structure is documented below.
+
+* `certificate_users` - The certificate users. The [endpoints](#cce_certificate_users) object structure
+  is documented below.
+
+* `kube_config_raw` - The raw Kubernetes config to be used by kubectl and other compatible tools.
+
+<a name="cce_masters"></a>
+The `masters` block supports:
+
+* `availability_zone` - The availability zone (AZ) of the master node.
+
+<a name="cce_endpoints"></a>
+The `endpoints` block supports:
+
+* `url` - The URL of the cluster access address.
+
+* `type` - The type of the cluster access address.
+  + **Internal**: The user's subnet access address.
+  + **External**: The public network access address.
+
+<a name="cce_certificate_clusters"></a>
+The `certificate_clusters` block supports:
+
+* `name` - The cluster name.
+
+* `server` - The server IP address.
+
+* `certificate_authority_data` - The certificate data.
+
+<a name="cce_certificate_users"></a>
+The `certificate_users` block supports:
+
+* `name` - The username.
+
+* `client_certificate_data` - The client certificate data.
+
+* `client_key_data` - The client key data.

--- a/docs/data-sources/cce_nodes.md
+++ b/docs/data-sources/cce_nodes.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud_cce_nodes
+
+Use this data source to get a list of CCE nodes.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "node_name" {}
+
+data "g42cloud_cce_nodes" "node" {
+  cluster_id = var.cluster_id
+  name       = var.node_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the CCE nodes. If omitted, the provider-level
+  region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of CCE cluster.
+
+* `name` - (Optional, String) Specifies the of the node.
+
+* `node_id` - (Optional, String) Specifies the ID of the node.
+
+* `status` - (Optional, String) Specifies the status of the node.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `ids` - Indicates a list of IDs of all CCE nodes found.
+
+* `nodes` - Indicates a list of CCE nodes found. The [nodes](#cce_nodes) object structure is documented below.
+
+<a name="cce_nodes"></a>
+The `nodes` block supports:
+
+* `name` - The name of the node.
+
+* `id` - The ID of the node.
+
+* `status` - The state of the node.
+
+* `flavor_id` - The flavor ID to be used.
+
+* `availability_zone` - The available partitions where the node is located.
+
+* `os` - The operating System of the node.
+
+* `subnet_id` - The ID of the subnet to which the NIC belongs.
+
+* `ecs_group_id` - The ID of ECS group to which the node belongs.
+
+* `tags` - The tags of a VM node, key/value pair format.
+
+* `key_pair` - The key pair name when logging in to select the key pair mode.
+
+* `billing_mode` - The node's billing mode: The value is 0 (on demand).
+
+* `server_id` - The node's virtual machine ID in ECS.
+
+* `public_ip` - The elastic IP parameters of the node.
+
+* `private_ip` - The private IP of the node.
+
+* `root_volume` - The system disk related configuration. The [root_volume](#cce_node) object structure is
+  documented below.
+
+* `data_volumes` - The data related configuration. The [data_volumes](#cce_node) object structure is documented below.
+
+<a name="cce_node"></a>
+The `root_volume` and `data_volumes` blocks support:
+
+* `size` - Disk size in GB.
+
+* `volumetype` - Disk type.
+
+* `extend_params` - Disk expansion parameters.

--- a/docs/resources/cce_namespace.md
+++ b/docs/resources/cce_namespace.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud_cce_namespace
+
+Manages a CCE namespace resource within G42Cloud.
+
+## Example Usage
+
+### Basic
+
+```hcl
+variable "cluster_id" {}
+
+resource "g42cloud_cce_namespace" "test" {
+  cluster_id = var.cluster_id
+  name       = "test-namespace"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the namespace resource.
+  If omitted, the provider-level region will be used. Changing this will create a new namespace resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the cluster ID to which the CCE namespace belongs.
+  Changing this will create a new namespace resource.
+
+* `name` - (Optional, String, ForceNew) Specifies the unique name of the namespace.
+  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and hyphens (-),
+  and must start and end with lowercase letters and digits. Changing this will create a new namespace resource.
+  Exactly one of `name` or `prefix` must be provided.
+
+* `prefix` - (Optional, String, ForceNew) Specifies a prefix used by the server to generate a unique name.
+  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and
+  hyphens (-), and must start and end with lowercase letters and digits.
+  Changing this will create a new namespace resource. Exactly one of `name` or `prefix` must be provided.
+
+* `annotations` - (Optional, Map, ForceNew) Specifies an unstructured key value map for external parameters.
+  Changing this will create a new namespace resource.
+
+* `labels` - (Optional, Map, ForceNew) Specifies the map of string keys and values for labels.
+  Changing this will create a new namespace resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The namespace ID in UUID format.
+
+* `creation_timestamp` - The server time when namespace was created.
+
+* `status` - The current phase of the namespace.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `delete` - Default is 5 minutes.
+
+## Import
+
+CCE namespace can be imported using the cluster ID and namespace name separated by a slash, e.g.:
+
+```shell
+terraform import g42cloud_cce_namespace.test bb6923e4-b16e-11eb-b0cd-0255ac101da1/test-namespace
+```

--- a/docs/resources/cce_pvc.md
+++ b/docs/resources/cce_pvc.md
@@ -1,0 +1,157 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# g42cloud_cce_pvc
+
+Manages a CCE Persistent Volume Claim resource within G42Cloud.
+
+## Example Usage
+
+### Create PVC with EVS
+
+```hcl
+variable "cluster_id" {}
+variable "namespace" {}
+variable "pvc_name" {}
+
+resource "g42cloud_cce_pvc" "test" {
+  cluster_id = var.cluster_id
+  namespace  = var.namespace
+  name       = var.pvc_name
+
+  annotations = {
+    "everest.io/disk-volume-type" = "SSD"
+  }
+
+  storage_class_name = "csi-disk"
+  access_modes       = ["ReadWriteOnce"]
+  storage            = "10Gi"
+}
+```
+
+### Create PVC with OBS
+
+```hcl
+variable "cluster_id" {}
+variable "namespace" {}
+variable "pvc_name" {}
+
+resource "g42cloud_cce_pvc" "test" {
+  cluster_id = var.cluster_id
+  namespace  = var.namespace
+  name       = var.pvc_name
+
+  annotations = {
+    "everest.io/obs-volume-type" = "STANDARD"
+    "csi.storage.k8s.io/fstype"  = "obsfs"
+  }
+
+  storage_class_name = "csi-obs"
+  access_modes       = ["ReadWriteMany"]
+  storage            = "1Gi"
+}
+```
+
+### Create PVC with SFS
+
+```hcl
+variable "cluster_id" {}
+variable "namespace" {}
+variable "pvc_name" {}
+
+resource "g42cloud_cce_pvc" "test" {
+  cluster_id         = var.cluster_id
+  namespace          = var.namespace
+  name               = var.pvc_name
+  storage_class_name = "csi-nas"
+  access_modes       = ["ReadWriteMany"]
+  storage            = "10Gi"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the PVC resource.
+  If omitted, the provider-level region will be used. Changing this will create a new PVC resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the cluster ID to which the CCE PVC belongs.
+  Changing this will create a new PVC resource.
+
+* `namespace` - (Required, String, ForceNew) Specifies the namespace to logically divide your containers into different
+  group. Changing this will create a new PVC resource.
+
+* `name` - (Required, String, ForceNew) Specifies the unique name of the PVC resource. This parameter can contain a
+  maximum of 63 characters, which may consist of lowercase letters, digits and hyphens (-), and must start and end with
+  lowercase letters and digits. Changing this will create a new PVC resource.
+
+* `annotations` - (Optional, Map, ForceNew) Specifies the unstructured key value map for external parameters.
+  Changing this will create a new PVC resource.
+
+* `labels` - (Optional, Map, ForceNew) Specifies the map of string keys and values for labels.
+  Changing this will create a new PVC resource.
+
+* `storage_class_name` - (Required, String, ForceNew) Specifies the type of the storage bound to the CCE PVC.
+  The valid values are as follows:
+    + **csi-disk**: EVS.
+    + **csi-obs**: OBS.
+  
+  Changing this will create a new PVC resource.
+
+* `access_modes` - (Required, List, ForceNew) Specifies the desired access modes the volume should have.
+  The valid values are as follows:
+    + **ReadWriteOnce**: The volume can be mounted as read-write by a single node.
+    + **ReadOnlyMany**: The volume can be mounted as read-only by many nodes.
+    + **ReadWriteMany**: The volume can be mounted as read-write by many nodes.
+
+  Changing this will create a new PVC resource.
+
+* `storage` - (Required, String, ForceNew) Specifies the minimum amount of storage resources required.
+  Changing this creates a new PVC resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The PVC ID in UUID format.
+
+* `creation_timestamp` - The server time when PVC was created.
+
+* `status` - The current phase of the PVC.
+    + **Pending**: Not yet bound.
+    + **Bound**: Already bound.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `delete` - Default is 3 minutes.
+
+## Import
+
+CCE PVC can be imported using the cluster ID, namespace and ID separated by slashes, e.g.
+
+```shell
+terraform import g42cloud_cce_pvc.test 5c20fdad-7288-11eb-b817-0255ac10158b/default/fa540f3b-12d9-40e5-8268-04bcfed95a46
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `annotations`.
+It is generally recommended running `terraform plan` after importing a PVC.
+You can then decide if changes should be applied to the PVC, or the resource
+definition should be updated to align with the PVC. Also, you can ignore changes as below.
+
+```
+resource "g42cloud_cce_pvc" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      annotations,
+    ]
+  }
+}
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -194,10 +194,12 @@ func Provider() *schema.Provider {
 
 			"g42cloud_cbr_vaults": cbr.DataSourceVaults(),
 
-			"g42cloud_cce_cluster":        cce.DataSourceCCEClusterV3(),
-			"g42cloud_cce_node":           cce.DataSourceNode(),
 			"g42cloud_cce_addon_template": cce.DataSourceAddonTemplate(),
+			"g42cloud_cce_cluster":        cce.DataSourceCCEClusterV3(),
+			"g42cloud_cce_clusters":       cce.DataSourceCCEClusters(),
+			"g42cloud_cce_node":           cce.DataSourceNode(),
 			"g42cloud_cce_node_pool":      cce.DataSourceCCENodePoolV3(),
+			"g42cloud_cce_nodes":          cce.DataSourceNodes(),
 
 			"g42cloud_compute_flavors":      ecs.DataSourceEcsFlavors(),
 			"g42cloud_compute_instance":     ecs.DataSourceComputeInstance(),
@@ -306,10 +308,12 @@ func Provider() *schema.Provider {
 			"g42cloud_cbr_policy": cbr.ResourcePolicy(),
 			"g42cloud_cbr_vault":  cbr.ResourceVault(),
 
-			"g42cloud_cce_cluster":   cce.ResourceCCEClusterV3(),
-			"g42cloud_cce_node":      cce.ResourceNode(),
 			"g42cloud_cce_addon":     cce.ResourceAddon(),
+			"g42cloud_cce_cluster":   cce.ResourceCluster(),
+			"g42cloud_cce_namespace": cce.ResourceCCENamespaceV1(),
 			"g42cloud_cce_node_pool": cce.ResourceNodePool(),
+			"g42cloud_cce_node":      cce.ResourceNode(),
+			"g42cloud_cce_pvc":       cce.ResourceCcePersistentVolumeClaimsV1(),
 
 			"g42cloud_ces_alarmrule": ces.ResourceAlarmRule(),
 

--- a/g42cloud/services/acceptance/cce/data_source_g42cloud_cce_clusters_test.go
+++ b/g42cloud/services/acceptance/cce/data_source_g42cloud_cce_clusters_test.go
@@ -1,0 +1,44 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccCCEClustersDataSource_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_cce_clusters.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClustersDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "clusters.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "clusters.0.status", "Available"),
+					resource.TestCheckResourceAttr(dataSourceName, "clusters.0.cluster_type", "VirtualMachine"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCEClustersDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cce_clusters" "test" {
+  name = g42cloud_cce_cluster.test.name
+
+  depends_on = [g42cloud_cce_cluster.test]
+}
+`, testAccCCEClusterV3_base(rName))
+}

--- a/g42cloud/services/acceptance/cce/data_source_g42cloud_cce_nodes_test.go
+++ b/g42cloud/services/acceptance/cce/data_source_g42cloud_cce_nodes_test.go
@@ -1,0 +1,43 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNodesDataSource_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_cce_nodes.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodesDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "nodes.0.name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccNodesDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_cce_nodes" "test" {
+  cluster_id = g42cloud_cce_cluster.test.id
+  name       = g42cloud_cce_node.test.name
+
+  depends_on = [g42cloud_cce_node.test]
+}
+`, testAccCCENodeV3_base(rName))
+}

--- a/g42cloud/services/acceptance/cce/resource_g42cloud_cce_namespace_test.go
+++ b/g42cloud/services/acceptance/cce/resource_g42cloud_cce_namespace_test.go
@@ -1,0 +1,204 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v1/namespaces"
+)
+
+func getNamespaceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CceV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating G42Cloud CCE v1 client: %s", err)
+	}
+	resp, err := namespaces.Get(c, state.Primary.Attributes["cluster_id"],
+		state.Primary.Attributes["name"]).Extract()
+	if resp == nil && err == nil {
+		return resp, fmt.Errorf("Unable to find the namespace (%s)", state.Primary.ID)
+	}
+	return resp, err
+}
+
+func TestAccCCENamespaceV1_basic(t *testing.T) {
+	var namespace namespaces.Namespace
+	resourceName := "g42cloud_cce_namespace.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&namespace,
+		getNamespaceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENamespaceV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${g42cloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCENamespaceImportStateIdFunc(randName),
+			},
+		},
+	})
+}
+
+func TestAccCCENamespaceV1_generateName(t *testing.T) {
+	var namespace namespaces.Namespace
+	resourceName := "g42cloud_cce_namespace.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&namespace,
+		getNamespaceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENamespaceV1_generateName(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${g42cloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "prefix", randName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(fmt.Sprintf(`^%s[a-z0-9-]*`, randName))),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCENamespaceImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var clusterID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "g42cloud_cce_cluster" {
+				clusterID = rs.Primary.ID
+			}
+		}
+		if clusterID == "" || name == "" {
+			return "", fmtp.Errorf("resource not found: %s/%s", clusterID, name)
+		}
+		return fmt.Sprintf("%s/%s", clusterID, name), nil
+
+	}
+}
+
+func testAccCCEClusterV3_base(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/16"
+  gateway_ip = "192.168.0.1"
+
+  //dns is required for cce node installing
+  primary_dns   = "100.125.3.250"
+  secondary_dns = "100.125.3.92"
+  vpc_id        = g42cloud_vpc.test.id
+}
+
+resource "g42cloud_cce_cluster" "test" {
+  name                   = "%[1]s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = g42cloud_vpc.test.id
+  subnet_id              = g42cloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+
+`, rName)
+}
+
+func testAccCCENodeV3_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_compute_keypair" "test" {
+  name       = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "g42cloud_cce_node" "test" {
+  cluster_id        = g42cloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "c7n.large.2"
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  key_pair          = g42cloud_compute_keypair.test.name
+  os                = "CentOS 7.6"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccCCEClusterV3_base(rName), rName, rName)
+}
+
+func testAccCCENamespaceV1_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_namespace" "test" {
+  cluster_id = g42cloud_cce_cluster.test.id
+  name       = "%s"
+}
+`, testAccCCEClusterV3_base(rName), rName)
+}
+
+func testAccCCENamespaceV1_generateName(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_namespace" "test" {
+  cluster_id = g42cloud_cce_cluster.test.id
+  prefix     = "%s"
+}
+`, testAccCCEClusterV3_base(rName), rName)
+}

--- a/g42cloud/services/acceptance/cce/resource_g42cloud_cce_pvc_test.go
+++ b/g42cloud/services/acceptance/cce/resource_g42cloud_cce_pvc_test.go
@@ -1,0 +1,158 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v1/persistentvolumeclaims"
+)
+
+func getPvcResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CceV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating G42Cloud CCE v1 client: %s", err)
+	}
+	resp, err := cce.GetCcePvcInfoById(c, state.Primary.Attributes["cluster_id"],
+		state.Primary.Attributes["namespace"], state.Primary.ID)
+	if resp == nil && err == nil {
+		return resp, fmt.Errorf("Unable to find the persistent volume claim (%s)", state.Primary.ID)
+	}
+	return resp, err
+}
+
+func TestAccCcePersistentVolumeClaimsV1_basic(t *testing.T) {
+	var pvc persistentvolumeclaims.PersistentVolumeClaim
+	resourceName := "g42cloud_cce_pvc.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pvc,
+		getPvcResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcePersistentVolumeClaimsV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${g42cloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "default"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "storage_class_name", "csi-disk"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCEPVCImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"annotations",
+				},
+			},
+		},
+	})
+}
+
+func TestAccCcePersistentVolumeClaimsV1_obs(t *testing.T) {
+	var pvc persistentvolumeclaims.PersistentVolumeClaim
+	resourceName := "g42cloud_cce_pvc.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pvc,
+		getPvcResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcePersistentVolumeClaimsV1_obs(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "cluster_id",
+						"${g42cloud_cce_cluster.test.id}"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "default"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "storage_class_name", "csi-obs"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCEPVCImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		cluster, ok := s.RootModule().Resources["g42cloud_cce_cluster.test"]
+		if !ok {
+			return "", fmt.Errorf("Cluster not found: %s", cluster)
+		}
+		pvc, ok := s.RootModule().Resources["g42cloud_cce_pvc.test"]
+		if !ok {
+			return "", fmt.Errorf("PVC not found: %s", pvc)
+		}
+		if cluster.Primary.ID == "" || pvc.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", cluster.Primary.ID, pvc.Primary.ID)
+		}
+		return fmt.Sprintf("%s/default/%s", cluster.Primary.ID, pvc.Primary.ID), nil
+	}
+}
+
+func testAccCcePersistentVolumeClaimsV1_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_pvc" "test" {
+  cluster_id  = g42cloud_cce_cluster.test.id
+  namespace   = "default"
+  name        = "%s"
+  annotations = {
+    "everest.io/disk-volume-type" = "SSD"
+  }
+  storage_class_name = "csi-disk"
+  access_modes       = ["ReadWriteOnce", "ReadOnlyMany"]
+  storage            = "10Gi"
+}
+`, testAccCCENodeV3_base(rName), rName)
+}
+
+func testAccCcePersistentVolumeClaimsV1_obs(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_cce_pvc" "test" {
+  cluster_id  = g42cloud_cce_cluster.test.id
+  namespace   = "default"
+  name        = "%s"
+  annotations = {
+    "everest.io/obs-volume-type" = "STANDARD"
+    "csi.storage.k8s.io/fstype"  =  "obsfs"
+  }
+  storage_class_name = "csi-obs"
+  access_modes       = ["ReadWriteMany"]
+  storage            = "1Gi"
+}
+`, testAccCCENodeV3_base(rName), rName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import CCE resource, unit test and document

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed


```markdown
### resource_g42cloud_cce_namespace

=== RUN   TestAccCCENamespaceV1_basic
=== PAUSE TestAccCCENamespaceV1_basic
=== CONT  TestAccCCENamespaceV1_basic
--- PASS: TestAccCCENamespaceV1_basic (566.04s)

PASS

coverage: 14.1% of statements in ../../../../../terraform-provider-g42cloud/...
```


```markdown
### resource_g42cloud_cce_pvc

=== RUN   TestAccCcePersistentVolumeClaimsV1_basic
=== PAUSE TestAccCcePersistentVolumeClaimsV1_basic
=== CONT  TestAccCcePersistentVolumeClaimsV1_basic
--- PASS: TestAccCcePersistentVolumeClaimsV1_basic (807.23s)
PASS

coverage: 14.1% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccCcePersistentVolumeClaimsV1_obs
=== PAUSE TestAccCcePersistentVolumeClaimsV1_obs
=== CONT  TestAccCcePersistentVolumeClaimsV1_obs
--- PASS: TestAccCcePersistentVolumeClaimsV1_obs (781.48s)
PASS

coverage: 14.1% of statements in ../../../../../terraform-provider-g42cloud/...



```


```markdown
### data_source_g42cloud_cce_clusters

=== RUN   TestAccCCEClustersDataSource_basic
=== PAUSE TestAccCCEClustersDataSource_basic
=== CONT  TestAccCCEClustersDataSource_basic
--- PASS: TestAccCCEClustersDataSource_basic (499.55s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```markdown
### data_source_g42cloud_cce_nodes

=== RUN   TestAccNodesDataSource_basic
=== PAUSE TestAccNodesDataSource_basic
=== CONT  TestAccNodesDataSource_basic
--- PASS: TestAccNodesDataSource_basic (805.10s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```



