### PR TITLE
feat(DDS): import DDS resource, unit test and document

### DIFF
--- a/docs/data-sources/dds_instances.md
+++ b/docs/data-sources/dds_instances.md
@@ -1,0 +1,116 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# g42cloud_dds_instances
+
+Use this data source to get the list of DDS instances.
+
+## Example Usage
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+data "g42cloud_dds_instances" "test" {
+  name      = "test_name"
+  mode      = "Sharding"
+  vpc_id    = var.vpc_id
+  subnet_id = var.subnet_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the DB instance name.
+
+* `mode` - (Optional, String) Specifies the mode of the database instance.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID.
+
+* `subnet_id` - (Optional, String) Specifies the subnet Network ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `instances` - Indicates the list of DDS instances.
+  The [instances](#dds_instances) object structure is documented below.
+
+<a name="dds_instances"></a>
+The `instances` block supports:
+
+* `id` - Indicates the ID of the instance.
+
+* `name` - Indicates the DB instance name.
+
+* `ssl` - Indicates whether to enable or disable SSL.
+
+* `port` - Indicates the database port number. The port range is 2100 to 9500.
+
+* `datastore` - Indicates database information.
+  The [datastore](#dds_datastore) object structure is documented below.
+
+* `backup_strategy` - Indicates the database information.
+  The [backup_strategy](#dds_backup_strategy) object structure is documented below.
+
+* `vpc_id` - Indicates the VPC ID
+
+* `subnet_id` - Indicates the subnet Network ID.
+
+* `security_group_id` - Indicates the security group ID of the DDS instance.
+
+* `disk_encryption_id` - Indicates the disk encryption ID of the instance.
+
+* `mode` - Specifies the mode of the database instance.
+
+* `db_username` - Indicates the DB Administrator name.
+
+* `status` - Indicates the DB instance status.
+
+* `enterprise_project_id` - Indicates the enterprise project id of the dds instance.
+
+* `nodes` - Indicates the instance nodes information.
+  The [nodes](#dds_nodes) object structure is documented below.
+
+* `tags` - Indicates the key/value pairs to associate with the DDS instance.
+
+<a name="dds_datastore"></a>
+The `datastore` block supports:
+
+* `type` - Indicates the DB engine.
+
+* `version` - Indicates the DB instance version.
+
+* `storage_engine` - Indicates the storage engine of the DB instance.
+
+<a name="dds_backup_strategy"></a>
+The `backup_strategy` block supports:
+
+* `start_time` - Indicates the backup time window.
+
+* `keep_days` - Indicates the number of days to retain the generated backup files.
+
+<a name="dds_nodes"></a>
+The `nodes` block supports:
+
+* `id` - Indicates the node ID.
+
+* `name` - Indicates the node name.
+
+* `role` - Indicates the node role.
+
+* `type` - Indicates the node type.
+
+* `private_ip` - Indicates the private IP address of a node.
+
+* `public_ip` - Indicates the EIP that has been bound on a node.
+
+* `status` - Indicates the node status.

--- a/docs/resources/dds_audit_log_policy.md
+++ b/docs/resources/dds_audit_log_policy.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# g42cloud_dds_audit_log_policy
+
+Manages a DDS audit log policy resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "keep_days" {}
+
+resource "g42cloud_dds_audit_log_policy" "test"{
+  instance_id = var.instance_id
+  keep_days   = var.keep_days
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the DDS instance.
+
+  Changing this parameter will create a new resource.
+
+* `keep_days` - (Required, Int) Specifies the number of days for storing audit logs. The value ranges from 7 to 732.
+
+* `audit_scope` - (Optional, String) Specifies the audit scope.
+  If this parameter is left blank or set to **all**, all audit log policies are enabled.
+  You can enter the database or collection name. Use commas (,) to separate multiple databases
+  or collections. If the name contains a comma (,), add a dollar sign ($) before the comma
+  to distinguish it from the separators. Enter a maximum of 1024 characters. The value
+  cannot contain spaces or the following special characters "[]{}():? The dollar sign ($)
+  can be used only in escape mode.
+
+* `audit_types` - (Optional, List) Specifies the audit type. Value options are **auth**, **insert**, **delete**,
+  **update**, **query** or **command**.
+
+* `reserve_auditlogs` - (Optional, String) Specifies whether the historical audit logs are
+  retained when SQL audit is disabled.
+  + **true**: indicates that historical audit logs are retained when SQL audit is disabled.(default value)
+  + **false**: indicates that existing historical audit logs are deleted when SQL audit is disabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The DDS audit log policy can be imported using the instance ID, e.g.:
+
+```bash
+$ terraform import g42cloud_dds_audit_log.test <instance_id>
+```

--- a/docs/resources/dds_backup.md
+++ b/docs/resources/dds_backup.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# g42cloud_dds_backup
+
+Manages a DDS backup resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "dds_instance_id" {}
+variable "name" {}
+
+resource "g42cloud_dds_backup" "test"{
+  instance_id = var.dds_instance_id
+  name        = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of a DDS instance.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the manual backup name.
+  The value must be 4 to 64 characters in length and start with a letter (from A to Z or from a to z).
+  It is case-sensitive and can contain only letters, digits (from 0 to 9), hyphens (-), and underscores (_).
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the manual backup description.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `instance_name` - Indicates the name of a DDS instance.
+
+* `datastore` - Indicates the database version.
+  The [datastore](#dds_datastore) object structure is documented below.
+
+* `type` - Indicates the backup type. Valid value:
+  + **Manual**: indicates manual full backup.
+
+* `begin_time` - Indicates the start time of the backup. The format is yyyy-mm-dd hh:mm:ss. The value is in UTC format.
+
+* `end_time` - Indicates the end time of the backup. The format is yyyy-mm-dd hh:mm:ss. The value is in UTC format.
+
+* `status` - Indicates the backup status. Valid value:
+  + **BUILDING**: Backup in progress.
+  + **COMPLETED**: Backup completed.
+  + **FAILED**: Backup failed.
+  + **DISABLED**: Backup being deleted.
+
+* `size` - Indicates the backup size in KB.
+
+<a name="dds_datastore"></a>
+The `datastore` block supports:
+
+* `type` - Indicates the DB engine.
+
+* `version` - Indicates the database version. The value can be **4.2**, **4.0**, or **3.4**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The DDS backup can be imported using the instance ID and the backup ID separated by a slash, e.g.:
+
+```shell
+terraform import g42cloud_dds_backup.test 6fb8b99944c7459da32f751f0edea756br02/0ce123456a00f2591fabc00385ff1234
+```

--- a/docs/resources/dds_database_role.md
+++ b/docs/resources/dds_database_role.md
@@ -1,0 +1,106 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# g42cloud_dds_database_role
+
+Manages a database role resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "role_name" {}
+variable "db_name" {}
+variable "owned_role_name" {}
+variable "owned_role_db_name" {}
+
+resource "g42cloud_dds_database_role" "test" {
+  instance_id = var.instance_id
+
+  name    = var.role_name
+  db_name = var.db_name
+
+  roles {
+    name    = var.owned_role_name
+    db_name = var.owned_role_db_name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the DDS instance is located.
+  Changing this parameter will create a new role.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the DDS instance ID to which the role belongs.
+  Changing this parameter will create a new role.
+
+* `name` - (Required, String, ForceNew) Specifies the role name.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. Changing this parameter will create a new role.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which the role belongs.
+  The name can contain `1` to `64` characters, only letters, digits and underscores (_) are allowed.
+  Changing this parameter will create a new role.
+
+  -> After a DDS instances is created, the default database is **admin**.
+
+* `roles` - (Optional, List, ForceNew) Specifies the list of roles owned by the current role.
+  The [roles](#dds_roles) object structure is documented below.
+  Changing this parameter will create a new role.
+
+<a name="dds_roles"></a>
+The `roles` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the name of role owned by the current role.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. Changing this parameter will create a new role.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which this owned role belongs.
+  Changing this parameter will create a new role.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `privileges` - The list of database privileges owned by the current role.
+  The [privileges](#dds_privileges) object structure is documented below.
+
+* `inherited_privileges` - The list of database privileges owned by the current role, includes all privileges
+  inherited by owned roles. The [inherited_privileges](#dds_privileges) object structure is documented below.
+
+<a name="dds_privileges"></a>
+The `privileges` and `inherited_privileges` block supports:
+
+* `resources` - The details of the resource to which the privilege belongs.
+  The [resources](#dds_resources) structure is documented below.
+
+* `actions` - The operation permission list.
+
+<a name="dds_resources"></a>
+The `resources` block supports:
+
+* `collection` - The database collection type.
+
+* `db_name` - The database name.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minutes.
+* `delete` - Default is 2 minutes.
+
+## Import
+
+Database roles can be imported using their `id` (combination of `instance_id`, `db_name` and `name`), separated by a
+slash (/), e.g.
+
+```shell
+terraform import g42cloud_dds_database_role.test &ltinstance_id&gt/&ltdb_name&gt/&ltname&gt
+```

--- a/docs/resources/dds_database_user.md
+++ b/docs/resources/dds_database_user.md
@@ -1,0 +1,129 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# g42cloud_dds_database_user
+
+Manages a database user resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "user_name" {}
+variable "user_password" {}
+variable "owned_role_name" {}
+variable "owned_role_db_name" {}
+
+resource "g42cloud_dds_database_user" "test" {
+  instance_id = var.instance_id
+
+  name     = var.user_name
+  password = var.user_password
+  db_name  = var.db_name
+
+  roles {
+    name    = var.owned_role_name
+    db_name = var.owned_role_db_name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the DDS instance is located.
+  Changing this parameter will create a new user.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the DDS instance ID to which the user belongs.
+  Changing this parameter will create a new user.
+
+* `name` - (Required, String, ForceNew) Specifies the username.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. And cannot use reserved names: **drsFull** or **drsIncremental**.
+  Changing this parameter will create a new user.
+
+* `password` - (Required, String) Specifies the user password.
+  The password content must meet `8` to `32` characters long. And must meet uppercase and lowercase letters,
+  digits, and at least one special character (`~!@#%^*-_=+?`).
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which the user belongs.
+  The name can contain `1` to `64` characters, only letters, digits and underscores (_) are allowed.
+  Changing this parameter will create a new user.
+
+  -> After a DDS instances is created, the default database is **admin**.
+
+* `roles` - (Required, List, ForceNew) Specifies the list of roles owned by the current user.
+  The [roles](#dds_roles) structure is documented below. Changing this parameter will create a new user.
+
+<a name="dds_roles"></a>
+The `roles` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the name of role owned by the current user.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. Changing this parameter will create a new user.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which this owned role belongs.
+  Changing this parameter will create a new user.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `privileges` - The list of database privileges owned by the current user.
+  The [privileges](#dds_database_privileges) structure is documented below.
+
+* `inherited_privileges` - The list of database privileges owned by the current user, includes all privileges
+  inherited by owned roles. The [inherited_privileges](#dds_database_privileges) structure is documented below.
+
+<a name="dds_database_privileges"></a>
+The `privileges` and `inherited_privileges` block supports:
+
+* `resources` - The details of the resource to which the privilege belongs.
+  The [resources](#dds_database_resources) structure is documented below.
+
+* `actions` - The operation permission list.
+
+<a name="dds_database_resources"></a>
+The `resources` block supports:
+
+* `collection` - The database collection type.
+
+* `db_name` - The database name.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minutes.
+* `update` - Default is 2 minutes.
+* `delete` - Default is 2 minutes.
+
+## Import
+
+Database users can be imported using their `id` (combination of `instance_id`, `db_name` and `name`), separated by a
+slash (/), e.g.
+
+```shell
+terraform import g42cloud_dds_database_user.test &ltinstance_id&gt/&ltdb_name&gt/&ltname&gt
+```
+
+Due to security reason, the imported state may not be identical to your resource definition (`password` parameter).
+It is generally recommended running `terraform plan` after importing a user resource.
+You can then decide if changes should be applied to the user, or the resource definition should be updated to align with
+the user. Also, you can ignore changes as below.
+
+```
+resource "g42cloud_dds_database_user" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      password,
+    ]
+  }
+}
+```

--- a/docs/resources/dds_parameter_template.md
+++ b/docs/resources/dds_parameter_template.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# g42cloud_dds_parameter_template
+
+Manages a DDS parameter template resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+variable "parameter_values" {}
+variable "node_type" {}
+variable "node_version" {}
+
+resource "g42cloud_dds_parameter_template" "test"{
+  name             = var.name
+  parameter_values = var.parameter_values
+  node_type        = var.node_type
+  node_version     = var.node_version
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the parameter template name.
+  The value must be 1 to 64 characters, which can contain only letters, digits, hyphens (-),
+  underscores (_), and periods (.).
+
+* `node_type` - (Required, String, ForceNew) Specifies the node type of parameter template node_type. Valid value:
+  + **mongos**: the mongos node type.
+  + **shard**: the shard node type.
+  + **config**: the config node type.
+  + **replica**: the replica node type.
+
+  Changing this parameter will create a new resource.
+
+* `node_version` - (Required, String, ForceNew) Specifies the database version.
+  The value can be **4.2**, **4.0** or **3.4**.
+
+  Changing this parameter will create a new resource.
+
+* `parameter_values` - (Optional, Map) Specifies the mapping between parameter names and parameter values.
+  You can customize parameter values based on the parameters in the default parameter template.
+
+* `description` - (Optional, String) Specifies the parameter template description.
+  The description must consist of a maximum of 256 characters and cannot contain the carriage
+  return character or the following special characters: **>!<"&'=**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `parameters` - Indicates the parameters defined by users based on the default parameter templates.
+  The [parameters](#dds_parameters) object structure is documented below.
+
+<a name="dds_parameters"></a>
+The `parameters` block supports:
+
+* `name` - Indicates the parameter name.
+
+* `value` - Indicates the parameter value.
+
+* `description` - Indicates the parameter description.
+
+* `type` - Indicates the parameter type. The value can be **integer**, **string**, **boolean**, **float**, or **list**.
+
+* `value_range` - Indicates the value range.
+
+* `restart_required` - Indicates whether the instance needs to be restarted.
+  + If the value is **true**, restart is required.
+  + If the value is **false**, restart is not required.
+
+* `readonly` - Indicates whether the parameter is read-only.
+  + If the value is **true**, the parameter is read-only.
+  + If the value is **false**, the parameter is not read-only.
+
+## Import
+
+The DDS parameter template can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_dds_parameter_template.test <tempalate_id>
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -219,7 +219,8 @@ func Provider() *schema.Provider {
 			"g42cloud_ddm_engines": ddm.DataSourceDdmEngines(),
 			"g42cloud_ddm_flavors": ddm.DataSourceDdmFlavors(),
 
-			"g42cloud_dds_flavors": dds.DataSourceDDSFlavorV3(),
+			"g42cloud_dds_flavors":   dds.DataSourceDDSFlavorV3(),
+			"g42cloud_dds_instances": dds.DataSourceDdsInstance(),
 
 			"g42cloud_kms_key":      dew.DataSourceKmsKey(),
 			"g42cloud_kms_data_key": dew.DataSourceKmsDataKeyV1(),
@@ -347,7 +348,12 @@ func Provider() *schema.Provider {
 
 			"g42cloud_dcs_instance": dcs.ResourceDcsInstance(),
 
-			"g42cloud_dds_instance": dds.ResourceDdsInstanceV3(),
+			"g42cloud_dds_audit_log_policy":   dds.ResourceDdsAuditLogPolicy(),
+			"g42cloud_dds_backup":             dds.ResourceDdsBackup(),
+			"g42cloud_dds_database_role":      dds.ResourceDatabaseRole(),
+			"g42cloud_dds_database_user":      dds.ResourceDatabaseUser(),
+			"g42cloud_dds_instance":           dds.ResourceDdsInstanceV3(),
+			"g42cloud_dds_parameter_template": dds.ResourceDdsParameterTemplate(),
 
 			"g42cloud_dli_queue": dli.ResourceDliQueue(),
 

--- a/g42cloud/services/acceptance/dds/data_source_g42cloud_dds_instances_test.go
+++ b/g42cloud/services/acceptance/dds/data_source_g42cloud_dds_instances_test.go
@@ -1,0 +1,98 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDatasourceDdsInstance_basic(t *testing.T) {
+	rName := "data.g42cloud_dds_instances.test"
+	name := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDdsInstance_basic(name, 8800),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "instances.0.name", name),
+					resource.TestCheckResourceAttr(rName, "instances.0.mode", "Sharding"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDdsInstance_base(rName string, port int) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_dds_instance" "test" {
+  name              = "%s"
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+  vpc_id            = g42cloud_vpc.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  security_group_id = g42cloud_networking_secgroup.test.id
+  password          = "Terraform@123"
+  mode              = "Sharding"
+  port              = %d
+
+  datastore {
+    type           = "DDS-Community"
+    version        = "3.4"
+    storage_engine = "wiredTiger"
+  }
+
+  flavor {
+    type      = "mongos"
+    num       = 2
+    spec_code = "dds.mongodb.c6.large.4.mongos"
+  }
+
+  flavor {
+    type      = "shard"
+    num       = 2
+    storage   = "ULTRAHIGH"
+    size      = 20
+    spec_code = "dds.mongodb.c6.large.4.shard"
+  }
+
+  flavor {
+    type      = "config"
+    num       = 1
+    storage   = "ULTRAHIGH"
+    size      = 20
+    spec_code = "dds.mongodb.c6.large.2.config"
+  }
+
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = "8"
+  }
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}`, common.TestBaseNetwork(rName), rName, port)
+}
+
+func testAccDatasourceDdsInstance_basic(name string, port int) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_dds_instances" "test" {
+  name = g42cloud_dds_instance.test.name
+}
+`, testAccDatasourceDdsInstance_base(name, port))
+}

--- a/g42cloud/services/acceptance/dds/resource_g42cloud_dds_audit_log_policy_test.go
+++ b/g42cloud/services/acceptance/dds/resource_g42cloud_dds_audit_log_policy_test.go
@@ -1,0 +1,135 @@
+package dds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDdsAuditLogPolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getAuditLog: Query DDS audit log
+	var (
+		getAuditLogPolicyHttpUrl = "v3/{project_id}/instances/{instance_id}/auditlog-policy"
+		getAuditLogPolicyProduct = "dds"
+	)
+	getAuditLogPolicyClient, err := cfg.NewServiceClient(getAuditLogPolicyProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS Client: %s", err)
+	}
+
+	instanceID := state.Primary.ID
+	getAuditLogPolicyPath := getAuditLogPolicyClient.Endpoint + getAuditLogPolicyHttpUrl
+	getAuditLogPolicyPath = strings.ReplaceAll(getAuditLogPolicyPath, "{project_id}",
+		getAuditLogPolicyClient.ProjectID)
+	getAuditLogPolicyPath = strings.ReplaceAll(getAuditLogPolicyPath, "{instance_id}", instanceID)
+
+	getAuditLogPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	getAuditLogPolicyResp, err := getAuditLogPolicyClient.Request("GET", getAuditLogPolicyPath, &getAuditLogPolicyOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DDS audit log policy: %s", err)
+	}
+
+	getAuditLogPolicyRespBody, err := utils.FlattenResponse(getAuditLogPolicyResp)
+	if err != nil {
+		return nil, err
+	}
+
+	keepDays := utils.PathSearch("keep_days", getAuditLogPolicyRespBody, 0)
+	if keepDays.(float64) == 0 {
+		return nil, fmt.Errorf("the instance %s has no audit log policy", instanceID)
+	}
+
+	return getAuditLogPolicyRespBody, nil
+}
+
+func TestAccDdsAuditLogPolicy_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dds_audit_log_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDdsAuditLogPolicyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDdsAuditLogPolicy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "keep_days", "7"),
+					resource.TestCheckResourceAttr(rName, "audit_types.#", "1"),
+					resource.TestCheckResourceAttr(rName, "audit_types.0", "auth"),
+				),
+			},
+			{
+				Config: testDdsAuditLogPolicy_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "keep_days", "15"),
+					resource.TestCheckResourceAttr(rName, "audit_types.#", "1"),
+					resource.TestCheckResourceAttr(rName, "audit_types.0", "insert"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_id"},
+			},
+		},
+	})
+}
+
+func testDdsAuditLogPolicy_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_dds_audit_log_policy" "test" {
+  instance_id = g42cloud_dds_instance.test.id
+  keep_days   = 7
+
+  audit_types = [
+    "auth"
+  ]
+}
+`, testAccDatasourceDdsInstance_base(name, 8800))
+}
+
+func testDdsAuditLogPolicy_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_dds_audit_log_policy" "test" {
+  instance_id = g42cloud_dds_instance.test.id
+  keep_days   = 15
+  
+  audit_types = [
+    "insert"
+  ]
+}
+`, testAccDatasourceDdsInstance_base(name, 8800))
+}

--- a/g42cloud/services/acceptance/dds/resource_g42cloud_dds_backup_test.go
+++ b/g42cloud/services/acceptance/dds/resource_g42cloud_dds_backup_test.go
@@ -1,0 +1,138 @@
+package dds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDdsBackupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getBackup: Query DDS backup
+	var (
+		getBackupHttpUrl = "v3/{project_id}/backups"
+		getBackupProduct = "dds"
+	)
+	getBackupClient, err := cfg.NewServiceClient(getBackupProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS Client: %s", err)
+	}
+
+	getBackupPath := getBackupClient.Endpoint + getBackupHttpUrl
+	getBackupPath = strings.ReplaceAll(getBackupPath, "{project_id}", getBackupClient.ProjectID)
+
+	instanceId := state.Primary.Attributes["instance_id"]
+	backupId := state.Primary.ID
+	getBackupQueryParams := buildGetBackupQueryParams(instanceId, backupId)
+	getBackupPath += getBackupQueryParams
+
+	getBackupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getBackupResp, err := getBackupClient.Request("GET", getBackupPath, &getBackupOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DdsBackup: %s", err)
+	}
+	getBackupRespBody, err := utils.FlattenResponse(getBackupResp)
+	if err != nil {
+		return nil, err
+	}
+	backups := utils.PathSearch("backups", getBackupRespBody, make([]interface{}, 0)).([]interface{})
+	if len(backups) == 0 {
+		return nil, fmt.Errorf("error get backup by backup ID %s", backupId)
+	}
+
+	return backups[0], nil
+}
+
+func buildGetBackupQueryParams(instanceId, backupId string) string {
+	res := ""
+	if instanceId != "" {
+		res = fmt.Sprintf("%s&instance_id=%v", res, instanceId)
+	}
+	if backupId != "" {
+		res = fmt.Sprintf("%s&backup_id=%v", res, backupId)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func TestAccDdsBackup_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dds_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDdsBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDdsBackup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "this is a test dds instance"),
+					resource.TestCheckResourceAttr(rName, "type", "Manual"),
+					resource.TestCheckResourceAttr(rName, "status", "COMPLETED"),
+					resource.TestCheckResourceAttr(rName, "datastore.0.type", "DDS-Community"),
+					acceptance.TestCheckResourceAttrWithVariable(rName, "instance_name",
+						"${g42cloud_dds_instance.test.name}"),
+					acceptance.TestCheckResourceAttrWithVariable(rName, "datastore.0.version",
+						"${g42cloud_dds_instance.test.datastore.0.version}"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testDdsBackup_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_dds_backup" "test" {
+  instance_id = g42cloud_dds_instance.test.id
+  name        = "%s"
+  description = "this is a test dds instance"
+}
+`, testAccDatasourceDdsInstance_base(name, 8800), name)
+}
+
+func testAccBackupImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}

--- a/g42cloud/services/acceptance/dds/resource_g42cloud_dds_database_role_test.go
+++ b/g42cloud/services/acceptance/dds/resource_g42cloud_dds_database_role_test.go
@@ -1,0 +1,115 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/dds/v3/roles"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getDatabaseRoleFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.DdsV3Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS v3 client: %s ", err)
+	}
+
+	instanceId := state.Primary.Attributes["instance_id"]
+	name := state.Primary.Attributes["name"]
+	opts := roles.ListOpts{
+		Name:   state.Primary.Attributes["name"],
+		DbName: state.Primary.Attributes["db_name"],
+	}
+	resp, err := roles.List(client, instanceId, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error getting role (%s) from DDS instance (%s): %v", name, instanceId, err)
+	}
+	if len(resp) < 1 {
+		return nil, fmt.Errorf("unable to find role (%s) from DDS instance (%s)", name, instanceId)
+	}
+	role := resp[0]
+	return &role, nil
+}
+
+func TestAccDatabaseRole_basic(t *testing.T) {
+	var role roles.Role
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_dds_database_role.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&role,
+		getDatabaseRoleFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRole_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "roles.0.name",
+						"g42cloud_dds_database_role.base", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "inherited_privileges",
+						"g42cloud_dds_database_role.base", "inherited_privileges"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDatabaseRoleImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccDatabaseRoleImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, dbName, name string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "g42cloud_dds_database_role" {
+				instanceId = rs.Primary.Attributes["instance_id"]
+				dbName = rs.Primary.Attributes["db_name"]
+				name = rs.Primary.Attributes["name"]
+			}
+		}
+		if instanceId == "" || dbName == "" || name == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", instanceId, dbName, name)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, dbName, name), nil
+	}
+}
+
+func testAccDatabaseRole_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_dds_database_role" "base" {
+  instance_id = g42cloud_dds_instance.test.id
+
+  name    = "%[2]s-base"
+  db_name = "admin"
+}
+
+resource "g42cloud_dds_database_role" "test" {
+  instance_id = g42cloud_dds_instance.test.id
+
+  name    = "%[2]s"
+  db_name = "admin"
+
+  roles {
+    name    = g42cloud_dds_database_role.base.name
+    db_name = "admin"
+  }
+}
+`, testAccDatasourceDdsInstance_base(rName, 8800), rName)
+}

--- a/g42cloud/services/acceptance/dds/resource_g42cloud_dds_database_user_test.go
+++ b/g42cloud/services/acceptance/dds/resource_g42cloud_dds_database_user_test.go
@@ -1,0 +1,119 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/dds/v3/users"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getDatabaseUserFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.DdsV3Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS v3 client: %s ", err)
+	}
+
+	instanceId := state.Primary.Attributes["instance_id"]
+	name := state.Primary.Attributes["name"]
+	opts := users.ListOpts{
+		Name:   state.Primary.Attributes["name"],
+		DbName: state.Primary.Attributes["db_name"],
+	}
+	resp, err := users.List(client, instanceId, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error getting user (%s) from DDS instance (%s): %v", name, instanceId, err)
+	}
+	if len(resp) < 1 {
+		return nil, fmt.Errorf("unable to find user (%s) from DDS instance (%s)", name, instanceId)
+	}
+	user := resp[0]
+	return &user, nil
+}
+
+func TestAccDatabaseUser_basic(t *testing.T) {
+	var user users.UserResp
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_dds_database_user.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&user,
+		getDatabaseUserFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseUser_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "roles.0.name",
+						"g42cloud_dds_database_role.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "inherited_privileges",
+						"g42cloud_dds_database_role.test", "inherited_privileges"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDatabaseUserImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+		},
+	})
+}
+
+func testAccDatabaseUserImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, dbName, userName string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "g42cloud_dds_database_user" {
+				instanceId = rs.Primary.Attributes["instance_id"]
+				dbName = rs.Primary.Attributes["db_name"]
+				userName = rs.Primary.Attributes["name"]
+			}
+		}
+		if instanceId == "" || dbName == "" || userName == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", instanceId, dbName, userName)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, dbName, userName), nil
+	}
+}
+
+func testAccDatabaseUser_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_dds_database_role" "test" {
+  instance_id = g42cloud_dds_instance.test.id
+
+  name    = "%[2]s"
+  db_name = "admin"
+}
+
+resource "g42cloud_dds_database_user" "test" {
+  instance_id = g42cloud_dds_instance.test.id
+
+  name     = "%[2]s"
+  password = "G42CloudTest@12345678"
+  db_name  = "admin"
+
+  roles {
+    name    = g42cloud_dds_database_role.test.name
+    db_name = "admin"
+  }
+}
+`, testAccDatasourceDdsInstance_base(rName, 8860), rName)
+}

--- a/g42cloud/services/acceptance/dds/resource_g42cloud_dds_parameter_template_test.go
+++ b/g42cloud/services/acceptance/dds/resource_g42cloud_dds_parameter_template_test.go
@@ -1,0 +1,293 @@
+package dds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDdsParameterTemplateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getParameterTemplate: Query DDS parameter template
+	var (
+		getParameterTemplateHttpUrl = "v3/{project_id}/configurations/{config_id}"
+		getParameterTemplateProduct = "dds"
+	)
+	getParameterTemplateClient, err := cfg.NewServiceClient(getParameterTemplateProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS Client: %s", err)
+	}
+
+	getParameterTemplatePath := getParameterTemplateClient.Endpoint + getParameterTemplateHttpUrl
+	getParameterTemplatePath = strings.ReplaceAll(getParameterTemplatePath, "{project_id}",
+		getParameterTemplateClient.ProjectID)
+	getParameterTemplatePath = strings.ReplaceAll(getParameterTemplatePath, "{config_id}", state.Primary.ID)
+
+	getParameterTemplateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	getParameterTemplateResp, err := getParameterTemplateClient.Request("GET",
+		getParameterTemplatePath, &getParameterTemplateOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DDS parameter template: %s", err)
+	}
+	return utils.FlattenResponse(getParameterTemplateResp)
+}
+
+func TestAccDdsParameterTemplate_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dds_parameter_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDdsParameterTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDdsParameterTemplate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "node_type", "mongos"),
+					resource.TestCheckResourceAttr(rName, "node_version", "4.2"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.name",
+						"connPoolMaxConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.value", "800"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.name",
+						"connPoolMaxShardedConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.value", "800"),
+				),
+			},
+			{
+				Config: testDdsParameterTemplate_basic_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "node_version", "4.2"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.name",
+						"connPoolMaxConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.value", "500"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.name",
+						"connPoolMaxShardedConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.value", "500"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"node_type", "parameter_values"},
+			},
+		},
+	})
+}
+
+func TestDdsParameterTemplate_shard_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dds_parameter_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDdsParameterTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDdsParameterTemplate_shard_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "node_type", "shard"),
+					resource.TestCheckResourceAttr(rName, "node_version", "4.0"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.name",
+						"connPoolMaxConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.value", "800"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.name",
+						"connPoolMaxShardedConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.value", "800"),
+				),
+			},
+		},
+	})
+}
+
+func TestDdsParameterTemplate_config_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dds_parameter_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDdsParameterTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDdsParameterTemplate_config_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "node_type", "config"),
+					resource.TestCheckResourceAttr(rName, "node_version", "3.4"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.name",
+						"connPoolMaxConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.value", "800"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.name",
+						"connPoolMaxShardedConnsPerHost"),
+					resource.TestCheckResourceAttr(rName, "parameters.1.value", "800"),
+				),
+			},
+		},
+	})
+}
+
+func TestDdsParameterTemplate_replica_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dds_parameter_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDdsParameterTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDdsParameterTemplate_replica_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "node_type", "replica"),
+					resource.TestCheckResourceAttr(rName, "node_version", "4.0"),
+				),
+			},
+		},
+	})
+}
+
+func testDdsParameterTemplate_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_dds_parameter_template" "test" {
+  name         = "%s"
+  description  = "test description"
+  node_type    = "mongos"
+  node_version = "4.2"
+
+  parameter_values = {
+    connPoolMaxConnsPerHost        = 800
+    connPoolMaxShardedConnsPerHost = 800
+  }
+}
+`, name)
+}
+
+func testDdsParameterTemplate_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_dds_parameter_template" "test" {
+  name         = "%s"
+  description  = "test description update"
+  node_type    = "mongos"
+  node_version = "4.2"
+
+  parameter_values = {
+    connPoolMaxConnsPerHost        = 500
+    connPoolMaxShardedConnsPerHost = 500
+  }
+}
+`, name)
+}
+
+func testDdsParameterTemplate_shard_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_dds_parameter_template" "test" {
+  name         = "%s"
+  description  = "test description"
+  node_type    = "shard"
+  node_version = "4.0"
+
+  parameter_values = {
+    connPoolMaxConnsPerHost        = 800
+    connPoolMaxShardedConnsPerHost = 800
+  }
+}
+`, name)
+}
+
+func testDdsParameterTemplate_config_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_dds_parameter_template" "test" {
+  name         = "%s"
+  description  = "test description"
+  node_type    = "config"
+  node_version = "3.4"
+
+  parameter_values = {
+    connPoolMaxConnsPerHost        = 800
+    connPoolMaxShardedConnsPerHost = 800
+  }
+}
+`, name)
+}
+
+func testDdsParameterTemplate_replica_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_dds_parameter_template" "test" {
+  name         = "%s"
+  description  = "test description"
+  node_type    = "replica"
+  node_version = "4.0"
+
+  parameter_values = {
+    connPoolMaxConnsPerHost        = 800
+    connPoolMaxShardedConnsPerHost = 800
+  }
+}
+`, name)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import CSS resource, unit test and document

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed


