### PR TITLE
feat(TMS): add a data source to query supported resource types information

### DIFF
--- a/docs/data-sources/tms_resource_types.md
+++ b/docs/data-sources/tms_resource_types.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Tag Management Service (TMS)"
+---
+
+# g42cloud_tms_resource_types
+
+Using this data source to query supported resource types information that used to manage resource tags within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "supported_region" {}
+
+data "g42cloud_tms_resource_types" "test" {
+  region = var.supported_region
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region name used to filter resource types information
+
+* `service_name` - (Optional, String) Specifies the service name used to filter resource types information.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `types` - All resource types that match the filter parameters.
+  The [types](#tms_resource_types) structure is documented below.
+
+<a name="tms_resource_types"></a>
+The `types` block supports:
+
+* `name` - The resource type name.
+
+* `is_global` - Whether the resource corresponding to this type is a global resource.
+
+* `display_name` - The service display name of the resource type.
+
+* `service_name` - The name of the service to which the resource type belong.

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -271,6 +271,8 @@ func Provider() *schema.Provider {
 
 			"g42cloud_sms_source_servers": sms.DataSourceServers(),
 
+			"g42cloud_tms_resource_types": tms.DataSourceResourceTypes(),
+
 			"g42cloud_vpc_bandwidth": eip.DataSourceBandWidth(),
 			"g42cloud_vpc_eip":       eip.DataSourceVpcEip(),
 			"g42cloud_vpc_eips":      eip.DataSourceVpcEips(),

--- a/g42cloud/services/acceptance/acceptance.go
+++ b/g42cloud/services/acceptance/acceptance.go
@@ -507,3 +507,9 @@ func TestAccPreCheckUserId(t *testing.T) {
 		t.Skip("The environment variables does not support the user ID (G42_USER_ID) for acc tests")
 	}
 }
+
+func TestAccPreCheckProjectID(t *testing.T) {
+	if G42_PROJECT_ID == "" {
+		t.Skip("G42_PROJECT_ID must be set for acceptance tests")
+	}
+}

--- a/g42cloud/services/acceptance/tms/resource_g42cloud_tms_resource_tags_test.go
+++ b/g42cloud/services/acceptance/tms/resource_g42cloud_tms_resource_tags_test.go
@@ -1,0 +1,177 @@
+package tms
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	tags "github.com/chnsz/golangsdk/openstack/tms/v1/resourcetags"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/tms"
+)
+
+func getResourceTagsFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.TmsV2Client(acceptance.G42_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating TMS v2 client: %s", err)
+	}
+
+	var (
+		projectId       = state.Primary.Attributes["project_id"]
+		resourcesLen, _ = strconv.Atoi(state.Primary.Attributes["resources.#"])
+		tagsLen, _      = strconv.Atoi(state.Primary.Attributes["tags.%"])
+		tagsConfigured  = false
+	)
+
+	for i := 0; i < resourcesLen; i++ {
+		resourceId := state.Primary.Attributes[fmt.Sprintf("resources.%d.resource_id", i)]
+		opts := tags.QueryOpts{
+			ResourceId:   resourceId,
+			ResourceType: state.Primary.Attributes[fmt.Sprintf("resources.%d.resource_type", i)],
+			ProjectId:    projectId,
+		}
+		resp, err := tags.Get(client, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error query resource (%s) tags: %s", resourceId, err)
+		}
+		actualTags := tms.FlattenTagsToMap(resp)
+		if len(actualTags) != tagsLen {
+			return nil, fmt.Errorf("some tags were not set successfully")
+		}
+		if len(actualTags) > 0 {
+			tagsConfigured = true
+		}
+	}
+	if !tagsConfigured {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return tagsConfigured, nil
+}
+
+func TestAccResourceTags_basic(t *testing.T) {
+	var (
+		tagsConfigured bool
+
+		rName    = "g42cloud_tms_resource_tags.test"
+		basicCfg = testAccResourceTags_base()
+		rc       = acceptance.InitResourceCheck(rName, &tagsConfigured, getResourceTagsFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceTags_basic_step1(basicCfg),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(rName, "resources.0.resource_type", "DNS_public_zone"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.resource_id", "g42cloud_dns_zone.test", "id"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
+				),
+			},
+			{
+				Config: testAccResourceTags_basic_step2(basicCfg),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(rName, "resources.0.resource_type", "instance"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.resource_id", "huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(rName, "tags.creator", "terraform"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceTags_base() string {
+	var (
+		name         = acceptance.RandomAccResourceName()
+		nameWithDash = acceptance.RandomAccResourceNameWithDash()
+		bgpAsNum     = acctest.RandIntRange(64512, 65534)
+	)
+
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_dns_zone" "test" {
+  name      = "%[2]s.com."
+  email     = "jdoe@example.com"
+  ttl       = 3000
+  zone_type = "public"
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = slice(data.g42cloud_availability_zones.test.names, 0, 1)
+  
+  name = "%[1]s"
+  asn  = "%[3]d"
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+`, name, nameWithDash, bgpAsNum)
+}
+
+func testAccResourceTags_basic_step1(basicCfg string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_tms_resource_tags" "test" {
+  project_id = "%[2]s"
+
+  resources {
+    resource_type = "DNS_public_zone"
+    resource_id   = g42cloud_dns_zone.test.id
+  }
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, basicCfg, acceptance.G42_PROJECT_ID)
+}
+
+func testAccResourceTags_basic_step2(basicCfg string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_tms_resource_tags" "test" {
+  project_id = "%[2]s"
+
+  resources {
+    resource_type = "instance"
+    resource_id   = huaweicloud_er_instance.test.id
+  }
+
+  tags = {
+    foo     = "baar"
+    creator = "terraform"
+  }
+}
+`, basicCfg, acceptance.G42_PROJECT_ID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
transfer tms data sources from HuaweiCloud Provider to G42Cloud Provider
**Which issue this PR fixes**:
import tms resource, unit tests and docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceResourceTypes_basic
=== PAUSE TestAccDataSourceResourceTypes_basic
=== CONT  TestAccDataSourceResourceTypes_basic
--- PASS: TestAccDataSourceResourceTypes_basic (22.19s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccDataSourceResourceTypes_filterByRegion
=== PAUSE TestAccDataSourceResourceTypes_filterByRegion
=== CONT  TestAccDataSourceResourceTypes_filterByRegion
--- PASS: TestAccDataSourceResourceTypes_filterByRegion (19.89s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...
```