### PR TITLE
feat(DWS): add DWS DataSource and Resources

### DIFF
--- a/docs/data-sources/dws_flavors.md
+++ b/docs/data-sources/dws_flavors.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# g42cloud_dws_flavors
+
+Use this data source to get available flavors of DWS cluster node.
+
+## Example Usage
+
+```hcl
+data "g42cloud_dws_flavors" "flavor" {
+  vcpus = 8
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `availability_zone` - (Optional, String) The availability zone name.
+
+* `vcpus` - (Optional, Int) The vcpus of the dws node flavor.
+
+* `memory` - (Optional, Int) The ram of the dws node flavor in GB.
+
+* `datastore_type` - (Optional, String) The type of datastore.  
+  The options are as follows:
+    - **dws**: OLAP, elastic scaling, unlimited scaling of compute and storage capacity.
+    - **hybrid**: a single data warehouse used for transaction and analytics workloads,
+       in single-node or cluster mode.
+    - **stream**: built-in time series operators; up to 40:1 compression ratio; applicable to IoT services.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `flavors` - The list of flavor detail.
+  The [flavors](#dwsFlavors_Flavors) structure is documented below.
+
+<a name="dwsFlavors_Flavors"></a>
+The `flavors` block supports:
+
+* `flavor_id` - The name of the dws node flavor.  
+ It is referenced by `node_type` in `g42cloud_dws_flavors`.
+
+* `datastore_type` - The type of datastore.  
+  The options are as follows:
+    - **dws**: OLAP, elastic scaling, unlimited scaling of compute and storage capacity.
+    - **hybrid**: a single data warehouse used for transaction and analytics workloads,
+       in single-node or cluster mode.
+    - **stream**: built-in time series operators; up to 40:1 compression ratio; applicable to IoT services.
+
+* `vcpus` - The vcpus of the dws node flavor.
+
+* `memory` - The ram of the dws node flavor in GB.
+
+* `volumetype` - Disk type.  
+  The options are as follows:
+    - **LOCAL_DISK**:common I/O disk.
+    - **SSD**: ultra-high I/O disk.
+
+* `size` - The default disk size in GB.
+
+* `availability_zones` - The list of availability zones.
+
+* `elastic_volume_specs` - The [elastic_volume_specs](#dwsFlavors_FlavorsElasticVolumeSpec) structure is documented below.
+
+<a name="dwsFlavors_FlavorsElasticVolumeSpec"></a>
+The `elastic_volume_specs` block supports:
+
+* `step` - Disk size increment step.
+
+* `min_size` - Minimum disk size.
+
+* `max_size` - Maximum disk size.

--- a/docs/resources/dws_alarm_subscription.md
+++ b/docs/resources/dws_alarm_subscription.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# g42cloud_dws_alarm_subscription
+
+Manages a DWS alarm subscription resource within G42Cloud.  
+
+## Example Usage
+
+```hcl
+variable "smn_urn" {}
+variable "smn_name" {}
+
+resource "g42cloud_dws_alarm_subscription" "test" {
+  name                     = "demo"
+  enable                   = 1
+  notification_target      = var.smn_urn
+  notification_target_name = var.smn_name
+  notification_target_type = "SMN"
+  alarm_level              = "urgent,important"
+  time_zone                = "GMT+08:00"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) The name of the alarm subscription.
+
+* `enable` - (Required, Int) Whether the alarm subscription is enabled.  
+  The options are as follows:
+    + **1**: enable.
+    + **0**: closed.
+
+* `notification_target` - (Required, String) The notification target.  
+
+* `notification_target_name` - (Required, String) The name of notification target.  
+
+* `notification_target_type` - (Required, String) The type of notification target. Currently only **SMN** is supported.
+
+* `time_zone` - (Required, String, ForceNew) The time_zone of the alarm subscription.  
+
+  Changing this parameter will create a new resource.
+
+* `alarm_level` - (Optional, String) The level of alarm. separate multiple alarm levels with commas (,).
+  The valid values are **urgent**, **important**, **minor**, and **prompt**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The DWS alarm subscription can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_dws_alarm_subscription.test 535d9c3c-e135-4a6f-bcbf-4db51446f471
+```

--- a/docs/resources/dws_event_subscription.md
+++ b/docs/resources/dws_event_subscription.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# g42cloud_dws_event_subscription
+
+Manages a DWS event subscription resource within G42Cloud.  
+
+## Example Usage
+
+```hcl
+variable "smn_urn" {}
+variable "smn_name" {}
+
+resource "g42cloud_dws_event_subscription" "test" {
+  name                     = "demo"
+  enable                   = 1
+  notification_target      = var.smn_urn
+  notification_target_name = var.smn_name
+  notification_target_type = "SMN"
+  category                 = "management,monitor,security"
+  severity                 = "normal,warning"
+  source_type              = "cluster,backup,disaster-recovery"
+  time_zone                = "GMT+08:00"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) The name of the event subscription.
+
+* `enable` - (Required, String) Whether the event subscription is enabled.  
+  The options are as follows:
+    + **1**: open.
+    + **0**: closed.
+
+* `notification_target` - (Required, String) The notification target.  
+
+* `notification_target_name` - (Required, String) The name of notification target.  
+
+* `notification_target_type` - (Required, String) The type of notification target. Currently only **SMN** is supported.
+
+* `source_id` - (Optional, String) ID of source event.
+
+* `source_type` - (Optional, String) The type of source event.  
+  The valid values are **cluster**, **backup**, and **disaster-recovery**.
+
+* `category` - (Optional, String) The category of source event.  
+  The valid values are **management**, **monitor**, **security** and **system alarm**.
+
+* `severity` - (Optional, String) The severity of source event.  
+  The valid values are **normal**, and **warning**.
+
+* `time_zone` - (Optional, String, ForceNew) The time_zone of the event subscription.  
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The DWS event subscription can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_dws_event_subscription.test 535d9c3c-e135-4a6f-bcbf-4db51446f471
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -436,7 +436,10 @@ func Provider() *schema.Provider {
 			"g42cloud_dns_recordset": dns.ResourceDNSRecordSetV2(),
 			"g42cloud_dns_zone":      dns.ResourceDNSZone(),
 
-			"g42cloud_dws_cluster":                 dws.ResourceDwsCluster(),
+			"g42cloud_dws_alarm_subscription": dws.ResourceDwsAlarmSubs(),
+			"g42cloud_dws_cluster":            dws.ResourceDwsCluster(),
+			"g42cloud_dws_event_subscription": dws.ResourceDwsEventSubs(),
+
 			"g42cloud_dms_rocketmq_consumer_group": dms.ResourceDmsRocketMQConsumerGroup(),
 			"g42cloud_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),
 			"g42cloud_dms_rocketmq_user":           dms.ResourceDmsRocketMQUser(),

--- a/g42cloud/services/acceptance/dws/data_source_g42cloud_dws_flavors_test.go
+++ b/g42cloud/services/acceptance/dws/data_source_g42cloud_dws_flavors_test.go
@@ -1,0 +1,133 @@
+package dws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDwsFlavorsDataSource_basic(t *testing.T) {
+	resourceName := "data.g42cloud_dws_flavors.test"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.availability_zones.#"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.vcpus", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDwsFlavorsDataSource_memory(t *testing.T) {
+	resourceName := "data.g42cloud_dws_flavors.test"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_memory,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.availability_zones.#"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.memory", "16"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDwsFlavorsDataSource_all(t *testing.T) {
+	resourceName := "data.g42cloud_dws_flavors.test"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_all,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.availability_zones.#"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.vcpus", "4"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.memory", "16"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDwsFlavorsDataSource_az(t *testing.T) {
+	resourceName := "data.g42cloud_dws_flavors.test"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_az,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDwsFlavorsDataSource_basic = `
+data "g42cloud_dws_flavors" "test" {
+  vcpus = 4
+}
+`
+
+const testAccDwsFlavorsDataSource_memory = `
+data "g42cloud_dws_flavors" "test" {
+  memory = 16
+}
+`
+
+const testAccDwsFlavorsDataSource_all = `
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_dws_flavors" "test" {
+  vcpus             = 4
+  memory            = 16
+  availability_zone = data.g42cloud_availability_zones.test.names[0]
+}
+`
+
+const testAccDwsFlavorsDataSource_az = `
+data "g42cloud_availability_zones" "test" {}
+
+data "g42cloud_dws_flavors" "test" {
+  availability_zone = data.g42cloud_availability_zones.test.names[2]
+}
+`

--- a/g42cloud/services/acceptance/dws/resource_g42cloud_dws_alarm_subscription_test.go
+++ b/g42cloud/services/acceptance/dws/resource_g42cloud_dws_alarm_subscription_test.go
@@ -1,0 +1,163 @@
+package dws
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDwsAlarmSubsResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getDwsAlarmSubs: Query the DWS alarm subscription.
+	var (
+		getDwsAlarmSubsHttpUrl = "v2/{project_id}/alarm-subs"
+		getDwsAlarmSubsProduct = "dws"
+	)
+	getDwsAlarmSubsClient, err := cfg.NewServiceClient(getDwsAlarmSubsProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+	}
+
+	getDwsAlarmSubsPath := getDwsAlarmSubsClient.Endpoint + getDwsAlarmSubsHttpUrl
+	getDwsAlarmSubsPath = strings.ReplaceAll(getDwsAlarmSubsPath, "{project_id}", getDwsAlarmSubsClient.ProjectID)
+
+	getDwsAlarmSubsResp, err := pagination.ListAllItems(
+		getDwsAlarmSubsClient,
+		"offset",
+		getDwsAlarmSubsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsAlarmSubs: %s", err)
+	}
+
+	getDwsAlarmSubsRespJson, err := json.Marshal(getDwsAlarmSubsResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsEventSubs: %s", err)
+	}
+	var getDwsAlarmSubsRespBody interface{}
+	err = json.Unmarshal(getDwsAlarmSubsRespJson, &getDwsAlarmSubsRespBody)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsEventSubs: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("alarm_subscriptions[?id=='%s']|[0]", state.Primary.ID)
+	rawData := utils.PathSearch(jsonPath, getDwsAlarmSubsRespBody, nil)
+	if rawData == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return rawData, nil
+}
+
+func TestAccDwsAlarmSubs_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dws_alarm_subscription.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDwsAlarmSubsResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDwsAlarmSubs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enable", "1"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "g42cloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "g42cloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "urgent,important"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				Config: testDwsAlarmSubs_basic_update(name + "_update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "enable", "0"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "g42cloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "g42cloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "urgent,important,minor"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				Config: testDwsAlarmSubs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enable", "1"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "g42cloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "g42cloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "urgent,important"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDwsAlarmSubs_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_smn_topic" "test" {
+  name         = "%s"
+  display_name = "The display name of topic"
+}
+
+resource "g42cloud_dws_alarm_subscription" "test" {
+  name                     = "%s"
+  enable                   = "1"
+  notification_target      = g42cloud_smn_topic.test.id
+  notification_target_type = "SMN"
+  notification_target_name = g42cloud_smn_topic.test.name
+  time_zone                = "GMT+09:00"
+  alarm_level              = "urgent,important"
+}
+`, name, name)
+}
+
+func testDwsAlarmSubs_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_smn_topic" "test" {
+  name         = "%s"
+  display_name = "The display name of topic"
+}
+
+resource "g42cloud_dws_alarm_subscription" "test" {
+  name                     = "%s"
+  enable                   = "0"
+  notification_target      = g42cloud_smn_topic.test.id
+  notification_target_type = "SMN"
+  notification_target_name = g42cloud_smn_topic.test.name
+  time_zone                = "GMT+09:00"
+  alarm_level              = "urgent,important,minor"
+}
+`, name, name)
+}

