### PR TITLE
feat(EIP): add EIP resource and data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Terraform G42Cloud Provider
 * [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 * Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-<!-- markdownlint-disable-next-line MD033 MD045 -->
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
+<!-- markdownlint-disable-next-line MD033 MD045-->
+<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg"
+width="600px">
 
 Requirements
 ------------

--- a/docs/data-sources/vpc_eip.md
+++ b/docs/data-sources/vpc_eip.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# g42cloud_vpc_eip
+
+Use this data source to get the details of an available EIP.
+
+## Example Usage
+
+```hcl
+data "g42cloud_vpc_eip" "by_address" {
+  public_ip = "123.60.208.163"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the EIP.
+  If omitted, the provider-level region will be used.
+
+* `public_ip` - (Optional, String) Specifies the public **IPv4** address of the EIP.
+
+* `port_id` - (Optional, String) Specifies the port id of the EIP.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the EIP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `status` - The status of the EIP.
+
+* `type` - The type of the EIP.
+
+* `private_ip` - The private ip of the EIP.
+
+* `ip_version` - The IP version, either 4 or 6.
+
+* `ipv6_address` - The IPv6 address of the EIP.
+
+* `bandwidth_id` - The bandwidth id of the EIP.
+
+* `bandwidth_size` - The bandwidth size of the EIP.
+
+* `bandwidth_share_type` - The bandwidth share type of the EIP.

--- a/docs/data-sources/vpc_eips.md
+++ b/docs/data-sources/vpc_eips.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# g42cloud_vpc_eips
+
+Use this data source to get a list of EIPs.
+
+## Example Usage
+
+An example filter by name and tag
+
+```hcl
+variable "public_ip" {}
+
+data "g42cloud_vpc_eips" "eip" {
+  public_ips = [var.public_ip]
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+output "eip_ids" {
+  value = data.g42cloud_vpc_eips.eip.eips[*].id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available EIPs in the current region.
+ All EIPs that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the EIP. If omitted, the provider-level region
+  will be used.
+
+* `ids` - (Optional, List) Specifies an array of one or more IDs of the desired EIP.
+
+* `public_ips` - (Optional, List) Specifies an array of one or more public ip addresses of the desired EIP.
+
+* `port_ids` - (Optional, List) Specifies an array of one or more port ids which bound to the desired EIP.
+
+* `ip_version` - (Optional, Int) Specifies ip version of the desired EIP. The options are:
+    + `4`: IPv4.
+    + `6`: IPv6.
+
+  The default value is `4`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired EIP belongs to.
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired EIP.
+
+ -> A maximum of 10 tag keys are allowed for each query operation. Each tag key can have up to 10 tag values.
+  The tag key cannot be left blank or set to an empty string. Each tag key must be unique, and each tag value in a
+  tag must be unique, use commas(,) to separate the multiple values. An empty for values indicates any value.
+  The values are in the OR relationship.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `eips` - Indicates a list of all EIPs found. The [eips](#vpc_eips) structure is documented below.
+
+<a name="vpc_eips"></a>
+The `eips` block supports:
+
+* `id` - The ID of the EIP.
+* `name` - The name of the EIP.
+* `public_ip` - The public ip address of the EIP.
+* `private_ip` - The private ip address of the EIP.
+* `public_ipv6` - The public ipv6 address of the EIP.
+* `port_id` - The port id bound to the EIP.
+* `ip_version` - The ip version of the EIP.
+* `status` - The status of the EIP.
+* `type` - The type of the EIP.
+* `enterprise_project_id` - The the enterprise project ID of the EIP.
+* `bandwidth_id` - The bandwidth id of the EIP.
+* `bandwidth_name` - The bandwidth name of the EIP.
+* `bandwidth_size` - The bandwidth size of the EIP.
+* `bandwidth_share_type` - The bandwidth share type of the EIP.
+* `tags` - The key/value pairs which associated with the EIP.

--- a/docs/resources/vpc_bandwidth_associate.md
+++ b/docs/resources/vpc_bandwidth_associate.md
@@ -1,0 +1,115 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# g42cloud_vpc_bandwidth_associate
+
+Associates an EIP to a specified **shared** bandwidth.
+
+-> Yearly/monthly EIPs cannot be added to a shared bandwidth. After an EIP is removed from a shared bandwidth,
+  a dedicated bandwidth will be allocated to the EIP. By default, the dedicated bandwidth will be billed by bandwidth
+  and the size is 5 Mbit/s. You can configure the bandwidth as needed.
+
+## Example Usage
+
+### Associate an EIP
+
+```hcl
+variable "public_id" {}
+
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "g42cloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = g42cloud_vpc_bandwidth.test.id
+  eip_id       = var.public_id
+}
+```
+
+### Associate multiple EIPs
+
+```hcl
+variable "multiple_eips" {
+  type = list(string)
+}
+
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "g42cloud_vpc_bandwidth_associate" "test" {
+  count = length(var.multiple_eips)
+
+  bandwidth_id = g42cloud_vpc_bandwidth.test.id
+  eip_id       = var.multiple_eips[count.index]
+}
+```
+
+### Associate an EIP managed by Terraform
+
+```hcl
+resource "g42cloud_vpc_eip" "dedicated" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "dedicated"
+    size        = 5
+    charge_mode = "traffic"
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "g42cloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = g42cloud_vpc_bandwidth.test.id
+  eip_id       = g42cloud_vpc_eip.dedicated.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to associate the bandwidth. If omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `bandwidth_id` - (Required, String, ForceNew) Specifies the shared bandwidth ID to associate.
+  Changing this creates a new resource.
+
+* `eip_id` - (Required, String) Specifies the ID of the EIP that uses the bandwidth.
+
+* `bandwidth_charge_mode` - (Optional, String) Specifies the billing mode of the dedicated bandwidth used by the EIP that
+  has been removed from a shared bandwidth. The value can be **bandwidth** or **traffic**. If not specified, the dedicated
+  bandwidth will be billed by bandwidth.
+
+* `bandwidth_size` - (Optional, Int) Specifies the size (Mbit/s) of the dedicated bandwidth used by the EIP that
+  has been removed from a shared bandwidth. The default bandwidth size is 5 Mbit/s.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format of `<bandwidth_id>/<eip_id>`.
+* `public_ip` - The EIP address.
+* `bandwidth_name` - The shared bandwidth name.
+
+## Import
+
+Bandwidth associations can be imported using the `bandwidth_id` and `eip_id` separated by a slash, e.g.:
+
+```bash
+terraform import g42cloud_vpc_bandwidth_associate.eip <bandwidth_id>/<eip_id>
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -495,9 +495,10 @@ func Provider() *schema.Provider {
 
 			"g42cloud_tms_tags": tms.ResourceTmsTag(),
 
-			"g42cloud_vpc_bandwidth":     eip.ResourceVpcBandWidthV2(),
-			"g42cloud_vpc_eip":           eip.ResourceVpcEIPV1(),
-			"g42cloud_vpc_eip_associate": eip.ResourceEIPAssociate(),
+			"g42cloud_vpc_bandwidth":           eip.ResourceVpcBandWidthV2(),
+			"g42cloud_vpc_bandwidth_associate": eip.ResourceBandWidthAssociate(),
+			"g42cloud_vpc_eip":                 eip.ResourceVpcEIPV1(),
+			"g42cloud_vpc_eip_associate":       eip.ResourceEIPAssociate(),
 
 			"g42cloud_vpc":                             vpc.ResourceVirtualPrivateCloudV1(),
 			"g42cloud_vpc_route":                       vpc.ResourceVPCRouteTableRoute(),

--- a/g42cloud/services/acceptance/eip/data_source_g42cloud_vpc_eip_test.go
+++ b/g42cloud/services/acceptance/eip/data_source_g42cloud_vpc_eip_test.go
@@ -1,0 +1,55 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccVpcEipDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpc_eip.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEipConfig_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "UNBOUND"),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "ip_version", "4"),
+					resource.TestCheckResourceAttr(dataSourceName, "bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "bandwidth_share_type", "PER"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcEipConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "%s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+data "g42cloud_vpc_eip" "test" {
+  public_ip = g42cloud_vpc_eip.test.address
+}
+`, rName)
+}

--- a/g42cloud/services/acceptance/eip/data_source_g42cloud_vpc_eips_test.go
+++ b/g42cloud/services/acceptance/eip/data_source_g42cloud_vpc_eips_test.go
@@ -1,0 +1,121 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccVpcEipsDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpc_eips.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEips_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.ip_version", "4"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_share_type", "PER"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.key", "value"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
+						"g42cloud_vpc_eip.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcEips_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_eips" "test" {
+  public_ips = [g42cloud_vpc_eip.test.address]
+}
+`, testAccVpcEip_basic(rName))
+}
+
+func TestAccVpcEipsDataSource_byTag(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpc_eips.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEips_byTag(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.ip_version", "4"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_share_type", "PER"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.key", "value"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
+						"g42cloud_vpc_eip.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcEips_byTag(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_eips" "test" {
+  public_ips = [g42cloud_vpc_eip.test.address]
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccVpcEip_basic(rName))
+}
+
+func testAccVpcEip_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_eip" "test" {
+  name = "%[1]s"
+
+  publicip {
+    type       = "5_bgp"
+    ip_version = 4
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[1]s"
+    size        = 5
+    charge_mode = "traffic"
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}

--- a/g42cloud/services/acceptance/eip/resource_g42cloud_vpc_bandwidth_associate_test.go
+++ b/g42cloud/services/acceptance/eip/resource_g42cloud_vpc_bandwidth_associate_test.go
@@ -1,0 +1,210 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getBandwidthAssociateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.NetworkingV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating bandwidth client: %s", err)
+	}
+
+	bwID := state.Primary.Attributes["bandwidth_id"]
+	return bandwidths.Get(c, bwID).Extract()
+}
+
+func TestAccBandWidthAssociate_basic(t *testing.T) {
+	var bandwidth bandwidths.BandWidth
+
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_vpc_bandwidth_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&bandwidth,
+		getBandwidthAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBandWidthAssociate_basic(randName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_name", randName),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "g42cloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "g42cloud_vpc_eip.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "g42cloud_vpc_eip.test.0", "address"),
+				),
+			},
+			{
+				Config: testAccBandWidthAssociate_basic(randName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "g42cloud_vpc_eip.test.1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "g42cloud_vpc_eip.test.1", "address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBandWidthAssociate_migrate(t *testing.T) {
+	var bandwidth bandwidths.BandWidth
+
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "g42cloud_vpc_bandwidth_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&bandwidth,
+		getBandwidthAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBandWidthAssociate_migrate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_name", randName),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "g42cloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "g42cloud_vpc_eip.source", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "g42cloud_vpc_eip.source", "address"),
+				),
+			},
+			{
+				Config: testAccBandWidthAssociate_owner(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "g42cloud_vpc_eip.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "g42cloud_vpc_eip.test", "address"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBandWidthAssociate_base(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "g42cloud_vpc_eip" "test" {
+  count = 2
+  name  = "%[1]s-${count.index}"
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[1]s-${count.index}"
+    size        = 5
+    charge_mode = "traffic"
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+`, rName)
+}
+
+func testAccBandWidthAssociate_basic(rName string, index int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = g42cloud_vpc_bandwidth.test.id
+  eip_id       = g42cloud_vpc_eip.test.%d.id
+}
+`, testAccBandWidthAssociate_base(rName), index)
+}
+
+func testAccBandWidthAssociate_migrate(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "g42cloud_vpc_bandwidth" "source" {
+  name = "%[1]s-source"
+  size = 5
+}
+
+resource "g42cloud_vpc_eip" "source" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type = "WHOLE"
+    id         = g42cloud_vpc_bandwidth.source.id
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+
+resource "g42cloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = g42cloud_vpc_bandwidth.test.id
+  eip_id       = g42cloud_vpc_eip.source.id
+}
+`, rName)
+}
+
+func testAccBandWidthAssociate_owner(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "g42cloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type = "WHOLE"
+    id         = g42cloud_vpc_bandwidth.test.id
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+
+resource "g42cloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = g42cloud_vpc_bandwidth.test.id
+  eip_id       = g42cloud_vpc_eip.test.id
+}
+`, rName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
transfer eip resource from HuaweiCloud to G42Cloud
**Which issue this PR fixes**:
import eip resource, unit tests and docs

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccBandWidthAssociate_migrate
=== PAUSE TestAccBandWidthAssociate_migrate
=== CONT  TestAccBandWidthAssociate_migrate
--- PASS: TestAccBandWidthAssociate_migrate (91.76s)
PASS
coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccBandWidthAssociate_basic
=== PAUSE TestAccBandWidthAssociate_basic
=== CONT  TestAccBandWidthAssociate_basic
--- PASS: TestAccBandWidthAssociate_basic (70.29s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
