### PR TITLE
feat(vpc): import vpc resource and add unit test and docs

### DIFF
--- a/docs/data-sources/networking_secgroups.md
+++ b/docs/data-sources/networking_secgroups.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# g42cloud_networking_secgroups
+
+Use this data source to get the list of the available G42Cloud security groups.
+
+## Example Usage
+
+### Filter the list of security groups by a description keyword
+
+```hcl
+variable "key_word" {}
+
+data "g42cloud_networking_secgroups" "test" {
+  description = var.key_word
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the security group list.
+  If omitted, the provider-level region will be used.
+
+* `id` - (Optional, String) Specifies the id of the desired security group.
+
+* `name` - (Optional, String) Specifies the name of the security group.
+
+* `description` - (Optional, String) Specifies the description of the security group. The security groups can be
+  filtered by keywords in the description.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the security group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `security_groups` - The list of security groups. The [security_groups](#networking_security_groups) is documented below.
+
+<a name="networking_security_groups"></a>
+The `security_groups` block supports:
+
+* `id` - The security group ID.
+
+* `description`- The description of the security group.
+
+* `name` - The name of the security group.
+
+* `enterprise_project_id` - The enterprise project ID of the security group.
+
+* `created_at` - The creation time, in UTC format.
+
+* `updated_at` - The last update time, in UTC format.

--- a/docs/data-sources/vpc_peering_connection.md
+++ b/docs/data-sources/vpc_peering_connection.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# g42cloud_vpc_peering_connection
+
+The VPC Peering Connection data source provides details about a specific VPC peering connection.
+
+## Example Usage
+
+```hcl
+data "g42cloud_vpc" "vpc" {
+  name = "vpc"
+}
+
+data "g42cloud_vpc" "peer_vpc" {
+  name = "peer_vpc"
+}
+
+data "g42cloud_vpc_peering_connection" "peering" {
+  vpc_id      = data.g42cloud_vpc.vpc.id
+  peer_vpc_id = data.g42cloud_vpc.peer_vpc.id
+}
+
+resource "g42cloud_vpc_route" "vpc_route" {
+  type        = "peering"
+  nexthop     = data.g42cloud_vpc_peering_connection.peering.id
+  destination = "192.168.0.0/16"
+  vpc_id      = data.g42cloud_vpc.vpc.id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPC peering connection. The given filters
+must match exactly one VPC peering connection whose data will be exported as attributes.
+
+* `region` - (Optional, String) The region in which to obtain the VPC Peering Connection. If omitted, the provider-level
+  region will be used.
+
+* `id` - (Optional, String) The ID of the specific VPC Peering Connection to retrieve.
+
+* `name` - (Optional, String) The name of the specific VPC Peering Connection to retrieve.
+
+* `status` - (Optional, String) The status of the specific VPC Peering Connection to retrieve.
+
+* `vpc_id` - (Optional, String) The ID of the requester VPC of the specific VPC Peering Connection to retrieve.
+
+* `peer_vpc_id` - (Optional, String) The ID of the accepter/peer VPC of the specific VPC Peering Connection to retrieve.
+
+* `peer_tenant_id` - (Optional, String) The Tenant ID of the accepter/peer VPC of the specific VPC Peering Connection to
+  retrieve.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - The description of the VPC Peering Connection.

--- a/docs/data-sources/vpc_subnets.md
+++ b/docs/data-sources/vpc_subnets.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# g42cloud_vpc_subnets
+
+Use this data source to get a list of VPC subnet.
+
+## Example Usage
+
+An example filter by name and tag
+
+```hcl
+data "g42cloud_vpc_subnets" "subnet" {
+  name = var.subnet_name
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+output "subnet_vpc_ids" {
+  value = data.g42cloud_vpc_subnets.subnet.subnets[*].vpc_id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available subnets in the current tenant.
+All subnets that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the subnet. If omitted, the provider-level
+  region will be used.
+
+* `id` - (Optional, String) - Specifies the id of the desired subnet.
+
+* `name` - (Optional, String) Specifies the name of the desired subnet.
+
+* `cidr` - (Optional, String) Specifies the network segment of desired subnet. The value must be in CIDR format.
+
+* `status` - (Optional, String) Specifies the current status of the desired subnet.
+  the value can be ACTIVE, DOWN, UNKNOWN, or ERROR.
+
+* `vpc_id` - (Optional, String) Specifies the id of the VPC that the desired subnet belongs to.
+
+* `gateway_ip` - (Optional, String) Specifies the subnet gateway address of desired subnet.
+
+* `primary_dns` - (Optional, String) Specifies the IP address of DNS server 1 on the desired subnet.
+
+* `secondary_dns` - (Optional, String) Specifies the IP address of DNS server 2 on the desired subnet.
+
+* `availability_zone` - (Optional, String) Specifies the availability zone (AZ) to which the desired subnet belongs to.
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired subnet.
+
+ -> A maximum of 10 tag keys are allowed for each query operation. Each tag key can have up to 10 tag values.
+  The tag key cannot be left blank or set to an empty string. Each tag key must be unique, and each tag value in a
+  tag must be unique, use commas(,) to separate the multiple values. An empty for values indicates any value.
+  The values are in the OR relationship.
+
+## **Attributes Reference**
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+* `subnets` - Indicates a list of all subnets found. The [subnets](#vpc_subnets) structure is documented below.
+
+<a name="vpc_subnets"></a>
+The `subnets` block supports:
+
+* `id` - Indicates the ID of the subnet.
+* `name` - Indicates the name of the subnet.
+* `description` - Indicates the description of the subnet.
+* `cidr` - Indicates the cidr block of the subnet.
+* `status` - Indicates the current status of the subnet.
+* `vpc_id` - Indicates the Id of the VPC that the subnet belongs to.
+* `gateway_ip` - Indicates the subnet gateway address of the subnet.
+* `primary_dns` - Indicates the IP address of DNS server 1 on the subnet.
+* `secondary_dns` - Indicates the IP address of DNS server 2 on the subnet.
+* `availability_zone` - Indicates the availability zone (AZ) to which the subnet belongs to.
+* `dhcp_enable` - Indicates whether the DHCP is enabled.
+* `dns_list` - Indicates The IP address list of DNS servers on the subnet.
+* `ipv4_subnet_id` - Indicates the ID of the IPv4 subnet (Native OpenStack API).
+* `ipv6_enable` - Indicates whether the IPv6 is enabled.
+* `ipv6_subnet_id` - Indicates the ID of the IPv6 subnet (Native OpenStack API).
+* `ipv6_cidr` - Indicates the IPv6 subnet CIDR block.
+* `ipv6_gateway` - Indicates the IPv6 subnet gateway.
+* `tags` - Indicates the key/value pairs which associated with the subnet.

--- a/docs/data-sources/vpcs.md
+++ b/docs/data-sources/vpcs.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# g42cloud_vpcs
+
+Use this data source to get a list of VPC.
+
+## Example Usage
+
+An example filter by name and tag
+
+```hcl
+variable "vpc_name" {}
+
+data "g42cloud_vpcs" "vpc" {
+  name = var.vpc_name
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+output "vpc_ids" {
+  value = data.g42cloud_vpcs.vpc.vpcs[*].id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPCs in the current region.
+ All VPCs that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the VPC. If omitted, the provider-level region
+  will be used.
+
+* `id` - (Optional, String) Specifies the id of the desired VPC.
+
+* `name` - (Optional, String) Specifies the name of the desired VPC. The value is a string of no more than 64 characters
+  and can contain digits, letters, underscores (_) and hyphens (-).
+
+* `status` - (Optional, String) Specifies the current status of the desired VPC. The value can be CREATING, OK or ERROR.
+
+* `cidr` - (Optional, String) Specifies the cidr block of the desired VPC.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired VPC belongs to.
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired VPC.
+
+ -> A maximum of 10 tag keys are allowed for each query operation. Each tag key can have up to 10 tag values.
+  The tag key cannot be left blank or set to an empty string. Each tag key must be unique, and each tag value in a
+  tag must be unique, use commas(,) to separate the multiple values. An empty for values indicates any value.
+  The values are in the OR relationship.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+* `vpcs` - Indicates a list of all VPCs found. The [vpcs](#vpc_vpcs) structure is documented below.
+
+<a name="vpc_vpcs"></a>
+The `vpcs` block supports:
+
+* `id` - Indicates the ID of the VPC.
+* `name` - Indicates the name of the VPC.
+* `cidr` - Indicates the cidr block of the VPC.
+* `status` - Indicates the current status of the VPC.
+* `enterprise_project_id` - Indicates the the enterprise project ID of the VPC.
+* `description` - Indicates the description of the VPC.
+* `tags` - Indicates the key/value pairs which associated with the VPC.

--- a/docs/resources/vpc_flow_log.md
+++ b/docs/resources/vpc_flow_log.md
@@ -1,0 +1,86 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# g42cloud_vpc_flow_log
+
+Manages a VPC flow log resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+var "subnet_id" {}
+
+resource "g42cloud_lts_group" "test_group" {
+  group_name  = "test_group"
+  ttl_in_days = 7
+}
+resource "g42cloud_lts_stream" "test_stream" {
+  group_id    = g42cloud_lts_group.test_group.id
+  stream_name = "test_stream"
+}
+
+resource "g42cloud_vpc_flow_log" "test_flowlog" {
+  name          = "flowlog-test"
+  resource_type = "network"
+  resource_id   = var.subnet_id
+  traffic_type  = "all"
+  log_group_id  = g42cloud_lts_group.test_group.id
+  log_stream_id = g42cloud_lts_stream.test_stream.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new VPC flow log.
+
+* `name` - (Required, String) Specifies the VPC flow log name. The value can contain no more than 64 characters,
+  including letters, digits, underscores (_), hyphens (-), and periods (.).
+
+* `resource_type` - (Required, String, ForceNew) Specifies the resource type for which that the logs to be collected.
+  The value can be:
+  + *port*: Select this to record traffic information about a specific NIC.
+  + *network*: Select this to record traffic information about all NICs in a specific subnet.
+  + *vpc*: Select this to record traffic information about all NICs in a specific VPC.
+
+  Changing this creates a new VPC flow log.
+
+* `resource_id` - (Required, String, ForceNew) Specifies the resource ID for which that the logs to be collected.
+  Changing this creates a new VPC flow log.
+
+* `log_group_id` - (Required, String, ForceNew) Specifies the LTS log group ID.
+  Changing this creates a new VPC flow log.
+
+* `log_stream_id` - (Required, String, ForceNew) Specifies the LTS log stream ID.
+  Changing this creates a new VPC flow log.
+
+* `traffic_type` - (Optional, String, ForceNew) Specifies the type of traffic to log. The value can be:
+  + *all*: Specifies that both accepted and rejected traffic of the specified resource will be logged.
+  + *accept*: Specifies that only accepted inbound and outbound traffic of the specified resource will be logged.
+  + *reject*: Specifies that only rejected inbound and outbound traffic of the specified resource will be logged.
+
+  Defauts to *all*. Changing this creates a new VPC flow log.
+
+* `enabled` - (Optional, Bool) Specifies whether to enable the flow log function, the default value is *true*.
+
+* `description` - (Optional, String) Specifies description about the VPC flow log.
+  The value can contain no more than 255 characters and cannot contain angle brackets (< or >).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The VPC flow log ID in UUID format.
+
+* `status` - The status of the flow log. The value can be `ACTIVE`, `DOWN` or `ERROR`.
+
+## Import
+
+VPC flow logs can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_vpc_flow_log_v1.flowlog1 41b9d73f-eb1c-4795-a100-59a99b062513
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -253,8 +253,9 @@ func Provider() *schema.Provider {
 
 			"g42cloud_nat_gateway": nat.DataSourcePublicGateway(),
 
-			"g42cloud_networking_port":     vpc.DataSourceNetworkingPortV2(),
-			"g42cloud_networking_secgroup": vpc.DataSourceNetworkingSecGroup(),
+			"g42cloud_networking_port":      vpc.DataSourceNetworkingPortV2(),
+			"g42cloud_networking_secgroup":  vpc.DataSourceNetworkingSecGroup(),
+			"g42cloud_networking_secgroups": vpc.DataSourceNetworkingSecGroups(),
 
 			"g42cloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
@@ -275,11 +276,14 @@ func Provider() *schema.Provider {
 			"g42cloud_vpc_eip":       eip.DataSourceVpcEip(),
 			"g42cloud_vpc_eips":      eip.DataSourceVpcEips(),
 
-			"g42cloud_vpc":             vpc.DataSourceVpcV1(),
-			"g42cloud_vpc_subnet":      vpc.DataSourceVpcSubnetV1(),
-			"g42cloud_vpc_subnet_ids":  vpc.DataSourceVpcSubnetIdsV1(),
-			"g42cloud_vpc_route":       vpc.DataSourceVpcRouteV2(),
-			"g42cloud_vpc_route_table": vpc.DataSourceVPCRouteTable(),
+			"g42cloud_vpc":                    vpc.DataSourceVpcV1(),
+			"g42cloud_vpcs":                   vpc.DataSourceVpcs(),
+			"g42cloud_vpc_peering_connection": vpc.DataSourceVpcPeeringConnectionV2(),
+			"g42cloud_vpc_subnet":             vpc.DataSourceVpcSubnetV1(),
+			"g42cloud_vpc_subnets":            vpc.DataSourceVpcSubnets(),
+			"g42cloud_vpc_subnet_ids":         vpc.DataSourceVpcSubnetIdsV1(),
+			"g42cloud_vpc_route":              vpc.DataSourceVpcRouteV2(),
+			"g42cloud_vpc_route_table":        vpc.DataSourceVPCRouteTable(),
 
 			"g42cloud_vpcep_public_services": vpcep.DataSourceVPCEPPublicServices(),
 
@@ -500,6 +504,7 @@ func Provider() *schema.Provider {
 			"g42cloud_vpc_eip_associate": eip.ResourceEIPAssociate(),
 
 			"g42cloud_vpc":                             vpc.ResourceVirtualPrivateCloudV1(),
+			"g42cloud_vpc_flow_log":                    vpc.ResourceVpcFlowLog(),
 			"g42cloud_vpc_route":                       vpc.ResourceVPCRouteTableRoute(),
 			"g42cloud_vpc_route_table":                 vpc.ResourceVPCRouteTable(),
 			"g42cloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),

--- a/g42cloud/services/acceptance/vpc/data_source_g42cloud_networking_secgroups_test.go
+++ b/g42cloud/services/acceptance/vpc/data_source_g42cloud_networking_secgroups_test.go
@@ -1,0 +1,136 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccNetworkingSecGroupsDataSource_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_networking_secgroups.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingSecGroupsDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.description",
+						"[Acc Test] The security group name is "+rName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.0.id",
+						"g42cloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingSecGroupsDataSource_description(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_networking_secgroups.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingSecGroupsDataSource_description(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.description",
+						"[Acc Test] The security group name is "+rName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.0.id",
+						"g42cloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingSecGroupsDataSource_id(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_networking_secgroups.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingSecGroupsDataSource_id(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.description",
+						"[Acc Test] The security group name is "+rName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.0.id",
+						"g42cloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkingSecGroupsDataSource_base(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_networking_secgroup" "test" {
+  name        = "%s"
+  description = "[Acc Test] The security group name is %s"
+}
+`, rName, rName)
+}
+
+func testAccNetworkingSecGroupsDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_networking_secgroups" "test" {
+  name = g42cloud_networking_secgroup.test.name
+}
+`, testAccNetworkingSecGroupsDataSource_base(rName))
+}
+
+func testAccNetworkingSecGroupsDataSource_description(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_networking_secgroups" "test" {
+  description = g42cloud_networking_secgroup.test.description
+}
+`, testAccNetworkingSecGroupsDataSource_base(rName))
+}
+
+func testAccNetworkingSecGroupsDataSource_id(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_networking_secgroups" "test" {
+  id = g42cloud_networking_secgroup.test.id
+}
+`, testAccNetworkingSecGroupsDataSource_base(rName))
+}

--- a/g42cloud/services/acceptance/vpc/data_source_g42cloud_vpc_peering_connection_test.go
+++ b/g42cloud/services/acceptance/vpc/data_source_g42cloud_vpc_peering_connection_test.go
@@ -1,0 +1,161 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccVpcPeeringConnectionDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpc_peering_connection.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcPeeringConnectionDataSource_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "vpc1 peers to vpc2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVpcPeeringConnectionDataSource_byVpcId(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpc_peering_connection.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcPeeringConnectionDataSource_byVpcId(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVpcPeeringConnectionDataSource_byPeerVpcId(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpc_peering_connection.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcPeeringConnectionDataSource_byPeerVpcId(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVpcPeeringConnectionDataSource_byVpcIds(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpc_peering_connection.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcPeeringConnectionDataSource_byVpcIds(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpcPeeringConnectionDataSource_base(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "vpc_1" {
+  name = "%[1]s_1"
+  cidr = "172.16.0.0/20"
+}
+
+resource "g42cloud_vpc" "vpc_2" {
+  name = "%[1]s_2"
+  cidr = "172.16.128.0/20"
+}
+
+resource "g42cloud_vpc_peering_connection" "test" {
+  name        = "%[1]s"
+  vpc_id      = g42cloud_vpc.vpc_1.id
+  peer_vpc_id = g42cloud_vpc.vpc_2.id
+  description = "vpc1 peers to vpc2"
+}
+`, rName)
+}
+
+func testAccVpcPeeringConnectionDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_peering_connection" "test" {
+  id = g42cloud_vpc_peering_connection.test.id
+}
+`, testAccVpcPeeringConnectionDataSource_base(rName))
+}
+
+func testAccVpcPeeringConnectionDataSource_byVpcId(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_peering_connection" "test" {
+	vpc_id = g42cloud_vpc_peering_connection.test.vpc_id
+}
+`, testAccVpcPeeringConnectionDataSource_base(rName))
+}
+
+func testAccVpcPeeringConnectionDataSource_byPeerVpcId(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_peering_connection" "test" {
+	peer_vpc_id = g42cloud_vpc_peering_connection.test.peer_vpc_id
+}
+`, testAccVpcPeeringConnectionDataSource_base(rName))
+}
+
+func testAccVpcPeeringConnectionDataSource_byVpcIds(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_peering_connection" "test" {
+  vpc_id      = g42cloud_vpc_peering_connection.test.vpc_id
+  peer_vpc_id = g42cloud_vpc_peering_connection.test.peer_vpc_id
+}
+`, testAccVpcPeeringConnectionDataSource_base(rName))
+}

--- a/g42cloud/services/acceptance/vpc/data_source_g42cloud_vpc_subnets_test.go
+++ b/g42cloud/services/acceptance/vpc/data_source_g42cloud_vpc_subnets_test.go
@@ -1,0 +1,247 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccVpcSubnetsDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr, randGatewayIp := acceptance.RandomCidrAndGatewayIp()
+	dataSourceName := "data.g42cloud_vpc_subnets.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSubnetsDataSource_Basic(randName, randCidr, randGatewayIp),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.gateway_ip", randGatewayIp),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.dhcp_enable", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.primary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.secondary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.ipv4_subnet_id"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "subnets.0.vpc_id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpcSubnetsDataSource_Basic(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_subnets" "test" {
+  id = g42cloud_vpc_subnet.test.id
+}
+`, testAccVpcSubnetsDataSource_Base(rName, cidr, gatewayIp))
+}
+
+func TestAccVpcSubnetsDataSource_ipv4ByCidr(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr, randGatewayIp := acceptance.RandomCidrAndGatewayIp()
+	dataSourceName := "data.g42cloud_vpc_subnets.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSubnetsDataSource_ipv4ByCidr(randName, randCidr, randGatewayIp),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.gateway_ip", randGatewayIp),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.dhcp_enable", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.primary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.secondary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.ipv4_subnet_id"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "subnets.0.vpc_id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpcSubnetsDataSource_ipv4ByCidr(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_subnets" "test" {
+  cidr = g42cloud_vpc_subnet.test.cidr
+}
+`, testAccVpcSubnetsDataSource_Base(rName, cidr, gatewayIp))
+}
+
+func TestAccVpcSubnetsDataSource_ipv4ByName(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr, randGatewayIp := acceptance.RandomCidrAndGatewayIp()
+	dataSourceName := "data.g42cloud_vpc_subnets.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSubnetsDataSource_ipv4ByName(randName, randCidr, randGatewayIp),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.gateway_ip", randGatewayIp),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.dhcp_enable", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.primary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.secondary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.ipv4_subnet_id"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "subnets.0.vpc_id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpcSubnetsDataSource_ipv4ByName(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_subnets" "test" {
+  name = g42cloud_vpc_subnet.test.name
+}
+`, testAccVpcSubnetsDataSource_Base(rName, cidr, gatewayIp))
+}
+
+func TestAccVpcSubnetsDataSource_ipv4ByVpcId(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr, randGatewayIp := acceptance.RandomCidrAndGatewayIp()
+	dataSourceName := "data.g42cloud_vpc_subnets.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSubnetsDataSource_ipv4ByVpcId(randName, randCidr, randGatewayIp),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.gateway_ip", randGatewayIp),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.dhcp_enable", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.primary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.secondary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.ipv4_subnet_id"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "subnets.0.vpc_id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpcSubnetsDataSource_ipv4ByVpcId(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_subnets" "test" {
+  vpc_id = g42cloud_vpc_subnet.test.vpc_id
+}
+`, testAccVpcSubnetsDataSource_Base(rName, cidr, gatewayIp))
+}
+
+func TestAccVpcSubnetsDataSource_ipv6Basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr, randGatewayIp := acceptance.RandomCidrAndGatewayIp()
+	dataSourceName := "data.g42cloud_vpc_subnets.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSubnetsDataSource_ipv6Basic(randName, randCidr, randGatewayIp),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.gateway_ip", randGatewayIp),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.0.dhcp_enable", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.primary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.secondary_dns"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.ipv4_subnet_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "subnets.0.ipv6_subnet_id"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "subnets.0.vpc_id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpcSubnetsDataSource_ipv6Basic(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpc_subnets" "test" {
+  id = g42cloud_vpc_subnet.test.id
+}
+`, testAccVpcSubnetsDataSource_ipv6Base(rName, cidr, gatewayIp))
+}
+
+func testAccVpcSubnetsDataSource_Base(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "%s"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name       = "%s"
+  vpc_id     = g42cloud_vpc.test.id
+  cidr       = "%s"
+  gateway_ip = "%s"
+}`, rName, cidr, rName, cidr, gatewayIp)
+}
+
+func testAccVpcSubnetsDataSource_ipv6Base(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "%s"
+}
+
+resource "g42cloud_vpc_subnet" "test" {
+  name        = "%s"
+  cidr        = "%s"
+  gateway_ip  = "%s"
+  vpc_id      = g42cloud_vpc.test.id
+  ipv6_enable = true
+}`, rName, cidr, rName, cidr, gatewayIp)
+}

