### PR TITLE
feat(lb): add LB data sources

### DIFF
--- a/docs/data-sources/lb_certificate.md
+++ b/docs/data-sources/lb_certificate.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# g42cloud_lb_certificate
+
+Use this data source to get the certificates in G42Cloud Elastic Load Balance (ELB).
+
+## Example Usage
+
+```hcl
+variable "certificate_name" {}
+
+data "g42cloud_lb_certificate" "test" {
+  name = var.certificate_name
+  type = "server"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the ELB certificate. If omitted, the provider-level region
+  will be used.
+
+* `type` - (Optional, String) Specifies the certificate type. The default value is `server`. The value can be one of the
+  following:
+  + `server`: indicates the server certificate.
+  + `client`: indicates the CA certificate.
+
+* `name` - (Required, String) The name of certificate. The value is case sensitive and does not supports fuzzy matching.
+
+  -> **NOTE:** The certificate name is not unique. Only returns the last created one when matched multiple certificates.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The certificate ID in UUID format.
+
+* `domain` - The domain of the Certificate. This parameter is valid only when `type` is "server".
+
+* `description` - Human-readable description for the Certificate.
+
+* `expiration` - Indicates the time when the certificate expires.

--- a/docs/data-sources/lb_loadbalancer.md
+++ b/docs/data-sources/lb_loadbalancer.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# g42cloud_lb_loadbalancer
+
+Use this data source to get available G42Cloud elb load balancer.
+
+## Example Usage
+
+```hcl
+variable "lb_name" {}
+
+data "g42cloud_lb_loadbalancer" "test" {
+  name = var.lb_name
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the load balancer. If omitted, the
+  provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the load balancer.
+
+* `id` - (Optional, String) Specifies the data source ID of the load balancer in UUID format.
+
+* `status` - (Optional, String) Specifies the operating status of the load balancer. Valid values are *ONLINE* and
+  *FROZEN*.
+
+* `description` - (Optional, String) Specifies the supplementary information about the load balancer.
+
+* `vip_address` - (Optional, String) Specifies the private IP address of the load balancer.
+
+* `vip_subnet_id` - (Optional, String) Specifies the **IPv4 subnet ID** of the subnet where the load balancer works.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the load balancer.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `tags` - The tags associated with the load balancer.
+
+* `vip_port_id` - The ID of the port bound to the private IP address of the load balancer.
+
+* `public_ip` - The EIP address that is associated to the Load Balancer instance.

--- a/docs/data-sources/lb_pools.md
+++ b/docs/data-sources/lb_pools.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# g42cloud_lb_pools
+
+Use this data source to get the list of ELB pools.
+
+## Example Usage
+
+```hcl
+variable "pool_name" {}
+
+data "g42cloud_lb_pools" "test" {
+  name = var.pool_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the ELB pool.
+
+* `pool_id` - (Optional, String) Specifies the ID of the ELB pool.
+
+* `description` - (Optional, String) Specifies the description of the ELB pool.
+
+* `loadbalancer_id` - (Optional, String) Specifies the loadbalancer ID of the ELB pool.
+
+* `healthmonitor_id` - (Optional, String) Specifies the health monitor ID of the ELB pool.
+
+* `protocol` - (Optional, String) Specifies the protocol of the ELB pool. This can either be TCP, UDP or HTTP.
+
+* `lb_method` - (Optional, String) Specifies the method of the ELB pool. Must be one of ROUND_ROBIN, LEAST_CONNECTIONS,
+  or SOURCE_IP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `pools` - The pool list. For details, see data structure of the pool field.
+The [pools](#pools_object) structure is documented below.
+
+<a name="pools_object"></a>
+The `pools` block supports:
+
+* `id` - The pool ID.
+
+* `name` - The pool name.
+
+* `description` - The description of pool.
+
+* `protocol` - The protocol of pool.
+
+* `lb_method` - The load balancing algorithm to distribute traffic to the pool's members.
+
+* `healthmonitor_id` - The health monitor ID of the LB pool.
+
+* `listeners` - The listener list. The [listeners](#elem_object) structure is documented below.
+
+* `loadbalancers` - The loadbalancer list. The [loadbalancers](#elem_object) structure is documented below.
+
+* `members` - The member list. The [object](#elem_object) structure is documented below.
+
+* `persistence` - Indicates whether connections in the same session will be processed by the same pool member or not.
+  The [persistence](#persistence_object) structure is documented below.
+
+<a name="elem_object"></a>
+The `listeners`,  `loadbalancers` or `members` block supports:
+
+* `id` - The listener, loadbalancer or member ID.
+
+<a name="persistence_object"></a>
+The `persistence` block supports:
+
+* `type` - The type of persistence mode.
+
+* `cookie_name` - The name of the cookie if persistence mode is set appropriately.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -234,6 +234,10 @@ func Provider() *schema.Provider {
 			"g42cloud_images_image":  ims.DataSourceImagesImageV2(),
 			"g42cloud_images_images": ims.DataSourceImagesImages(),
 
+			"g42cloud_lb_loadbalancer": lb.DataSourceELBV2Loadbalancer(),
+			"g42cloud_lb_certificate":  lb.DataSourceLBCertificateV2(),
+			"g42cloud_lb_pools":        lb.DataSourcePools(),
+
 			"g42cloud_modelarts_datasets":         modelarts.DataSourceDatasets(),
 			"g42cloud_modelarts_dataset_versions": modelarts.DataSourceDatasetVerions(),
 			"g42cloud_modelarts_notebook_images":  modelarts.DataSourceNotebookImages(),

--- a/g42cloud/services/acceptance/lb/data_source_g42cloud_lb_certificate_test.go
+++ b/g42cloud/services/acceptance/lb/data_source_g42cloud_lb_certificate_test.go
@@ -1,0 +1,106 @@
+package lb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDataSourceLBCertificateV2_basic(t *testing.T) {
+	name := fmt.Sprintf("cert-%s", acctest.RandString(6))
+	dataSourceName := "data.g42cloud_lb_certificate.cert_1"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBCertificateSourceV2_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "server"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domain"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccLBCertificateSourceV2_conf(name string) string {
+	return fmt.Sprintf(`
+data "g42cloud_lb_certificate" "cert_1" {
+  name = g42cloud_elb_certificate.certificate_1.name
+
+  depends_on = [g42cloud_elb_certificate.certificate_1]
+}
+
+resource "g42cloud_elb_certificate" "certificate_1" {
+  name        = "%s"
+  description = "terraform test certificate"
+  domain      = "www.elb.com"
+  type        = "server"
+  private_key = <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
+qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
+UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
+MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
+M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
+13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
+DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
+Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
+iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
+rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
+1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
+yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
+RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
+vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
+Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
+aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
+Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
+75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
+uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
+Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
+79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
+yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
+2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
+ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
+nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
+-----END RSA PRIVATE KEY-----
+EOT
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----
+EOT
+}
+`, name)
+}

--- a/g42cloud/services/acceptance/lb/data_source_g42cloud_lb_loadbalancer_test.go
+++ b/g42cloud/services/acceptance/lb/data_source_g42cloud_lb_loadbalancer_test.go
@@ -1,0 +1,86 @@
+package lb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func getLoadBalancerResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.LoadBalancerClient(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ELB v2 Client: %s", err)
+	}
+	resp, err := loadbalancers.Get(c, state.Primary.ID).Extract()
+	if resp == nil && err == nil {
+		return resp, fmt.Errorf("unable to find the LoadBalancer (%s)", state.Primary.ID)
+	}
+	return resp, err
+}
+
+func TestAccELBV2LoadbalancerDataSource_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+	dataSourceName1 := "data.g42cloud_lb_loadbalancer.test_by_name"
+	dc1 := acceptance.InitDataSourceCheck(dataSourceName1)
+	dataSourceName2 := "data.g42cloud_lb_loadbalancer.test_by_description"
+	dc2 := acceptance.InitDataSourceCheck(dataSourceName2)
+
+	var lb loadbalancers.LoadBalancer
+	resourceName := "g42cloud_lb_loadbalancer.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&lb,
+		getLoadBalancerResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccELBV2LoadbalancerDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc1.CheckResourceExists(),
+					dc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName1, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName2, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccELBV2LoadbalancerDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+resource "g42cloud_lb_loadbalancer" "test" {
+  name          = "%s"
+  vip_subnet_id = data.g42cloud_vpc_subnet.test.ipv4_subnet_id
+  description   = "test for load balancer data source"
+}
+
+data "g42cloud_lb_loadbalancer" "test_by_name" {
+  name = g42cloud_lb_loadbalancer.test.name
+
+  depends_on = [g42cloud_lb_loadbalancer.test]
+}
+
+data "g42cloud_lb_loadbalancer" "test_by_description" {
+  description = g42cloud_lb_loadbalancer.test.description
+
+  depends_on = [g42cloud_lb_loadbalancer.test]
+}
+`, rName)
+}