--- a/g42cloud/services/acceptance/dws/resource_g42cloud_dws_event_subscription_test.go
+++ b/g42cloud/services/acceptance/dws/resource_g42cloud_dws_event_subscription_test.go
@@ -1,0 +1,158 @@
+package dws
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDwsEventSubsResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getDwsEventSubs: Query the DWS event subscription.
+	var (
+		getDwsEventSubsHttpUrl = "v2/{project_id}/event-subs"
+		getDwsEventSubsProduct = "dws"
+	)
+	getDwsEventSubsClient, err := cfg.NewServiceClient(getDwsEventSubsProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+	}
+
+	getDwsEventSubsPath := getDwsEventSubsClient.Endpoint + getDwsEventSubsHttpUrl
+	getDwsEventSubsPath = strings.ReplaceAll(getDwsEventSubsPath, "{project_id}", getDwsEventSubsClient.ProjectID)
+
+	getDwsEventSubsResp, err := pagination.ListAllItems(
+		getDwsEventSubsClient,
+		"offset",
+		getDwsEventSubsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsEventSubs: %s", err)
+	}
+
+	getDwsEventSubsRespJson, err := json.Marshal(getDwsEventSubsResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsEventSubs: %s", err)
+	}
+	var getDwsEventSubsRespBody interface{}
+	err = json.Unmarshal(getDwsEventSubsRespJson, &getDwsEventSubsRespBody)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsEventSubs: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("event_subscriptions[?id=='%s']|[0]", state.Primary.ID)
+	rawData := utils.PathSearch(jsonPath, getDwsEventSubsRespBody, nil)
+	if rawData == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return rawData, nil
+}
+
+func TestAccDwsEventSubs_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_dws_event_subscription.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDwsEventSubsResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDwsEventSubs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enable", "1"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "g42cloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "g42cloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "category", "management,monitor,security"),
+					resource.TestCheckResourceAttr(rName, "severity", "normal,warning"),
+					resource.TestCheckResourceAttr(rName, "source_type", "cluster,backup,disaster-recovery"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				Config: testDwsEventSubs_basic_update(name + "_update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "enable", "0"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "g42cloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "g42cloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "category", "management,monitor"),
+					resource.TestCheckResourceAttr(rName, "severity", "normal"),
+					resource.TestCheckResourceAttr(rName, "source_type", "cluster,backup"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDwsEventSubs_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_smn_topic" "test" {
+  name         = "%s"
+  display_name = "The display name of topic"
+}
+
+resource "g42cloud_dws_event_subscription" "test" {
+  name                     = "%s"
+  enable                   = 1
+  notification_target      = g42cloud_smn_topic.test.id
+  notification_target_type = "SMN"
+  notification_target_name = g42cloud_smn_topic.test.name
+  category                 = "management,monitor,security"
+  severity                 = "normal,warning"
+  source_type              = "cluster,backup,disaster-recovery"
+  time_zone                = "GMT+09:00"
+}
+`, name, name)
+}
+
+func testDwsEventSubs_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_smn_topic" "test" {
+  name         = "%s"
+  display_name = "The display name of topic"
+}
+
+resource "g42cloud_dws_event_subscription" "test" {
+  name                     = "%s"
+  enable                   = 0
+  notification_target      = g42cloud_smn_topic.test.id
+  notification_target_type = "SMN"
+  notification_target_name = g42cloud_smn_topic.test.name
+  category                 = "management,monitor"
+  severity                 = "normal"
+  source_type              = "cluster,backup"
+  time_zone                = "GMT+09:00"
+}
+`, name, name)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import DWS resource, unit test and document

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed


```md

### resource_g42cloud_dws_alarm_subscription

=== RUN   TestAccDwsAlarmSubs_basic
=== PAUSE TestAccDwsAlarmSubs_basic
=== CONT  TestAccDwsAlarmSubs_basic
--- PASS: TestAccDwsAlarmSubs_basic (106.04s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_dws_event_subscription

=== RUN   TestAccDwsEventSubs_basic
=== PAUSE TestAccDwsEventSubs_basic
=== CONT  TestAccDwsEventSubs_basic
--- PASS: TestAccDwsEventSubs_basic (69.95s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```


```md

### data_source_g42cloud_dws_flavors

=== RUN   TestAccDwsFlavorsDataSource_basic
=== PAUSE TestAccDwsFlavorsDataSource_basic
=== CONT  TestAccDwsFlavorsDataSource_basic
--- PASS: TestAccDwsFlavorsDataSource_basic (22.89s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccDwsFlavorsDataSource_memory
=== PAUSE TestAccDwsFlavorsDataSource_memory
=== CONT  TestAccDwsFlavorsDataSource_memory
--- PASS: TestAccDwsFlavorsDataSource_memory (24.49s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccDwsFlavorsDataSource_all
=== PAUSE TestAccDwsFlavorsDataSource_all
=== CONT  TestAccDwsFlavorsDataSource_all
--- PASS: TestAccDwsFlavorsDataSource_all (27.87s)
PASS
coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccDwsFlavorsDataSource_az
=== PAUSE TestAccDwsFlavorsDataSource_az
=== CONT  TestAccDwsFlavorsDataSource_az
--- PASS: TestAccDwsFlavorsDataSource_az (29.22s)
PASS

```