--- a/g42cloud/services/acceptance/vpc/data_source_g42cloud_vpcs_test.go
+++ b/g42cloud/services/acceptance/vpc/data_source_g42cloud_vpcs_test.go
@@ -1,0 +1,236 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccVpcsDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.g42cloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_basic(randName, randCidr),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "vpcs.0.id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_base(rName, cidr string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test" {
+  name = "%s"
+  cidr = "%s"
+}
+`, rName, cidr)
+}
+
+func testAccDataSourceVpcs_basic(rName, cidr string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpcs" "test" {
+  id = g42cloud_vpc.test.id
+}
+`, testAccDataSourceVpcs_base(rName, cidr))
+}
+
+func TestAccVpcsDataSource_byCidr(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.g42cloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_byCidr(randName, randCidr),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_byCidr(rName, cidr string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpcs" "test" {
+  cidr = g42cloud_vpc.test.cidr
+
+  depends_on = [
+    g42cloud_vpc.test
+  ]
+}
+`, testAccDataSourceVpcs_base(rName, cidr))
+}
+
+func TestAccVpcsDataSource_byName(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.g42cloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_byName(randName, randCidr),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "vpcs.0.id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_byName(rName, cidr string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpcs" "test" {
+  name = g42cloud_vpc.test.name
+
+  depends_on = [
+    g42cloud_vpc.test
+  ]
+}
+`, testAccDataSourceVpcs_base(rName, cidr))
+}
+
+func TestAccVpcsDataSource_byAll(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.g42cloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_byAll(randName, randCidr),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "vpcs.0.id",
+						"${g42cloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_byAll(rName, cidr string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_vpcs" "test" {
+  id     = g42cloud_vpc.test.id
+  name   = g42cloud_vpc.test.name
+  cidr   = g42cloud_vpc.test.cidr
+  status = "OK"
+
+  depends_on = [
+    g42cloud_vpc.test
+  ]
+}
+`, testAccDataSourceVpcs_base(rName, cidr))
+}
+
+func TestAccVpcsDataSource_tags(t *testing.T) {
+	randName1 := acceptance.RandomAccResourceName()
+	randName2 := acceptance.RandomAccResourceName()
+	dataSourceName := "data.g42cloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_tags(randName1, randName2),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.foo", randName1),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName1),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_tags(rName1, rName2 string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "test1" {
+  name = "%s"
+  cidr = "172.16.0.0/24"
+  tags = {
+    foo = "%s"
+  }
+}
+
+resource "g42cloud_vpc" "test2" {
+  name = "%s"
+  cidr = "10.12.2.0/24"
+  tags = {
+    foo = "%s"
+  }
+}
+
+data "g42cloud_vpcs" "test" {
+  tags = {
+    foo = "%s"
+  }
+  depends_on = [
+    g42cloud_vpc.test1,
+    g42cloud_vpc.test2,
+  ]
+}
+`, rName1, rName1, rName2, rName2, rName1)
+}