```markdown
### data_source_g42cloud_dds_instances

=== RUN   TestAccDatasourceDdsInstance_basic
=== PAUSE TestAccDatasourceDdsInstance_basic
=== CONT  TestAccDatasourceDdsInstance_basic
--- PASS: TestAccDatasourceDdsInstance_basic (888.87s)
PASS
coverage: 8.6% of statements in ../../../../../terraform-provider-g42cloud/...

### resource_g42cloud_dds_backup

=== RUN   TestAccDdsBackup_basic
=== PAUSE TestAccDdsBackup_basic
=== CONT  TestAccDdsBackup_basic
--- PASS: TestAccDdsBackup_basic (1186.65s)
PASS

coverage: 14.7% of statements in ../../../../../terraform-provider-g42cloud/...


### resource_g42cloud_dds_parameter_template

=== RUN   TestAccDdsParameterTemplate_basic
=== PAUSE TestAccDdsParameterTemplate_basic
=== CONT  TestAccDdsParameterTemplate_basic
--- PASS: TestAccDdsParameterTemplate_basic (71.84s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestDdsParameterTemplate_shared_basic
=== PAUSE TestDdsParameterTemplate_shared_basic
=== CONT  TestDdsParameterTemplate_shared_basic
--- PASS: TestDdsParameterTemplate_shared_basic (40.75s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestDdsParameterTemplate_config_basic
=== PAUSE TestDdsParameterTemplate_config_basic
=== CONT  TestDdsParameterTemplate_config_basic
--- PASS: TestDdsParameterTemplate_config_basic (55.69s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestDdsParameterTemplate_replica_basic
=== PAUSE TestDdsParameterTemplate_replica_basic
=== CONT  TestDdsParameterTemplate_replica_basic
--- PASS: TestDdsParameterTemplate_replica_basic (26.33s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


### resource_g42cloud_database_role

=== RUN   TestAccDatabaseRole_basic
=== PAUSE TestAccDatabaseRole_basic
=== CONT  TestAccDatabaseRole_basic
--- PASS: TestAccDatabaseRole_basic (1032.62s)
PASS

coverage: 11.6% of statements in ../../../../../terraform-provider-g42cloud/...


### resource_g42cloud_database_user

=== RUN   TestAccDatabaseUser_basic
=== PAUSE TestAccDatabaseUser_basic
=== CONT  TestAccDatabaseUser_basic
--- PASS: TestAccDatabaseUser_basic (864.56s)
PASS

coverage: 11.6% of statements in ../../../../../terraform-provider-g42cloud/...


### resource_g42cloud_audit_log_policy

=== RUN   TestAccDdsAuditLogPolicy_basic
=== PAUSE TestAccDdsAuditLogPolicy_basic
=== CONT  TestAccDdsAuditLogPolicy_basic
--- PASS: TestAccDdsAuditLogPolicy_basic (898.02s)
PASS

coverage: 11.6% of statements in ../../../../../terraform-provider-g42cloud/...


```



