### PR TITLE
feat(DEW): add a DataSource to query the CSMS secret

### DIFF
--- a/docs/data-sources/csms_secret_version.md
+++ b/docs/data-sources/csms_secret_version.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+---
+
+# g42cloud_csms_secret_version
+
+Use this data source to query the version and plaintext of the CSMS(Cloud Secret Management Service) secret.
+
+## Example Usage
+
+```hcl
+data "g42cloud_csms_secret_version" "version_1" {
+  secret_name = "your_secret_name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the CSMS secrets.
+  If omitted, the provider-level region will be used.
+
+* `secret_name` - (Required, String) The name of the CSMS secret to query.
+
+* `version` - (Optional, String) The version ID of the CSMS secret version to query.
+  If omitted, the latest version will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `secret_text` - The plaintext of a secret in text format.
+
+* `kms_key_id` - The ID of the KMS CMK used for secret encryption.
+
+* `status` - The status of the CSMS secret version.
+
+* `created_at` - Time when the CSMS secret version created, in UTC format.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -206,6 +206,8 @@ func Provider() *schema.Provider {
 			"g42cloud_compute_instances":    ecs.DataSourceComputeInstances(),
 			"g42cloud_compute_servergroups": ecs.DataSourceComputeServerGroups(),
 
+			"g42cloud_csms_secret_version": dew.DataSourceDewCsmsSecret(),
+
 			"g42cloud_css_flavors": css.DataSourceCssFlavors(),
 
 			"g42cloud_dcs_flavors":        dcs.DataSourceDcsFlavorsV2(),

--- a/g42cloud/services/acceptance/dew/data_source_g42cloud_csms_secret_version_test.go
+++ b/g42cloud/services/acceptance/dew/data_source_g42cloud_csms_secret_version_test.go
@@ -1,0 +1,73 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDewCsmsSecretVersion_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	resourceName := "data.g42cloud_csms_secret_version.version_1"
+
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDewCsmsSecretVersion_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "secret_name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttr(resourceName, "secret_text", "this is a password"),
+				),
+			},
+			{
+				Config: testAccDewCsmsSecretVersion_version(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "secret_name", name),
+					resource.TestCheckResourceAttr(resourceName, "version", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_text", "this is a password"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDewCsmsSecretVersion_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_csms_secret" "secret_1" {
+  name        = "%s"
+  secret_text = "this is a password"
+}
+
+data "g42cloud_csms_secret_version" "version_1" {
+  secret_name = "%s"
+
+  depends_on = [g42cloud_csms_secret.secret_1]
+}
+`, name, name)
+}
+
+func testAccDewCsmsSecretVersion_version(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_csms_secret" "secret_1" {
+  name        = "%s"
+  secret_text = "this is a new password"
+}
+
+data "g42cloud_csms_secret_version" "version_1" {
+  secret_name = "%s"
+  version     = "v1"
+
+  depends_on = [g42cloud_csms_secret.secret_1]
+}
+`, name, name)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import DEW resource, unit test and document.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```md
=== RUN   TestAccDewCsmsSecretVersion_basic
=== PAUSE TestAccDewCsmsSecretVersion_basic
=== CONT  TestAccDewCsmsSecretVersion_basic
--- PASS: TestAccDewCsmsSecretVersion_basic (48.92s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
