### PR TITLE
feat(MPC): add DataSources to retrieve templates and template groups

### DIFF
--- a/docs/resources/mpc_transcoding_template.md
+++ b/docs/resources/mpc_transcoding_template.md
@@ -1,0 +1,195 @@
+---
+subcategory: "Media Processing Center (MPC)"
+---
+
+# g42cloud_mpc_transcoding_template
+
+Manages an MPC transcoding template resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_mpc_transcoding_template" "test" {
+  name                  = "test"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 1
+
+  audio {
+    bitrate       = 0
+    channels      = 2
+    codec         = 2
+    output_policy = "transcode"
+    sample_rate   = 1
+  }
+
+  video {
+    max_consecutive_bframes = 7
+    bitrate                 = 0
+    black_bar_removal       = 0
+    codec                   = 2
+    fps                     = 0
+    level                   = 15
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+    quality                 = 1
+    profile                 = 4
+    height                  = 0
+    width                   = 0
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the transcoding template resource. If omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of a transcoding template.
+
+* `output_format` - (Required, Int) Specifies the packaging type. Possible values are:
+  + **1**: HLS
+  + **2**: DASH
+  + **3**: HLS+DASH
+  + **4**: MP4
+  + **5**: MP3
+  + **6**: ADTS
+
+-> If output_format is set to 5 or 6, do not set video parameters.
+
+* `low_bitrate_hd` - (Optional, Bool) Specifies Whether to enable low bitrate HD. The default value is false.
+
+* `hls_segment_duration` - (Optional, Int) Specifies the HLS segment duration. This parameter is used only
+  when `output_format` is set to 1 or 3. The value ranges from 2 to 10. The default value is 5. The unit is second.
+
+* `dash_segment_duration` - (Optional, Int) Specifies the dash segment duration. This parameter is used only when
+  `output_format` is set to 2 or 3. The value ranges from 2 to 10. The default value is 5. The unit is second.
+
+* `audio` - (Optional, List) Specifies the audio parameters. The [audio](#mpc_audio) structure is documented below.
+
+* `video` - (Optional, List) Specifies the video parameters. The [video](#mpc_video) structure is documented below.
+
+<a name="mpc_audio"></a>
+The `audio` block supports:
+
+* `codec` - (Required, Int) Specifies the audio codec. Possible values are:
+  + **1**: AAC
+  + **2**: HEAAC1
+  + **3**: HEAAC2
+  + **4**: MP3
+
+* `sample_rate` - (Required, Int) Specifies the audio sampling rate. Possible values are:
+  + **1**: AUDIO_SAMPLE_AUTO
+  + **2**: AUDIO_SAMPLE_22050 (22,050 Hz)
+  + **3**: AUDIO_SAMPLE_32000 (32,000 Hz)
+  + **4**: AUDIO_SAMPLE_44100 (44,100 Hz)
+  + **5**: AUDIO_SAMPLE_48000 (48,000 Hz)
+  + **6**: AUDIO_SAMPLE_96000 (96,000 Hz)
+
+* `channels` - (Required, Int) Specifies the number of audio channels. Possible values are:
+  + **1**: AUDIO_CHANNELS_1
+  + **2**: AUDIO_CHANNELS_2
+  + **6**: AUDIO_CHANNELS_5_1
+
+* `bitrate` - (Optional, Int) Specifies the audio bitrate. The value is 0 or ranges from 8 to 1,000.
+  The default value is 0. The unit is kbit/s.
+
+* `output_policy` - (Optional, String) Specifies the output policy. Possible values are **discard** and **transcode**.
+  The default value is transcode.
+
+<a name="mpc_video"></a>
+The `video` block supports:
+
+* `output_policy` - (Optional, String) Specifies the output policy. Possible values are **discard** and **transcode**.
+  The default value is transcode.
+
+* `codec` - (Optional, Int) Specifies the video codec. Possible values are:
+  + **1**: H.264
+  + **2**: H.265
+
+  The default value is 1.
+
+* `bitrate` - (Optional, Int) Specifies the average output bitrate. The value is 0 or an integer ranging from 40 to
+  30,000. The default value is 0. The unit is kbit/s. If this parameter is set to 0, the average output bitrate is an
+  adaptive value.
+
+* `profile` - (Optional, Int) Specifies the encoding profile. The recommended value is 3. Possible values are:
+  + **1**: VIDEO_PROFILE_H264_BASE
+  + **2**: VIDEO_PROFILE_H264_MAIN
+  + **3**: VIDEO_PROFILE_H264_HIGH
+  + **4**: VIDEO_PROFILE_H265_MAIN
+
+  The default value is 3.
+
+* `level` - (Optional, Int) Specifies the encoding level. Possible values are:
+  + **1**: VIDEO_LEVEL_1_0
+  + **2**: VIDEO_LEVEL_1_1
+  + **3**: VIDEO_LEVEL_1_2
+  + **4**: VIDEO_LEVEL_1_3
+  + **5**: VIDEO_LEVEL_2_0
+  + **6**: VIDEO_LEVEL_2_1
+  + **7**: VIDEO_LEVEL_2_2
+  + **8**: VIDEO_LEVEL_3_0
+  + **9**: VIDEO_LEVEL_3_1
+  + **10**: VIDEO_LEVEL_3_2
+  + **11**: VIDEO_LEVEL_4_0
+  + **12**: VIDEO_LEVEL_4_1
+  + **13**: VIDEO_LEVEL_4_2
+  + **14**: VIDEO_LEVEL_5_0
+  + **15**: VIDEO_LEVEL_5_1
+
+  The default value is 15.
+
+* `quality` - (Optional, Int) Specifies the encoding quality. A larger value indicates higher encoding quality and
+  longer transcoding time. Possible values are:
+  + **1**: VIDEO_PRESET_HSPEED2
+  + **2**: VIDEO_PRESET_HSPEED
+  + **3**: VIDEO_PRESET_NORMAL
+
+  The default value is 1.
+
+* `max_iframes_interval` - (Optional, Int) Specifies the mximum I-frame interval. The value ranges from 2 to 10.
+  The default value is 5. The unit is second.
+
+* `max_consecutive_bframes` - (Optional, Int) Specifies the maximum number of B-frames.
+  The value range is 0 to 7, and the default value is 4. The unit is frame.
+
+* `fps` - (Optional, Int) Specifies the frame rate. Its value is 0 or an integer ranging from 5 to 30.
+  The default value is 0. The unit is FPS.
+
+* `width` - (Optional, Int) Specifies the video width. The value can be 0 or a multiple of 2 from 32 to 4,096 for H.264
+  and 0 or a multiple of 4 from 160 to 4,096 for H.265. The unit is pixel. If this parameter is set to 0, the video
+  width is an adaptive value. The default value is 0.
+
+* `height` - (Optional, Int) Specifies the video height. The value is 0 or a multiple of 2 from 32 to 2,880 for H.264,
+  and 0 or a multiple of 4 from 96 to 2,880 for H.265. The unit is pixel. If this parameter is set to 0, the video
+  height is an adaptive value. The default value is 0.
+
+* `black_bar_removal` - (Optional, Int) Specifies whether to enable black bar removal. Possible values are:
+  + **0**: Disable black bar removal.
+  + **1**: Enable black bar removal and low-complexity algorithms for long videos (>5 minutes).
+  + **2**: Enable black bar removal and high-complexity algorithms for short videos (≤5 minutes).
+
+  The default value is 0.
+
+-> If output_policy is set to discard in video parameters and transcode in audio parameters, only audio is output.
+  If output_policy is set to transcode in video parameters and discard in audio parameters, only video is output.
+  output_policy cannot be set to discard in video and audio parameters at the same time.
+  If output_policy is set to transcode in video and video parameters at the same time, video and video are output.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the transcoding template ID.
+
+## Import
+
+MPC transcoding templates can be imported using the `id`, e.g.
+
+```shell
+terraform import g42cloud_mpc_transcoding_template.test 542899
+```

--- a/docs/resources/mpc_transcoding_template_group.md
+++ b/docs/resources/mpc_transcoding_template_group.md
@@ -1,0 +1,206 @@
+---
+subcategory: "Media Processing Center (MPC)"
+---
+
+# g42cloud_mpc_transcoding_template_group
+
+Manages an MPC transcoding template group resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+resource "g42cloud_mpc_transcoding_template_group" "test" {
+  name                  = "test"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 1
+
+  audio {
+    bitrate       = 0
+    channels      = 2
+    codec         = 2
+    output_policy = "transcode"
+    sample_rate   = 1
+  }
+
+  video_common {
+    max_consecutive_bframes = 7
+    black_bar_removal       = 0
+    codec                   = 2
+    fps                     = 0
+    level                   = 15
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+    quality                 = 1
+    profile                 = 4
+  }
+
+  videos {
+    width   = 3840
+    height  = 2160
+    bitrate = 0
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the transcoding template group resource. If
+  omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of a transcoding template group.
+
+* `output_format` - (Required, Int) Specifies the packaging type. Possible values are:
+    + **1**: HLS
+    + **2**: DASH
+    + **3**: HLS+DASH
+    + **4**: MP4
+    + **5**: MP3
+    + **6**: ADTS
+
+-> If output_format is set to 5 or 6, do not set video parameters.
+
+* `low_bitrate_hd` - (Optional, Bool) Specifies Whether to enable low bitrate HD. The default value is false.
+
+* `hls_segment_duration` - (Optional, Int) Specifies the HLS segment duration. This parameter is used only
+  when `output_format` is set to 1 or 3. The value ranges from 2 to 10. The default value is 5. The unit is second.
+
+* `dash_segment_duration` - (Optional, Int) Specifies the dash segment duration. This parameter is used only
+  when `output_format`
+  is set to 2 or 3. The value ranges from 2 to 10. The default value is 5. The unit is second.
+
+* `audio` - (Optional, List) Specifies the audio parameters. The [audio](#audio_object) structure is documented below.
+
+* `video_common` - (Optional, List) Specifies the video parameters.
+  The [video_common](#video_common_object) structure is documented below.
+
+* `videos` - (Optional, List) Specifies the list of output video configurations.
+  The [videos](#videos_object) structure is documented below.
+
+<a name="audio_object"></a>
+The `audio` block supports:
+
+* `codec` - (Required, Int) Specifies the audio codec. Possible values are:
+  + **1**: AAC
+  + **2**: HEAAC1
+  + **3**: HEAAC2
+  + **4**: MP3
+
+* `sample_rate` - (Required, Int) Specifies the audio sampling rate. Possible values are:
+  + **1**: AUDIO_SAMPLE_AUTO
+  + **2**: AUDIO_SAMPLE_22050 (22,050 Hz)
+  + **3**: AUDIO_SAMPLE_32000 (32,000 Hz)
+  + **4**: AUDIO_SAMPLE_44100 (44,100 Hz)
+  + **5**: AUDIO_SAMPLE_48000 (48,000 Hz)
+  + **6**: AUDIO_SAMPLE_96000 (96,000 Hz)
+
+* `channels` - (Required, Int) Specifies the number of audio channels. Possible values are:
+  + **1**: AUDIO_CHANNELS_1
+  + **2**: AUDIO_CHANNELS_2
+  + **6**: AUDIO_CHANNELS_5_1
+
+* `bitrate` - (Optional, Int) Specifies the audio bitrate. The value is 0 or ranges from 8 to 1,000.
+  The default value is 0. The unit is kbit/s.
+
+* `output_policy` - (Optional, String) Specifies the output policy. Possible values are **discard** and **transcode**.
+  The default value is transcode.
+
+<a name="video_common_object"></a>
+The `video_common` block supports:
+
+* `output_policy` - (Optional, String) Specifies the output policy. Possible values are **discard** and **transcode**.
+  The default value is transcode.
+
+* `codec` - (Optional, Int) Specifies the video codec. Possible values are:
+  + **1**: H.264
+  + **2**: H.265
+
+  The default value is 1.
+
+* `profile` - (Optional, Int) Specifies the encoding profile. The recommended value is 3. Possible values are:
+  + **1**: VIDEO_PROFILE_H264_BASE
+  + **2**: VIDEO_PROFILE_H264_MAIN
+  + **3**: VIDEO_PROFILE_H264_HIGH
+  + **4**: VIDEO_PROFILE_H265_MAIN
+
+  The default value is 3.
+
+* `level` - (Optional, Int) Specifies the encoding level. Possible values are:
+  + **1**: VIDEO_LEVEL_1_0
+  + **2**: VIDEO_LEVEL_1_1
+  + **3**: VIDEO_LEVEL_1_2
+  + **4**: VIDEO_LEVEL_1_3
+  + **5**: VIDEO_LEVEL_2_0
+  + **6**: VIDEO_LEVEL_2_1
+  + **7**: VIDEO_LEVEL_2_2
+  + **8**: VIDEO_LEVEL_3_0
+  + **9**: VIDEO_LEVEL_3_1
+  + **10**: VIDEO_LEVEL_3_2
+  + **11**: VIDEO_LEVEL_4_0
+  + **12**: VIDEO_LEVEL_4_1
+  + **13**: VIDEO_LEVEL_4_2
+  + **14**: VIDEO_LEVEL_5_0
+  + **15**: VIDEO_LEVEL_5_1
+
+  The default value is 15.
+
+* `quality` - (Optional, Int) Specifies the encoding quality. A larger value indicates higher encoding quality and
+  longer transcoding time. Possible values are:
+  + **1**: VIDEO_PRESET_HSPEED2
+  + **2**: VIDEO_PRESET_HSPEED
+  + **3**: VIDEO_PRESET_NORMAL
+
+  The default value is 1.
+
+* `max_iframes_interval` - (Optional, Int) Specifies the mximum I-frame interval. The value ranges from 2 to 10.
+  The default value is 5. The unit is second.
+
+* `max_consecutive_bframes` - (Optional, Int) Specifies the maximum number of B-frames.
+  The value range is 0 to 7, and the default value is 4. The unit is frame.
+
+* `fps` - (Optional, Int) Specifies the frame rate. Its value is 0 or an integer ranging from 5 to 30.
+  The default value is 0. The unit is FPS.
+
+* `black_bar_removal` - (Optional, Int) Specifies whether to enable black bar removal. Possible values are:
+  + **0**: Disable black bar removal.
+  + **1**: Enable black bar removal and low-complexity algorithms for long videos (>5 minutes).
+  + **2**: Enable black bar removal and high-complexity algorithms for short videos (≤5 minutes).
+
+  The default value is 0.
+
+<a name="videos_object"></a>
+The `videos` block supports:
+
+* `width` - (Optional, Int) Specifies the video width. The value can be 0 or a multiple of 2 from 32 to 4,096 for H.264
+  and 0 or a multiple of 4 from 160 to 4,096 for H.265. The unit is pixel. If this parameter is set to 0, the video
+  width
+  is an adaptive value. The default value is 0.
+
+* `height` - (Optional, Int) Specifies the video height. The value is 0 or a multiple of 2 from 32 to 2,880 for H.264,
+  and 0 or a multiple of 4 from 96 to 2,880 for H.265. The unit is pixel. If this parameter is set to 0, the video
+  height
+  is an adaptive value. The default value is 0.
+
+* `bitrate` - (Optional, Int) Specifies the average output bitrate. The value is 0 or an integer ranging from 40 to
+  30,000. The default value is 0. The unit is kbit/s. If this parameter is set to 0, the average output bitrate is an
+  adaptive value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the transcoding template group ID.
+
+* `template_ids` - Indicates the IDs of templates in the template group
+
+## Import
+
+MPC transcoding template groups can be imported using the `id`, e.g.
+
+```shell
+terraform import g42cloud_mpc_transcoding_template_group.test 589e49809bb84447a759f6fa9aa19949
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/antiddos"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lts"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/mpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
@@ -407,6 +408,9 @@ func Provider() *schema.Provider {
 			"g42cloud_modelarts_dataset_version":        modelarts.ResourceDatasetVersion(),
 			"g42cloud_modelarts_notebook":               modelarts.ResourceNotebook(),
 			"g42cloud_modelarts_notebook_mount_storage": modelarts.ResourceNotebookMountStorage(),
+
+			"g42cloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
+			"g42cloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),
 
 			"g42cloud_nat_dnat_rule": nat.ResourcePublicDnatRule(),
 			"g42cloud_nat_gateway":   nat.ResourcePublicGateway(),

--- a/g42cloud/services/acceptance/mpc/resource_g42cloud_mpc_transcoding_template_group_test.go
+++ b/g42cloud/services/acceptance/mpc/resource_g42cloud_mpc_transcoding_template_group_test.go
@@ -1,0 +1,305 @@
+package mpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	mpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/mpc/v1/model"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getTemplateGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.HcMpcV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating MPC client: %s", err)
+	}
+
+	resp, err := c.ListTemplateGroup(&mpc.ListTemplateGroupRequest{GroupId: &[]string{state.Primary.ID}})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving MPC transcoding template group: %s", err)
+	}
+
+	templateGroupList := *resp.TemplateGroupList
+
+	if len(templateGroupList) == 0 {
+		return nil, fmt.Errorf("unable to retrieve MPC transcoding template group: %s", state.Primary.ID)
+	}
+
+	return templateGroupList[0], nil
+}
+
+func TestAccTranscodingTemplateGroup_basic(t *testing.T) {
+	var templateGroup mpc.TemplateGroup
+	rName := acceptance.RandomAccResourceNameWithDash()
+	rNameUpdate := rName + "-update"
+	resourceName := "g42cloud_mpc_transcoding_template_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&templateGroup,
+		getTemplateGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplateGroup_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "1"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.profile", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.output_policy", "transcode"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testTranscodingTemplateGroup_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "false"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "2"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.profile", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTranscodingTemplateGroup_basic2(t *testing.T) {
+	var templateGroup mpc.TemplateGroup
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_mpc_transcoding_template_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&templateGroup,
+		getTemplateGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplateGroup_basic2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "3"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.profile", "3"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.output_policy", "transcode"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTranscodingTemplateGroup_basic3(t *testing.T) {
+	var templateGroup mpc.TemplateGroup
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_mpc_transcoding_template_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&templateGroup,
+		getTemplateGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplateGroup_basic3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "4"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "2"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.codec", "2"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.profile", "4"),
+					resource.TestCheckResourceAttr(resourceName, "video_common.0.output_policy", "transcode"),
+				),
+			},
+		},
+	})
+}
+
+func testTranscodingTemplateGroup_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template_group" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 1
+
+  audio {
+    codec         = 1
+    sample_rate   = 1
+    channels      = 6
+    output_policy = "transcode"
+    bitrate       = 0
+  }
+
+  video_common {
+    codec                   = 1
+    profile                 = 1
+    level                   = 1
+    quality                 = 1
+    black_bar_removal       = 0
+    max_consecutive_bframes = 7
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+  }
+
+  videos {
+    width   = 1920
+    height  = 1080
+    bitrate = 0
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplateGroup_update(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template_group" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = false
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 2
+
+  audio {
+    codec         = 1
+    sample_rate   = 2
+    channels      = 6
+    output_policy = "transcode"
+    bitrate       = 0
+  }
+
+  video_common {
+    codec                   = 1
+    profile                 = 2
+    level                   = 4
+    quality                 = 1
+    black_bar_removal       = 0
+    max_consecutive_bframes = 7
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+  }
+
+  videos {
+    width   = 3840
+    height  = 2560
+    bitrate = 0
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplateGroup_basic2(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template_group" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 3
+
+  audio {
+    codec         = 1
+    sample_rate   = 3
+    channels      = 2
+    output_policy = "transcode"
+    bitrate       = 0
+  }
+
+  video_common {
+    codec                   = 1
+    profile                 = 3
+    level                   = 7
+    quality                 = 2
+    black_bar_removal       = 1
+    max_consecutive_bframes = 7
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+  }
+
+  videos {
+    width   = 1920
+    height  = 1080
+    bitrate = 0
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplateGroup_basic3(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template_group" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 4
+
+  audio {
+    codec         = 2
+    sample_rate   = 4
+    channels      = 2
+    output_policy = "transcode"
+    bitrate       = 0
+  }
+
+  video_common {
+    codec                   = 2
+    profile                 = 4
+    level                   = 10
+    quality                 = 2
+    black_bar_removal       = 1
+    max_consecutive_bframes = 7
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+  }
+
+  videos {
+    width   = 1920
+    height  = 1080
+    bitrate = 0
+  }
+}
+`, rName)
+}

--- a/g42cloud/services/acceptance/mpc/resource_g42cloud_mpc_transcoding_template_test.go
+++ b/g42cloud/services/acceptance/mpc/resource_g42cloud_mpc_transcoding_template_test.go
@@ -1,0 +1,401 @@
+package mpc
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	mpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/mpc/v1/model"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getTemplateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.HcMpcV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating MPC client: %s", err)
+	}
+
+	id, err := strconv.ParseInt(state.Primary.ID, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.ListTemplate(&mpc.ListTemplateRequest{TemplateId: &[]int32{int32(id)}})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving MPC transcoding template: %d", err)
+	}
+
+	templateList := *resp.TemplateArray
+	template := templateList[0].Template
+	if template == nil {
+		return nil, fmt.Errorf("unable to retrieve MPC transcoding template: %d", id)
+	}
+
+	return template, nil
+}
+
+func TestAccTranscodingTemplate_basic(t *testing.T) {
+	var template mpc.QueryTransTemplate
+	rName := acceptance.RandomAccResourceNameWithDash()
+	rNameUpdate := rName + "-update"
+	resourceName := "g42cloud_mpc_transcoding_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&template,
+		getTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplate_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "1"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.profile", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.output_policy", "transcode"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testTranscodingTemplate_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "2"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.profile", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTranscodingTemplate_basic2(t *testing.T) {
+	var template mpc.QueryTransTemplate
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_mpc_transcoding_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&template,
+		getTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplate_basic2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "3"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.codec", "1"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.profile", "3"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.output_policy", "transcode"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTranscodingTemplate_basic3(t *testing.T) {
+	var template mpc.QueryTransTemplate
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_mpc_transcoding_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&template,
+		getTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplate_basic3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "4"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "2"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.codec", "2"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.profile", "4"),
+					resource.TestCheckResourceAttr(resourceName, "video.0.output_policy", "transcode"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTranscodingTemplate_basic4(t *testing.T) {
+	var template mpc.QueryTransTemplate
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_mpc_transcoding_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&template,
+		getTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplate_basic4(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "5"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "4"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTranscodingTemplate_basic5(t *testing.T) {
+	var template mpc.QueryTransTemplate
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "g42cloud_mpc_transcoding_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&template,
+		getTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTranscodingTemplate_basic5(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "low_bitrate_hd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "output_format", "6"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.codec", "2"),
+					resource.TestCheckResourceAttr(resourceName, "audio.0.output_policy", "transcode"),
+				),
+			},
+		},
+	})
+}
+
+func testTranscodingTemplate_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 1
+
+  audio {
+    codec         = 1
+    sample_rate   = 1
+    channels      = 1
+    bitrate       = 0
+    output_policy = "transcode"
+  }
+
+  video {
+    codec                   = 1
+    profile                 = 1
+    level                   = 1
+    quality                 = 1
+    black_bar_removal       = 0
+    max_consecutive_bframes = 7
+    bitrate                 = 0
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+    height                  = 0
+    width                   = 0
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplate_update(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 2
+
+  audio {
+    codec         = 1
+    sample_rate   = 2
+    channels      = 1
+    bitrate       = 0
+    output_policy = "transcode"
+  }
+
+  video {
+    codec                   = 1
+    profile                 = 2
+    level                   = 3
+    quality                 = 1
+    black_bar_removal       = 0
+    max_consecutive_bframes = 7
+    bitrate                 = 0
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+    height                  = 0
+    width                   = 0
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplate_basic2(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 3
+
+  audio {
+    codec         = 1
+    sample_rate   = 3
+    channels      = 2
+    bitrate       = 0
+    output_policy = "transcode"
+  }
+
+  video {
+    codec                   = 1
+    profile                 = 3
+    level                   = 4
+    quality                 = 3
+    black_bar_removal       = 1
+    max_consecutive_bframes = 7
+    bitrate                 = 0
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+    height                  = 0
+    width                   = 0
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplate_basic3(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 4
+
+  audio {
+    codec         = 2
+    sample_rate   = 4
+    channels      = 2
+    bitrate       = 0
+    output_policy = "transcode"
+  }
+
+  video {
+    codec                   = 2
+    profile                 = 4
+    level                   = 10
+    quality                 = 2
+    black_bar_removal       = 1
+    max_consecutive_bframes = 7
+    bitrate                 = 0
+    fps                     = 0
+    max_iframes_interval    = 5
+    output_policy           = "transcode"
+    height                  = 0
+    width                   = 0
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplate_basic4(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 5
+
+  audio {
+    codec         = 4
+    sample_rate   = 5
+    channels      = 2
+    bitrate       = 0
+    output_policy = "transcode"
+  }
+}
+`, rName)
+}
+
+func testTranscodingTemplate_basic5(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_mpc_transcoding_template" "test" {
+  name                  = "%s"
+  low_bitrate_hd        = true
+  dash_segment_duration = 5
+  hls_segment_duration  = 5
+  output_format         = 6
+
+  audio {
+    codec         = 2
+    sample_rate   = 6
+    channels      = 1
+    bitrate       = 0
+    output_policy = "transcode"
+  }
+}
+`, rName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import MPC resource, unit test and document

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```

### resource_g42cloud_mpc_transcoding_template

=== RUN   TestAccTranscodingTemplate_basic
=== PAUSE TestAccTranscodingTemplate_basic
=== CONT  TestAccTranscodingTemplate_basic
--- PASS: TestAccTranscodingTemplate_basic (43.98s)
PASS
coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccTranscodingTemplate_basic2
=== PAUSE TestAccTranscodingTemplate_basic2
=== CONT  TestAccTranscodingTemplate_basic2
--- PASS: TestAccTranscodingTemplate_basic2 (23.58s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccTranscodingTemplate_basic3
=== PAUSE TestAccTranscodingTemplate_basic3
=== CONT  TestAccTranscodingTemplate_basic3
--- PASS: TestAccTranscodingTemplate_basic3 (23.71s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccTranscodingTemplate_basic4
=== PAUSE TestAccTranscodingTemplate_basic4
=== CONT  TestAccTranscodingTemplate_basic4
--- PASS: TestAccTranscodingTemplate_basic4 (22.46s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccTranscodingTemplate_basic5
=== PAUSE TestAccTranscodingTemplate_basic5
=== CONT  TestAccTranscodingTemplate_basic5
--- PASS: TestAccTranscodingTemplate_basic5 (23.02s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...

‍```


### resource_g42cloud_mpc_transcoding_template_group


=== RUN   TestAccTranscodingTemplateGroup_basic
=== PAUSE TestAccTranscodingTemplateGroup_basic
=== CONT  TestAccTranscodingTemplateGroup_basic
--- PASS: TestAccTranscodingTemplateGroup_basic (48.44s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccTranscodingTemplateGroup_basic2
=== PAUSE TestAccTranscodingTemplateGroup_basic2
=== CONT  TestAccTranscodingTemplateGroup_basic2
--- PASS: TestAccTranscodingTemplateGroup_basic2 (48.84s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccTranscodingTemplateGroup_basic3
=== PAUSE TestAccTranscodingTemplateGroup_basic3
=== CONT  TestAccTranscodingTemplateGroup_basic3
--- PASS: TestAccTranscodingTemplateGroup_basic3 (25.88s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...

‍```



```
