### PR TITLE
feat(obs): add obs resources support

### DIFF
--- a/docs/resources/obs_bucket_acl.md
+++ b/docs/resources/obs_bucket_acl.md
@@ -1,0 +1,105 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# g42cloud_obs_bucket_acl
+
+Manages an OBS bucket acl resource within G42Cloud.
+
+-> **NOTE:** When creating or updating the OBS bucket acl, the original bucket acl will be overwritten. When deleting
+the OBS bucket acl, the full permissions of the bucket owner will be set, and the other permissions will be removed.
+
+## Example Usage
+
+```hcl
+variable "bucket" {}
+variable "account1" {}
+variable "account2" {}
+
+resource "g42cloud_obs_bucket_acl" "test" {
+  bucket = var.bucket
+
+  owner_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+  }
+
+  account_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = var.account1
+  }
+
+  account_permission {
+    access_to_bucket = ["READ"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = var.account2
+  }
+
+  public_permission {
+    access_to_bucket = ["READ", "WRITE"]
+  }
+
+  log_delivery_user_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+
+  Changing this parameter will create a new resource.
+
+* `bucket` - (Required, String, ForceNew) Specifies the name of the bucket to which to set the acl.
+
+  Changing this parameter will create a new resource.
+
+* `owner_permission` - (Optional, List) Specifies the bucket owner permission. If omitted, the current obs bucket acl
+  owner permission will not be changed.
+  The [owner_permission](#OBSBucketAcl_permission_struct) structure is documented below.
+
+* `public_permission` - (Optional, List) Specifies the public permission.
+  The [permission_struct](#OBSBucketAcl_permission_struct) structure is documented below.
+
+* `log_delivery_user_permission` - (Optional, List) Specifies the log delivery user permission.
+  The [permission_struct](#OBSBucketAcl_permission_struct) structure is documented below.
+
+* `account_permission` - (Optional, List) Specifies the account permissions.
+  The [account_permission_struct](#OBSBucketAcl_account_permission_struct) structure is documented below.
+
+<a name="OBSBucketAcl_permission_struct"></a>
+The `permission_struct` block supports:
+
+* `access_to_bucket` - (Optional, List) Specifies the access to bucket. Valid values are **READ** and **WRITE**.
+
+* `access_to_acl` - (Optional, List) Specifies the access to acl. Valid values are **READ_ACP** and **WRITE_ACP**.
+
+<a name="OBSBucketAcl_account_permission_struct"></a>
+The `account_permission_struct` block supports:
+
+* `access_to_bucket` - (Optional, List) Specifies the access to bucket. Valid values are **READ** and **WRITE**.
+
+* `access_to_acl` - (Optional, List) Specifies the access to acl. Valid values are **READ_ACP** and **WRITE_ACP**.
+
+* `account_id` - (Required, String) Specifies the account id to authorize. The account id cannot be the bucket owner,
+  and must be unique.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the bucket.
+
+## Import
+
+The obs bucket acl can be imported using the `bucket`, e.g.
+
+```bash
+$ terraform import g42cloud_obs_bucket_acl.test <bucket-name>
+```

--- a/docs/resources/obs_bucket_object_acl.md
+++ b/docs/resources/obs_bucket_object_acl.md
@@ -1,0 +1,104 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# g42cloud_obs_bucket_object_acl
+
+Manages an OBS bucket object acl resource within G42Cloud.
+
+-> **NOTE:** When creating or updating the OBS bucket object acl, the original object acl will be overwritten. When
+deleting the OBS bucket object acl, only the owner permissions will be retained, and the other permissions will be
+removed.
+
+## Example Usage
+
+```hcl
+variable "bucket" {}
+variable "key" {}
+variable "account1" {}
+variable "account2" {}
+
+resource "g42cloud_obs_bucket_object_acl" "test" {
+  bucket = var.bucket
+  key    = var.key
+
+  account_permission {
+    access_to_object = ["READ"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = var.account1
+  }
+
+  account_permission {
+    access_to_object = ["READ"]
+    access_to_acl    = ["READ_ACP"]
+    account_id       = var.account2
+  }
+
+  public_permission {
+    access_to_acl = ["READ_ACP", "WRITE_ACP"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+
+  Changing this parameter will create a new resource.
+
+* `bucket` - (Required, String, ForceNew) Specifies the name of the bucket which the object belongs to.
+
+  Changing this parameter will create a new resource.
+
+* `key` - (Required, String, ForceNew) Specifies the name of the object to which to set the acl.
+
+  Changing this parameter will create a new resource.
+
+* `public_permission` - (Optional, List) Specifies the object public permission.
+  The [permission_struct](#OBSBucketObjectAcl_permission_struct) structure is documented below.
+
+* `account_permission` - (Optional, List) Specifies the object account permissions.
+  The [account_permission_struct](#OBSBucketObjectAcl_account_permission_struct) structure is documented below.
+
+<a name="OBSBucketObjectAcl_permission_struct"></a>
+The `permission_struct` block supports:
+
+* `access_to_object` - (Optional, List) Specifies the access to object. Only **READ** supported.
+
+* `access_to_acl` - (Optional, List) Specifies the access to acl. Valid values are **READ_ACP** and **WRITE_ACP**.
+
+<a name="OBSBucketObjectAcl_account_permission_struct"></a>
+The `account_permission_struct` block supports:
+
+* `account_id` - (Required, String) Specifies the account id to authorize. The account id cannot be the object owner,
+  and must be unique.
+
+* `access_to_object` - (Optional, List) Specifies the access to object. Only **READ** supported.
+
+* `access_to_acl` - (Optional, List) Specifies the access to acl. Valid values are **READ_ACP** and **WRITE_ACP**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the bucket object key.
+* `owner_permission` - The object owner permission information.
+  The [owner_permission_struct](#OBSBucketObjectAcl_owner_permission_struct) structure is documented below.
+
+<a name="OBSBucketObjectAcl_owner_permission_struct"></a>
+The `owner_permission_struct` block supports:
+
+* `access_to_object` - The owner object permissions.
+
+* `access_to_acl` - The owner acl permissions.
+
+## Import
+
+The obs bucket object acl can be imported using `bucket` and `key`, separated by a slash, e.g.
+
+```bash
+$ terraform import g42cloud_obs_bucket_object_acl.test <bucket>/<key>
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -273,13 +273,13 @@ func Provider() *schema.Provider {
 
 			"g42cloud_mapreduce_clusters": mrs.DataSourceMrsClusters(),
 
+			"g42cloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
+
 			"g42cloud_nat_gateway": nat.DataSourcePublicGateway(),
 
 			"g42cloud_networking_port":      vpc.DataSourceNetworkingPortV2(),
 			"g42cloud_networking_secgroup":  vpc.DataSourceNetworkingSecGroup(),
 			"g42cloud_networking_secgroups": vpc.DataSourceNetworkingSecGroups(),
-
-			"g42cloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
 			"g42cloud_rds_backups":              rds.DataSourceBackup(),
 			"g42cloud_rds_engine_versions":      rds.DataSourceRdsEngineVersionsV3(),
@@ -491,9 +491,11 @@ func Provider() *schema.Provider {
 			"g42cloud_networking_vip":           vpc.ResourceNetworkingVip(),
 			"g42cloud_networking_vip_associate": vpc.ResourceNetworkingVIPAssociateV2(),
 
-			"g42cloud_obs_bucket":        obs.ResourceObsBucket(),
-			"g42cloud_obs_bucket_object": obs.ResourceObsBucketObject(),
-			"g42cloud_obs_bucket_policy": obs.ResourceObsBucketPolicy(),
+			"g42cloud_obs_bucket":            obs.ResourceObsBucket(),
+			"g42cloud_obs_bucket_acl":        obs.ResourceOBSBucketAcl(),
+			"g42cloud_obs_bucket_object":     obs.ResourceObsBucketObject(),
+			"g42cloud_obs_bucket_policy":     obs.ResourceObsBucketPolicy(),
+			"g42cloud_obs_bucket_object_acl": obs.ResourceOBSBucketObjectAcl(),
 
 			"g42cloud_rms_policy_assignment":                  rms.ResourcePolicyAssignment(),
 			"g42cloud_rms_resource_aggregator":                rms.ResourceAggregator(),

--- a/g42cloud/services/acceptance/obs/resource_g42cloud_obs_bucket_acl_test.go
+++ b/g42cloud/services/acceptance/obs/resource_g42cloud_obs_bucket_acl_test.go
@@ -1,0 +1,142 @@
+package obs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getOBSBucketAclResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	obsClient, err := cfg.ObjectStorageClient(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OBS Client: %s", err)
+	}
+
+	output, err := obsClient.GetBucketAcl(state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func TestAccOBSBucketAcl_basic(t *testing.T) {
+	var obj interface{}
+
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+	rName := "g42cloud_obs_bucket_acl.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOBSBucketAclResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testOBSBucketAcl_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_bucket.0", "READ"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_bucket.1", "WRITE"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_acl.0", "READ_ACP"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_acl.1", "WRITE_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.#", "2"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.#", "1"),
+				),
+			},
+			{
+				Config: testOBSBucketAcl_basic_update(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "owner_permission.0.access_to_bucket.0", "WRITE"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.0.access_to_acl.0", "WRITE_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.0.access_to_acl.0", "READ_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.0.account_id", "1000010023"),
+					resource.TestCheckResourceAttr(rName, "public_permission.0.access_to_bucket.0", "READ"),
+					resource.TestCheckResourceAttr(rName, "public_permission.0.access_to_bucket.1", "WRITE"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "public_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "account_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.#", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testOBSBucketAcl_base(bucketName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+`, bucketName)
+}
+
+func testOBSBucketAcl_basic(bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_obs_bucket_acl" "test" {
+  bucket = g42cloud_obs_bucket.bucket.bucket
+
+  account_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = "1000010020"
+  }
+
+  account_permission {
+    access_to_bucket = ["READ"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = "1000010021"
+  }
+
+  log_delivery_user_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+  }
+}
+`, testOBSBucketAcl_base(bucketName))
+}
+
+func testOBSBucketAcl_basic_update(bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_obs_bucket_acl" "test" {
+  bucket = g42cloud_obs_bucket.bucket.bucket
+
+  owner_permission {
+    access_to_bucket = ["WRITE"]
+    access_to_acl    = ["WRITE_ACP"]
+  }
+
+  account_permission {
+    access_to_acl    = ["READ_ACP"]
+    account_id       = "1000010023"
+  }
+
+  public_permission {
+    access_to_bucket = ["READ", "WRITE"]
+  }
+}
+`, testOBSBucketAcl_base(bucketName))
+}

--- a/g42cloud/services/acceptance/obs/resource_g42cloud_obs_bucket_object_acl_test.go
+++ b/g42cloud/services/acceptance/obs/resource_g42cloud_obs_bucket_object_acl_test.go
@@ -1,0 +1,212 @@
+package obs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getOBSBucketObjectAclResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	obsClient, err := cfg.ObjectStorageClient(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OBS Client: %s", err)
+	}
+	params := &obs.GetObjectAclInput{
+		Bucket: state.Primary.Attributes["bucket"],
+		Key:    state.Primary.ID,
+	}
+	return obsClient.GetObjectAcl(params)
+}
+
+func TestAccOBSBucketObjectAcl_basic(t *testing.T) {
+	var obj interface{}
+
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+	rName := "g42cloud_obs_bucket_object_acl.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOBSBucketObjectAclResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testOBSBucketObjectAcl_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(rName, "key", "test-key"),
+					resource.TestCheckResourceAttr(rName, "public_permission.0.access_to_acl.0", "READ_ACP"),
+					resource.TestCheckResourceAttr(rName, "public_permission.0.access_to_acl.1", "WRITE_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.#", "2"),
+					resource.TestCheckResourceAttr(rName, "public_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.#", "1"),
+				),
+			},
+			{
+				Config: testOBSBucketObjectAcl_basicUpdate(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(rName, "key", "test-key"),
+					resource.TestCheckResourceAttr(rName, "account_permission.0.access_to_acl.0", "READ_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.0.account_id", "1000010022"),
+					resource.TestCheckResourceAttr(rName, "public_permission.0.access_to_acl.0", "WRITE_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "public_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testObsBucketObjectAclImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccOBSBucketObjectAcl_checkError(t *testing.T) {
+	var obj interface{}
+
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+	rName := "g42cloud_obs_bucket_object_acl.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOBSBucketObjectAclResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// the object owner account id is required for this test check
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testOBSBucketObjectAcl_basicErrorCheck(bucketName),
+				ExpectError: regexp.MustCompile(`the account id cannot be the object owner`),
+			},
+		},
+	})
+}
+
+func testOBSBucketObjectAcl_basic(bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_obs_bucket_object_acl" "test" {
+  bucket = g42cloud_obs_bucket.bucket.bucket
+  key    = g42cloud_obs_bucket_object.object.key
+
+  account_permission {
+    access_to_object = ["READ"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = "1000010020"
+  }
+
+  account_permission {
+    access_to_object = ["READ"]
+    access_to_acl    = ["READ_ACP"]
+    account_id       = "1000010021"
+  }
+
+  public_permission {
+    access_to_acl = ["READ_ACP", "WRITE_ACP"]
+  }
+}
+`, testOBSBucketObjectAcl_base(bucketName))
+}
+
+func testOBSBucketObjectAcl_basicUpdate(bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_obs_bucket_object_acl" "test" {
+  bucket = g42cloud_obs_bucket.bucket.bucket
+  key    = g42cloud_obs_bucket_object.object.key
+
+  account_permission {
+    access_to_acl    = ["READ_ACP"]
+    account_id       = "1000010022"
+  }
+
+  public_permission {
+    access_to_acl = ["WRITE_ACP"]
+  }
+}
+`, testOBSBucketObjectAcl_base(bucketName))
+}
+
+func testOBSBucketObjectAcl_base(bucketName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+resource "g42cloud_obs_bucket_object" "object" {
+  bucket  = g42cloud_obs_bucket.bucket.bucket
+  key     = "test-key"
+  content = "some_bucket_content"
+}
+
+`, bucketName)
+}
+
+func testOBSBucketObjectAcl_basicErrorCheck(bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_obs_bucket_object_acl" "test" {
+  bucket = g42cloud_obs_bucket.bucket.bucket
+  key    = g42cloud_obs_bucket_object.object.key
+
+  account_permission {
+    access_to_acl    = ["READ_ACP"]
+    account_id       = "%s"
+  }
+
+  public_permission {
+    access_to_acl = ["WRITE_ACP"]
+  }
+}
+`, testOBSBucketObjectAcl_base(bucketName), acceptance.G42_DOMAIN_ID)
+}
+
+func testObsBucketObjectAclImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		bucket := rs.Primary.Attributes["bucket"]
+		if bucket == "" {
+			return "", fmt.Errorf("attribute (bucket) of Resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", bucket, rs.Primary.ID), nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
transfer obs resource from HuaweiCloud Provider to G42Cloud Provider
**Which issue this PR fixes**:
import obs resource, unit tests and docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
```
=== RUN   TestAccOBSBucketAcl_basic
=== PAUSE TestAccOBSBucketAcl_basic
=== CONT  TestAccOBSBucketAcl_basic
--- PASS: TestAccOBSBucketAcl_basic (81.70s)
PASS
coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccOBSBucketObjectAcl_basic
=== PAUSE TestAccOBSBucketObjectAcl_basic
=== CONT  TestAccOBSBucketObjectAcl_basic
--- PASS: TestAccOBSBucketObjectAcl_basic (82.19s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```
```
=== RUN   TestAccOBSBucketObjectAcl_checkError
=== PAUSE TestAccOBSBucketObjectAcl_checkError
=== CONT  TestAccOBSBucketObjectAcl_checkError
--- PASS: TestAccOBSBucketObjectAcl_checkError (25.32s)
PASS

coverage: 9.0% of statements in ../../../../../terraform-provider-g42cloud/...
```