### PR TITLE
feat(EVS): add a data source to query a list of EVS volumes

### DIFF
--- a/docs/data-sources/evs_volumes.md
+++ b/docs/data-sources/evs_volumes.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+---
+
+# g42cloud_evs_volumes
+
+Use this data source to query the detailed information list of the EVS disks within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "target_server" {}
+
+data "g42cloud_evs_volumes" "test" {
+  server_id = var.target_server
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the disk list.
+  If omitted, the provider-level region will be used.
+
+* `availability_zone` - (Optional, String) Specifies the availability zone for the disks.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID for filtering.
+
+* `shareable` - (Optional, Bool) Specifies whether the disk is shareable.
+
+* `server_id` - (Optional, String) Specifies the server ID to which the disks are attached.
+
+* `status` - (Optional, String) Specifies the disk status. The valid values are as following:
+  + **FREEZED**
+  + **BIND_ERROR**
+  + **BINDING**
+  + **PENDING_DELETE**
+  + **PENDING_CREATE**
+  + **NOTIFYING**
+  + **NOTIFY_DELETE**
+  + **PENDING_UPDATE**
+  + **DOWN**
+  + **ACTIVE**
+  + **ELB**
+  + **ERROR**
+  + **VPN**
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired disk.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A data source ID in hashcode format.
+
+* `volumes` - The detailed information of the disks. Structure is documented below.
+
+The `volumes` block supports:
+
+* `id` - The resource ID of EVS disk, in UUID format.
+
+* `attachments` - The disk attachment information. Structure is documented below.
+
+* `availability_zone` - The availability zone of the disk.
+
+* `bootable` - Whether the disk is bootable.
+
+* `description` - The disk description.
+
+* `volume_type` - The disk type. Valid values are as follows:
+  + **SAS**: High I/O type.
+  + **SSD**: Ultra-high I/O type.
+  + **GPSSD**: General purpose SSD type.
+  + **ESSD**: Extreme SSD type.
+  + **GPSSD2**: General purpose SSD V2 type.
+  + **ESSD2**: Extreme SSD V2 type.
+
+* `iops` - the IOPS(Input/Output Operations Per Second) of the volume. Only valid when `volume_type` is **GPSSD2** or
+  **ESSD2**.
+
+* `throughput` - The throughput of the system disk. Only valid when `volume_type` is **GPSSD2**.
+
+* `enterprise_project_id` - The ID of the enterprise project associated with the disk.
+
+* `name` - The disk name.
+
+* `service_type` - The service type, such as EVS, DSS or DESS.
+
+* `shareable` - Whether the disk is shareable.
+
+* `size` - The disk size, in GB.
+
+* `status` - The disk status.
+
+* `create_at` - The time when the disk was created.
+
+* `update_at` - The time when the disk was updated.
+
+* `tags` - The disk tags.
+
+* `wwn` - The unique identifier used when attaching the disk.
+
+The `attachments` block supports:
+
+* `id` - The ID of the attached resource in UUID format.
+
+* `attached_at` - The time when the disk was attached.
+
+* `attached_mode` - The ID of the attachment information.
+
+* `device_name` - The device name to which the disk is attached.
+
+* `server_id` - The ID of the server to which the disk is attached.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -215,6 +215,8 @@ func Provider() *schema.Provider {
 
 			"g42cloud_dds_flavors": dds.DataSourceDDSFlavorV3(),
 
+			"g42cloud_evs_volumes": evs.DataSourceEvsVolumesV2(),
+
 			"g42cloud_kms_key":      dew.DataSourceKmsKey(),
 			"g42cloud_kms_data_key": dew.DataSourceKmsDataKeyV1(),
 

--- a/g42cloud/services/acceptance/evs/data_source_g42cloud_evs_volumes_test.go
+++ b/g42cloud/services/acceptance/evs/data_source_g42cloud_evs_volumes_test.go
@@ -1,0 +1,106 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/common"
+)
+
+func TestAccEvsVolumesDataSource_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_evs_volumes.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	rName := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolumesDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "volumes.#", "5"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEvsVolumesDataSource_base(rName string) string {
+	return fmt.Sprintf(`
+variable "volume_configuration" {
+  type = list(object({
+    suffix      = string
+    size        = number
+    device_type = string
+    multiattach = bool
+  }))
+  default = [
+    {suffix = "vbd_normal_volume", size = 100, device_type = "VBD", multiattach = false},
+    {suffix = "vbd_share_volume", size = 100, device_type = "VBD", multiattach = true},
+    {suffix = "scsi_normal_volume", size = 100, device_type = "SCSI", multiattach = false},
+    {suffix = "scsi_share_volume", size = 100, device_type = "SCSI", multiattach = true},
+  ]
+}
+
+%[1]s
+
+resource "g42cloud_compute_instance" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  name              = "%[2]s"
+  image_id          = data.g42cloud_images_image.test.id
+  flavor_id         = "m6.large.8"
+
+  system_disk_type = "SSD"
+  system_disk_size = 50
+
+  security_group_ids = [
+    g42cloud_networking_secgroup.test.id
+  ]
+
+  network {
+    uuid = g42cloud_vpc_subnet.test.id
+  }
+}
+
+resource "g42cloud_evs_volume" "test" {
+  count = length(var.volume_configuration)
+  
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  volume_type       = "SAS"
+  name              = "%[2]s_${var.volume_configuration[count.index].suffix}"
+  size              = var.volume_configuration[count.index].size
+  device_type       = var.volume_configuration[count.index].device_type
+  multiattach       = var.volume_configuration[count.index].multiattach
+
+  tags = {
+    index = tostring(count.index)
+  }
+}
+
+resource "g42cloud_compute_volume_attach" "test" {
+  count = length(g42cloud_evs_volume.test)
+
+  instance_id = g42cloud_compute_instance.test.id
+  volume_id   = g42cloud_evs_volume.test[count.index].id
+}
+`, common.TestBaseComputeResources(rName), rName)
+}
+
+func testAccEvsVolumesDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_evs_volumes" "test" {
+  depends_on = [g42cloud_compute_volume_attach.test]
+
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  server_id         = g42cloud_compute_instance.test.id
+  status            = "in-use"
+}
+`, testAccEvsVolumesDataSource_base(rName))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
transfer resource from huawei provider to G42 provider

**Which issue this PR fixes**:

import evs resource and add unit test and docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccEvsVolumesDataSource_basic
=== PAUSE TestAccEvsVolumesDataSource_basic
=== CONT  TestAccEvsVolumesDataSource_basic
--- PASS: TestAccEvsVolumesDataSource_basic (406.82s)
PASS
```