--- a/g42cloud/services/acceptance/lb/data_source_g42cloud_lb_pools_test.go
+++ b/g42cloud/services/acceptance/lb/data_source_g42cloud_lb_pools_test.go
@@ -1,0 +1,86 @@
+package lb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDataLBPools_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.g42cloud_lb_pools.test"
+
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLBPools_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "pools.0.name", name),
+					resource.TestCheckResourceAttrPair(rName, "pools.0.id",
+						"g42cloud_lb_pool.pool_1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "pools.0.description",
+						"g42cloud_lb_pool.pool_1", "description"),
+					resource.TestCheckResourceAttrPair(rName, "pools.0.protocol",
+						"g42cloud_lb_pool.pool_1", "protocol"),
+					resource.TestCheckResourceAttrPair(rName, "pools.0.lb_method",
+						"g42cloud_lb_pool.pool_1", "lb_method"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataLBPools_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_lb_pools" "test" {
+  name = "%s"
+
+  depends_on = [
+    g42cloud_lb_pool.pool_1
+  ]
+}
+`, testAccLBV2PoolConfig_basic(name), name)
+}
+
+func testAccLBV2PoolConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+data "g42cloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+resource "g42cloud_lb_loadbalancer" "loadbalancer_1" {
+  name          = "%s"
+  vip_subnet_id = data.g42cloud_vpc_subnet.test.ipv4_subnet_id
+}
+
+resource "g42cloud_lb_listener" "listener_1" {
+  name            = "%s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = g42cloud_lb_loadbalancer.loadbalancer_1.id
+}
+
+resource "g42cloud_lb_pool" "pool_1" {
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = g42cloud_lb_listener.listener_1.id
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+`, rName, rName, rName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
transfer lb resource from HuaweiCloud to G42Cloud
**Which issue this PR fixes**:
import lb resource, unit tests and docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceLBCertificateV2_basic
--- PASS: TestAccDataSourceLBCertificateV2_basic (23.40s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...
```


```
=== RUN   TestAccELBV2LoadbalancerDataSource_basic
=== PAUSE TestAccELBV2LoadbalancerDataSource_basic
=== CONT  TestAccELBV2LoadbalancerDataSource_basic
--- PASS: TestAccELBV2LoadbalancerDataSource_basic (62.27s)
PASS

coverage: 10.4% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccDataLBPools_basic
=== PAUSE TestAccDataLBPools_basic
=== CONT  TestAccDataLBPools_basic
--- PASS: TestAccDataLBPools_basic (108.58s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