--- a/g42cloud/services/acceptance/vpc/resource_g42cloud_vpc_flow_log_test.go
+++ b/g42cloud/services/acceptance/vpc/resource_g42cloud_vpc_flow_log_test.go
@@ -1,0 +1,109 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/flowlogs"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getFlowLogResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NetworkingV1Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC client: %s", err)
+	}
+	return flowlogs.Get(client, state.Primary.ID).Extract()
+}
+
+func TestAccFlowLog_basic(t *testing.T) {
+	var flowlog flowlogs.FlowLog
+	rName := acceptance.RandomAccResourceName()
+	rNameUpdate := rName + "-updated"
+	resourceName := "g42cloud_vpc_flow_log.flow_log"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&flowlog,
+		getFlowLogResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlowLog_basic(rName, rName, "created by terraform testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform testacc"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", "network"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_type", "all"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+				),
+			},
+			{
+				Config: testAccFlowLog_basic(rName, rNameUpdate, "updated by terraform testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated by terraform testacc"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccFlowLogConfigBase(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_vpc" "vpc_1" {
+  name = "vpc-%[1]s"
+  cidr = "172.16.0.0/16"
+}
+
+resource "g42cloud_vpc_subnet" "subnet_1" {
+  vpc_id     = g42cloud_vpc.vpc_1.id
+  name       = "subnet-%[1]s"
+  cidr       = "172.16.0.0/24"
+  gateway_ip = "172.16.0.1"
+}
+
+resource "g42cloud_lts_group" "acc_group" {
+  group_name  = "%[1]s"
+  ttl_in_days = 7
+}
+resource "g42cloud_lts_stream" "acc_stream" {
+  group_id    = g42cloud_lts_group.acc_group.id
+  stream_name = "%[1]s"
+}
+`, name)
+}
+
+func testAccFlowLog_basic(baseName, resName, resDesc string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_vpc_flow_log" "flow_log" {
+  name          = "%s"
+  description   = "%s"
+  resource_type = "network"
+  resource_id   = g42cloud_vpc_subnet.subnet_1.id
+  log_group_id  = g42cloud_lts_group.acc_group.id
+  log_stream_id = g42cloud_lts_stream.acc_stream.id
+}
+`, testAccFlowLogConfigBase(baseName), resName, resDesc)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
transfer vpc resources from HuaweiCloud to G42Cloud
**Which issue this PR fixes**:
import vpc resource and add unit test and docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccFlowLog_basic
=== PAUSE TestAccFlowLog_basic
=== CONT  TestAccFlowLog_basic
--- PASS: TestAccFlowLog_basic (92.37s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccNetworkingSecGroupsDataSource_description
=== PAUSE TestAccNetworkingSecGroupsDataSource_description
=== CONT  TestAccNetworkingSecGroupsDataSource_description
--- PASS: TestAccNetworkingSecGroupsDataSource_description (34.65s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccNetworkingSecGroupsDataSource_id
=== PAUSE TestAccNetworkingSecGroupsDataSource_id
=== CONT  TestAccNetworkingSecGroupsDataSource_id
--- PASS: TestAccNetworkingSecGroupsDataSource_id (36.63s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccVpcPeeringConnectionDataSource_basic
=== PAUSE TestAccVpcPeeringConnectionDataSource_basic
=== CONT  TestAccVpcPeeringConnectionDataSource_basic
--- PASS: TestAccVpcPeeringConnectionDataSource_basic (60.46s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByCidr
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByCidr
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByCidr (67.49s)
PASS

coverage: 11.5% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== PAUSE TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== CONT  TestAccVpcPeeringConnectionDataSource_byPeerVpcId
--- PASS: TestAccVpcPeeringConnectionDataSource_byPeerVpcId (59.93s)
PASS

coverage: 8.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccOBSBucketAcl_basic
=== PAUSE TestAccOBSBucketAcl_basic
=== CONT  TestAccOBSBucketAcl_basic
--- PASS: TestAccOBSBucketAcl_basic (76.84s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
