### PR TITLE
feat(LTS): import LTS resource, unit test and document

### DIFF
--- a/docs/data-sources/lts_structuring_custom_templates.md
+++ b/docs/data-sources/lts_structuring_custom_templates.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_structuring_custom_templates
+
+Use this data source to get the list of LTS structuring custom templates.
+
+## Example Usage
+
+```hcl
+data "g42cloud_lts_structuring_custom_templates" "test" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `template_id` - (Optional, String) Specifies the custom template ID to be queried.
+
+* `name` - (Optional, String) Specifies the custom template name to be queried.
+
+* `type` - (Optional, String) Specifies the custom template type to be queried. Valid values are: **regex**, **json**,
+  **split** and **nginx**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `templates` - The list of LTS structuring custom templates.
+  The [templates](#CustomTemplates_templates) structure is documented below.
+
+<a name="CustomTemplates_templates"></a>
+The `templates` block supports:
+
+* `id` - The structuring custom template ID.
+
+* `name` - The structuring custom template name.
+
+* `type` - The structuring custom template type.
+
+* `demo_log` - The sample log event.

--- a/docs/resources/lts_aom_access.md
+++ b/docs/resources/lts_aom_access.md
@@ -1,0 +1,152 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_aom_access
+
+Manages an AOM to LTS log mapping rule resource within G42Cloud.
+
+## Example Usage
+
+### Creating with all workloads
+
+```hcl
+variable "cluster_id" {}
+variable "cluster_name" {}
+variable "log_group_id" {}
+variable "log_group_name" {}
+variable "log_stream_id" {}
+variable "log_stream_name" {}
+
+resource "g42cloud_lts_aom_access" "test" {
+  name         = "test_name"
+  cluster_id   = var.cluster_id
+  cluster_name = var.cluster_name
+  namespace    = "default"
+  workloads    = ["__ALL_DEPLOYMENTS__"]
+  
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+
+  access_rules {
+    file_name       = "/demo/demo.log"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+}
+```
+
+### Creating with specify workloads
+
+```hcl
+variable "cluster_id" {}
+variable "cluster_name" {}
+variable "log_group_id" {}
+variable "log_group_name" {}
+variable "log_stream_id" {}
+variable "log_stream_name" {}
+variable "workload" {}
+
+resource "g42cloud_lts_aom_access" "test" {
+  name         = "test_name"
+  cluster_id   = var.cluster_id
+  cluster_name = var.cluster_name
+  namespace    = "default"
+  workloads    = [var.workload]
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+}
+```
+
+### Creating with CCI cluster
+
+```hcl
+variable "log_group_id" {}
+variable "log_group_name" {}
+variable "log_stream_id" {}
+variable "log_stream_name" {}
+
+resource "g42cloud_lts_aom_access" "test" {
+  name         = "test_name"
+  cluster_id   = "CCI-ClusterID"
+  cluster_name = "CCI-Cluster"
+  namespace    = "default"
+  workloads    = ["__ALL_DEPLOYMENTS__"]
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the unique rule name. The name consists of 1 to 100 characters,
+  including letters, digits, underscores (_), hyphens (-) and dots (.).
+
+* `cluster_id` - (Required, String) Specifies the CCE or CCI cluster ID. It is fixed to **CCI-ClusterID** for CCI.
+
+* `cluster_name` - (Required, String) Specifies the CCE or CCI cluster name. It is fixed to **CCI-Cluster** for CCI.
+
+* `namespace` - (Required, String) Specifies the namespace.
+
+* `workloads` - (Required, List) Specifies the workloads.
+  + When creating with all workloads, this field should be `["__ALL_DEPLOYMENTS__"]`.
+  + When creating with specify workloads, this field should be the list of workloads.
+
+* `access_rules` - (Required, List) Specifies the access log details.
+  The [access_rules](#AOMAccess_access_rules) structure is documented below.
+
+* `container_name` - (Optional, String) Specifies the container name.
+
+<a name="AOMAccess_access_rules"></a>
+The `access_rules` block supports:
+
+* `file_name` - (Required, String) Specifies the path name.
+  + When collecting access all logs, set this field to `__ALL_FILES__`.
+  + When collecting specify log paths, the matching rule should be `^\/[A-Za-z0-9.*_\/-]+|stdout\.log|`, such as
+  `/test/*` or `/test/demo.log`. Up to two asterisks (*) are allowed.
+
+* `log_group_id` - (Required, String) Specifies the log group ID.
+
+* `log_group_name` - (Required, String) Specifies the log group name.
+
+* `log_stream_id` - (Required, String) Specifies the log stream ID.
+
+* `log_stream_name` - (Required, String) Specifies the log stream name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The AOM to LTS log mapping rule can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_lts_aom_access.test <id>
+```

--- a/docs/resources/lts_host_access.md
+++ b/docs/resources/lts_host_access.md
@@ -1,0 +1,156 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_host_access
+
+Manages an LTS host access resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "group_id" {}
+variable "stream_id" {}
+variable "host_group_id" {}
+
+resource "g42cloud_lts_host_access" "test" {
+  name           = "access-demo"
+  log_group_id   = var.group_id
+  log_stream_id  = var.stream_id
+  host_group_ids = [ var.host_group_id ]
+
+  access_config {
+    paths       = ["/var/log/*"]
+    black_paths = ["/var/log/*/a.log"]
+
+    single_log_format {
+      mode = "system"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the host access name. The name consists of 1 to 64 characters.
+  Only letters, digits, underscores (_), and periods (.) are allowed, and the period cannot be the first or last character.
+  Changing this parameter will create a new resource.
+
+* `log_group_id` - (Required, String, ForceNew) Specifies the log group ID.
+  Changing this parameter will create a new resource.
+
+* `log_stream_id` - (Required, String, ForceNew) Specifies the log stream ID.
+  Changing this parameter will create a new resource.
+
+* `access_config` - (Required, List) Specifies the configurations of host access.
+  The [access_config](#HostAccessConfigDeatil) structure is documented below.
+
+* `host_group_ids` - (Optional, List) Specifies the log access host group ID list.
+
+* `tags` - (Optional, Map) Specifies the key/value to attach to the host access.
+
+<a name="HostAccessConfigDeatil"></a>
+The `access_config` block supports:
+
+* `paths` - (Required, List) Specifies the collection paths.
+
+  + A path must start with `/` or `Letter:\`.
+  + A path cannot contain only slashes (/). The following special characters are not allowed: <>'|"
+  + A path cannot start with `/**` or `/*`.
+  + Only one double asterisk (**) can be contained in a path.
+  + Up to 10 paths can be specified.
+
+* `black_paths` - (Optional, List) Specifies the collection path blacklist.
+
+  + A path must start with `/` or `Letter:\`.
+  + A path cannot contain only slashes (/). The following special characters are not allowed: <>'|"
+  + A path cannot start with `/**` or `/*`.
+  + Only one double asterisk (**) can be contained in a path.
+  + Up to 10 paths can be specified.
+
+  -> If you blacklist a file or directory that has been set as a collection path, the blacklist settings
+    will be used and the file or files in the directory will be filtered out.
+
+* `single_log_format` - (Optional, List) Specifies the configuration single-line logs. Each log line is displayed as a
+  single log event. The [single_log_format](#HostAccessConfigSingleLogFormat) structure is documented below.
+
+* `multi_log_format` - (Optional, List) Specifies the configuration multi-line logs. Multiple lines of exception log events
+  can be displayed as a single log event. This is helpful when you check logs to locate problems.
+  The [multi_log_format](#HostAccessConfigMultiLogFormat) structure is documented below.
+
+* `windows_log_info` - (Optional, List) Specifies the configuration of Windows event logs.
+  The [windows_log_info](#HostAccessConfigWindowsLogInfo) structure is documented below.
+
+<a name="HostAccessConfigSingleLogFormat"></a>
+The `single_log_format` blocks supports:
+
+* `mode` - (Required, String) Specifies mode of single-line log format. The options are as follows:
+  + **system**: the system time.
+  + **wildcard**: the time wildcard.
+
+* `value` - (Optional, String) Specifies value of single-line log format.
+  + If mode is **system**, the value is the current timestamp, the number of milliseconds elapsed since January 1, 1970 UTC.
+  + If mode is **wildcard**, the value is **required** and is a time wildcard, which is used to look for the log printing
+    time as the beginning of a log event. If the time format in a log event is `2019-01-01 23:59:59`, the time wildcard is
+    **YYYY-MM-DD hh:mm:ss**. If the time format in a log event is `19-1-1 23:59:59`, the time wildcard is **YY-M-D hh:mm:ss**.
+
+<a name="HostAccessConfigMultiLogFormat"></a>
+The `multi_log_format` blocks supports:
+
+* `mode` - (Required, String) Specifies mode of multi-line log format. The options are as follows:
+  + **time**: the time wildcard.
+  + **regular**: the regular expression.
+
+* `value` - (Required, String) Specifies value of multi-line log format.
+  + If mode is **regular**, the value is a regular expression.
+  + If mode is **time**, the value is a time wildcard, which is used to look for the log printing time as the beginning
+    of a log event. If the time format in a log event is `2019-01-01 23:59:59`, the time wildcard is **YYYY-MM-DD hh:mm:ss**.
+    If the time format in a log event is `19-1-1 23:59:59`, the time wildcard is **YY-M-D hh:mm:ss**.
+
+-> The time wildcard and regular expression will look for the specified pattern right from the beginning of each log line.
+  If no match is found, the system time, which may be different from the time in the log event, is used. In general cases,
+  you are advised to select **Single-line** for Log Format and **system** time for Log Time.
+
+<a name="HostAccessConfigWindowsLogInfo"></a>
+The `windows_log_info` block supports:
+
+* `categorys` - (Required, List) Specifies the types of Windows event logs to collect. The valid values are
+  **Application**, **System**, **Security** and **Setup**.
+
+* `event_level` - (Required, List) Specifies the Windows event severity. The valid values are **information**, **warning**,
+   **error**, **critical** and **verbose**.  Only Windows Vista or later is supported.
+
+* `time_offset_unit` - (Required, String) Specifies the collection time offset unit. The valid values are
+  **day**, **hour** and **sec**.
+
+* `time_offset` - (Required, Int) Specifies the collection time offset. This time takes effect only for the first
+  time to ensure that the logs are not collected repeatedly.
+
+  + When `time_offset_unit` is set to **day**, the value ranges from 1 to 7 days.
+  + When `time_offset_unit` is set to **hour**, the value ranges from 1 to 168 hours.
+  + When `time_offset_unit` is set to **sec**, the value ranges from 1 to 604800 seconds.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the host access.
+
+* `access_type` - The log access type.
+
+* `log_group_name` - The log group name.
+
+* `log_stream_name` - The log stream name.
+
+## Import
+
+The host access can be imported using the `name`, e.g.
+
+```bash
+$ terraform import g42cloud_lts_host_access.test access-demo
+```

--- a/docs/resources/lts_host_group.md
+++ b/docs/resources/lts_host_group.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_host_group
+
+Manages an LTS host group resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "group_name" {}
+variable "host_id_1" {}
+variable "host_id_2" {}
+
+resource "g42cloud_lts_host_group" "test" {
+  name     = var.group_name
+  type     = "linux"
+  host_ids = [
+    var.host_id_1, var.host_id_2
+  ]
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the host group.
+
+* `type` - (Required, String, ForceNew) Specifies the type of the host group.
+  The value can be **linux** and **windows**.
+
+  Changing this parameter will create a new resource.
+
+* `host_ids` - (Optional, List) Specifies the ID list of hosts to join the host group.
+
+* `tags` - (Optional, Map) Specifies the key/value to attach to the host group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+## Import
+
+The host group can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_lts_host_group.test 020f77b3-765a-4f4c-8d67-c5de35576d14
+```

--- a/docs/resources/lts_keywords_alarm_rule.md
+++ b/docs/resources/lts_keywords_alarm_rule.md
@@ -1,0 +1,179 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_keywords_alarm_rule
+
+Manages an LTS keywords alarm rule resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_keywords_alarm_rule" "test" {
+  name        = "terraform_test"
+  description = "created by terraform"
+  alarm_level = "CRITICAL"
+  
+  keywords_requests {
+    keywords               = "terraform_test_keywords"
+    condition              = ">"
+    number                 = 100
+    log_group_id           = var.log_group_id
+    log_stream_id          = var.log_stream_id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type = "HOURLY"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the keywords alarm rule.
+  The value can contain no more than 64 characters.
+  Changing this parameter will create a new resource.
+
+* `keywords_requests` - (Required, List) Specifies the keywords requests.
+  The [keywords_requests](#KeywordsAlarmRule_KeywordsRequests) structure is documented below.
+
+* `frequency` - (Required, List) Specifies the alarm frequency configurations.
+  The [frequency](#KeywordsAlarmRule_Frequency) structure is documented below.
+
+* `alarm_level` - (Required, String) Specifies the alarm level.
+  The value can be: **INFO**, **MINOR**, **MAJOR** and **CRIRICAL**.
+
+* `description` - (Optional, String) Specifies the description of the keywords alarm rule.
+
+* `send_notifications` - (Optional, Bool, ForceNew) Specifies whether to send notifications.
+  Changing this parameter will create a new resource.
+
+* `notification_rule` - (Optional, List, ForceNew) Specifies the notification rule.
+  The [notification_rule](#KeywordsAlarmRule_NotificationRule) structure is documented below.
+  Changing this parameter will create a new resource.
+
+* `trigger_condition_count` - (Optional, Int) Specifies the count to trigger the alarm.
+  Defaults to **1**.
+
+* `trigger_condition_frequency` - (Optional, Int) Specifies the frequency to trigger the alarm.
+  Defaults to **1**.
+
+* `send_recovery_notifications` - (Optional, Bool) Specifies whether to send recovery notifications.
+
+* `recovery_frequency` - (Optional, Int) Specifies the frequency to recover the alarm.
+  Defaults to **3**.
+
+* `status` - (Optional, String) Specifies the status. The value can be: **RUNNING** and **STOPPING**.
+  Defaults to **RUNNING**.
+
+<a name="KeywordsAlarmRule_KeywordsRequests"></a>
+The `keywords_requests` block supports:
+
+* `keywords` - (Required, String) Specifies the keywords.
+
+* `condition` - (Required, String) Specifies the keywords request condition.
+  The value can be: **>=**, **<=**, **<** and **>**.
+
+* `number` - (Required, Int) Specifies the line number.
+
+* `log_stream_id` - (Required, String) Specifies the log stream id.
+
+* `log_group_id` - (Required, String) Specifies the log group id.
+
+* `search_time_range_unit` - (Required, String) Specifies the unit of search time range.
+  The value can be: **minute** and **hour**.
+
+* `search_time_range` - (Required, Int) Specifies the search time range.
+  + When the `search_time_range_unit` is **minute**, the value ranges from **1** to **60**.
+  + When the `search_time_range_unit` is **hour**, the value ranges from **1** to **24**
+
+<a name="KeywordsAlarmRule_Frequency"></a>
+The `frequency` block supports:
+
+* `type` - (Required, String) Specifies the frequency type.
+  The value can be: **CRON**, **HOURLY**, **DAILY**, **WEEKLY** and **FIXED_RATE**.
+
+* `cron_expression` - (Optional, String) Specifies the cron expression.
+  This parameter is used when `type` is set to **CRON**.
+
+* `hour_of_day` - (Optional, Int) Specifies the hour of day.
+  This parameter is used when `type` is set to **DAILY** or **WEEKLY**.
+  The value ranges from **0** to **23**.
+
+* `day_of_week` - (Optional, Int) Specifies the day of week.
+  This parameter is used when `type` is set to **WEEKLY**.
+  The value ranges from **1** to **7**. **1** means Sunday.
+
+* `fixed_rate_unit` - (Optional, String) Specifies the unit of fixed rate.
+  The value can be: **minute** and **hour**.
+
+* `fixed_rate` - (Optional, Int) Specifies the unit fixed rate.
+  This parameter is used when `type` is set to **FIXED_RATE**.
+  + When the `fixed_rate_unit` is **minute**, the value ranges from **1** to **60**.
+  + When the `fixed_rate_unit` is **hour**, the value ranges from **1** to **24**
+
+<a name="KeywordsAlarmRule_NotificationRule"></a>
+The `notification_rule` block supports:
+
+* `template_name` - (Required, String, ForceNew) Specifies the notification template name.
+  Changing this parameter will create a new resource.
+
+* `user_name` - (Required, String, ForceNew) Specifies the user name.
+  Changing this parameter will create a new resource.
+
+* `topics` - (Required, List, ForceNew) Specifies the SMN topics.
+  The [topics](#KeywordsAlarmRule_Topic) structure is documented below.
+  Changing this parameter will create a new resource.
+
+* `timezone` - (Optional, String, ForceNew) Specifies the timezone.
+  Changing this parameter will create a new resource.
+
+* `language` - (Optional, String, ForceNew) Specifies the notification language.
+  The value can be **zh-cn** and **en-us**.
+  Changing this parameter will create a new resource.
+
+<a name="KeywordsAlarmRule_Topic"></a>
+The `topics` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the topic name.
+  Changing this parameter will create a new resource.
+
+* `topic_urn` - (Required, String, ForceNew) Specifies the topic URN.
+  Changing this parameter will create a new resource.
+
+* `display_name` - (Optional, String, ForceNew) Specifies the display name.
+  This will be shown as the sender of the message.
+  Changing this parameter will create a new resource.
+
+* `push_policy` - (Optional, String, ForceNew) Specifies the push policy.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+  
+* `domain_id` - The domain ID.
+
+* `created_at` - The creation time of the alarm rule.
+
+* `updated_at` - The last update time of the alarm rule.
+
+## Import
+
+The keywords alarm rule can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_lts_keywords_alarm_rule.test ed8a4e02-b017-4c22-919d-8877b10cf505
+```

--- a/docs/resources/lts_search_criteria.md
+++ b/docs/resources/lts_search_criteria.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_search_criteria
+
+Manages an LTS search criteria resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_search_criteria" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+
+  criteria = "content:test"
+  name     = "search_criteria_test"
+  type     = "ORIGINALLOG"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `log_group_id` - (Required, String, ForceNew) Specifies the ID of a log group. Changing this parameter will create
+  a new resource.
+
+* `log_stream_id` - (Required, String, ForceNew) Specifies the ID of a log stream. Changing this parameter will create
+  a new resource.
+
+* `criteria` - (Required, String, ForceNew) Specifies the content of search criteria. Changing this parameter will create
+  a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the search criteria. The name can only contain English
+  letters, numbers, Chinese characters, hyphens, underscores, and periods. It cannot start with a period or underscore
+  or end with a period.Changing this parameter will create a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the type of the search criteria. Available types are
+  **ORIGINALLOG** (for raw logs) and **VISUALIZATION** (for visualized logs). Changing this parameter will create a new
+  resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID. Changing this parameter
+  will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The search criteria can be imported using the group ID, stream ID, and resource ID separated by a slash, e.g.
+
+```bash
+$ terraform import g42cloud_lts_search_criteria.test <log_group_id>/<log_stream_id>/<id>
+```

--- a/docs/resources/lts_sql_alarm_rule.md
+++ b/docs/resources/lts_sql_alarm_rule.md
@@ -1,0 +1,180 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_sql_alarm_rule
+
+Manages an LTS SQL alarm rule resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_sql_alarm_rule" "test" {
+  name                 = "terraform_test"
+  description          = "created by terraform"
+  condition_expression = "t>2"
+  alarm_level          = "CRITICAL"
+
+  sql_requests {
+    title                  = "terraform_test"
+    sql                    = "select count(*) as t"
+    log_group_id           = var.log_group_id
+    log_stream_id          = var.log_stream_id      
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type = "HOURLY"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the SQL alarm rule.
+  The value can contain no more than 64 characters.
+  Changing this parameter will create a new resource.
+
+* `sql_requests` - (Required, List) Specifies the SQL requests.
+  The [sql_requests](#SQLAlarmRule_SQLRequests) structure is documented below.
+
+* `frequency` - (Required, List) Specifies the alarm frequency configurations.
+  The [frequency](#SQLAlarmRule_Frequency) structure is documented below.
+
+* `condition_expression` - (Required, String) Specifies the condition expression.
+
+* `alarm_level` - (Required, String) Specifies the alarm level.
+  The value can be: **INFO**, **MINOR**, **MAJOR** and **CRIRICAL**.
+
+* `description` - (Optional, String) Specifies the description of the SQL alarm rule.
+
+* `send_notifications` - (Optional, Bool, ForceNew) Specifies whether to send notifications.
+  Changing this parameter will create a new resource.
+
+* `notification_rule` - (Optional, List, ForceNew) Specifies the notification rule.
+  Changing this parameter will create a new resource.
+  The [notification_rule](#SQLAlarmRule_NotificationRule) structure is documented below.
+
+* `trigger_condition_count` - (Optional, Int) Specifies the count to trigger the alarm.
+  Defaults to **1**.
+
+* `trigger_condition_frequency` - (Optional, Int) Specifies the frequency to trigger the alarm.
+  Defaults to **1**.
+
+* `send_recovery_notifications` - (Optional, Bool) Specifies whether to send recovery notifications.
+
+* `recovery_frequency` - (Optional, Int) Specifies the frequency to recover the alarm.
+  Defaults to **3**.
+
+* `status` - (Optional, String) Specifies the status. The value can be: **RUNNING** and **STOPPING**.
+  Defaults to **RUNNNING**
+
+<a name="SQLAlarmRule_SQLRequests"></a>
+The `sql_requests` block supports:
+
+* `title` - (Required, String) Specifies the SQL request title.
+
+* `sql` - (Required, String) Specifies the SQL.
+
+* `log_stream_id` - (Required, String) Specifies the log stream id.
+
+* `log_group_id` - (Required, String) Specifies the log group id.
+
+* `search_time_range_unit` - (Required, String) Specifies the unit of search time range.
+  The value can be: **minute** and **hour**.
+
+* `search_time_range` - (Required, Int) Specifies the search time range.
+  + When the `search_time_range_unit` is **minute**, the value ranges from **1** to **60**;
+  + When the `search_time_range_unit` is **hour**, the value ranges from **1** to **24**;
+
+* `is_time_range_relative` - (Optional, Bool) Specifies the SQL request is relative to time range.
+
+<a name="SQLAlarmRule_Frequency"></a>
+The `frequency` block supports:
+
+* `type` - (Required, String) Specifies the frequency type.
+  The value can be: **CRON**, **HOURLY**, **DAILY**, **WEEKLY** and **FIXED_RATE**.
+
+* `cron_expression` - (Optional, String) Specifies the cron expression.
+  This parameter is used when `type` is set to **CRON**.
+
+* `hour_of_day` - (Optional, Int) Specifies the hour of day.
+  This parameter is used when `type` is set to **DAILY** or **WEEKLY**.
+  The value ranges from **0** to **23**.
+
+* `day_of_week` - (Optional, Int) Specifies the day of week.
+  This parameter is used when `type` is set to **WEEKLY**.
+  The value ranges from **1** to **7**. **1** means Sunday.
+
+* `fixed_rate_unit` - (Optional, String) Specifies the unit of fixed rate.
+  The value can be: **minute** and **hour**.
+
+* `fixed_rate` - (Optional, Int) Specifies the unit fixed rate.
+  This parameter is used when `type` is set to **FIXED_RATE**.
+  + When the `fixed_rate_unit` is **minute**, the value ranges from **1** to **60**.
+  + When the `fixed_rate_unit` is **hour**, the value ranges from **1** to **24**
+
+<a name="SQLAlarmRule_NotificationRule"></a>
+The `notification_rule` block supports:
+
+* `template_name` - (Required, String, ForceNew) Specifies the notification template name.
+  Changing this parameter will create a new resource.
+
+* `language` - (Required, String, ForceNew) Specifies the notification language.
+  The value can be **zh-cn** and **en-us**.
+  Changing this parameter will create a new resource.
+
+* `user_name` - (Required, String, ForceNew) Specifies the user name.
+  Changing this parameter will create a new resource.
+
+* `topics` - (Required, List, ForceNew) Specifies the SMN topics.
+  The [topics](#SQLAlarmRule_Topic) structure is documented below.
+  Changing this parameter will create a new resource.
+
+* `timezone` - (Optional, String, ForceNew) Specifies the timezone.
+  Changing this parameter will create a new resource.
+
+<a name="SQLAlarmRule_Topic"></a>
+The `topics` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the topic name.
+  Changing this parameter will create a new resource.
+
+* `topic_urn` - (Required, String, ForceNew) Specifies the topic URN.
+  Changing this parameter will create a new resource.
+
+* `display_name` - (Optional, String, ForceNew) Specifies the display name.
+  This will be shown as the sender of the message.
+  Changing this parameter will create a new resource.
+
+* `push_policy` - (Optional, String, ForceNew) Specifies the push policy.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `domain_id` - The domain ID.
+
+* `created_at` - The creation time of the alarm rule.
+
+* `updated_at` - The last update time of the alarm rule.
+
+## Import
+
+The sql alarm rule can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_lts_sql_alarm_rule.test ed8a4e02-b017-4c22-919d-8877b10cf505
+```

--- a/docs/resources/lts_structuring_configuration.md
+++ b/docs/resources/lts_structuring_configuration.md
@@ -1,0 +1,159 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_structuring_configuration
+
+Manages an LTS structuring configuration resource within G42Cloud.
+
+## Example Usage
+
+### Creating with system template
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_structuring_configuration" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  template_name = "CTS"
+  template_type = "built_in"
+}
+```
+
+### Creating with custom template
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+variable "template_name" {}
+variable "template_id" {}
+
+resource "g42cloud_lts_structuring_configuration" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  template_name = var.template_name
+  template_id   = var.template_id
+  template_type = "custom"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `log_group_id` - (Required, String, ForceNew) Specifies the log group ID.
+  Changing this parameter will create a new resource.
+
+* `log_stream_id` - (Required, String, ForceNew) Specifies the log stream ID.
+  Changing this parameter will create a new resource.
+
+* `template_type` - (Required, String) Specifies the type of the template. The valid values are as follows:
+  + **built_in**: System templates.
+  + **custom**: Custom templates.
+
+* `template_name` - (Required, String) Specifies the template name. When `template_type` is set to **built_in**,
+  valid values are:
+  + **ELB**.
+  + **VPC**.
+  + **CTS**.
+  + **APIG**.
+  + **DCS_AUDIT**: DCS audit log.
+  + **TOMCAT**.
+  + **NGINX**.
+  + **GAUSSDB_OPENGAUSS_AUDIT**: GAUSSV5 audit log.
+  + **DDS_AUDIT**: DDS audit log.
+  + **MONGODB_ERROR**: DDS error log.
+  + **MONGODB_SLOW**: DDS slow log.
+  + **CFW_ACCESS**: CFW access control log.
+  + **CFW_ATTACK**: CFW attack log.
+  + **CFW_FLOW**: CFW traffic log.
+  + **MYSQL_ERROR**: MYSQL error log.
+  + **MYSQL_SLOW**: MYSQL slow log:
+  + **POSTGRESQL_SLOW**: POSTGRESQL slow log.
+  + **POSTGRESQL_ERROR**: POSTGRESQL error log.
+  + **SQLSERVER_ERROR**: SQLSERVER error log.
+  + **GAUSSDB_REDIS_SLOW**: GAUSSDB_REDIS slow log.
+  + **CDN**.
+  + **SMN**.
+  + **GAUSSDB_MYSQL_ERROR**: GAUSSDB_MYSQL error log.
+  + **GAUSSDB_MYSQL_SLOW**: GAUSSDB_MYSQL slow log.
+  + **ER**: ER Enterprise Router.
+  + **MYSQL_AUDIT**: MYSQL audit log.
+  + **GAUSSDB_CASSANDRA_SLOW**: GaussDBforCassandra slow log.
+  + **GAUSSDB_MONGO_SLOW**: GaussDBforMongo slow log.
+  + **GAUSSDB_MONGO_ERROR**: GaussDBforMongo error log.
+  + **WAF_ACCESS**: WAF access log.
+  + **WAF_ATTACK**: WAF attack log.
+  + **DMS_REBALANCED**:DMS rebalancing log.
+  + **CCE_AUDIT**: CCE audit log.
+  + **CCE_EVENT**: CCE event log.
+  + **GAUSSDB_REDIS_AUDIT**: GaussDBforRedis audit log.
+
+* `template_id` - (Optional, String) Specifies the template ID. The field is valid and required only when
+  `template_type` is set to **custom**.
+
+* `demo_fields` - (Optional, List) Specifies the example fields. Use to set quick analysis configurations for fields.
+  Only need to enter the fields whose status is different from that of `is_analysis` in the template.
+  The [demo_fields](#StructConfig_fields) structure is documented below.
+
+* `tag_fields` - (Optional, List) Specifies the tag fields. Use to set quick analysis configurations for fields.
+  Only need to enter the fields whose status is different from that of `is_analysis` in the template.
+  The [tag_fields](#StructConfig_fields) structure is documented below.
+
+* `quick_analysis` - (Optional, Bool) Specifies whether to enable `demo_fields` and `tag_fields` quick analysis.
+  + If this parameter is set to **true**, quick analysis is enabled for all `demo_fields` and `tag_fields`.
+  + If this parameter is set to **false**, `is_analysis` in `demo_fields` and `tag_fields` in the template determines
+    whether to enable quick analysis.
+
+  Defaults to **false**.
+
+<a name="StructConfig_fields"></a>
+The `demo_fields` and `tag_fields` block supports:
+
+* `is_analysis` - (Optional, Bool) Specifies whether quick analysis is enabled. Defaults to **false**.
+
+* `field_name` - (Required, String) Specifies the field name. The valid length is limited from `1` to `64`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `demo_log` - The sample log event.
+
+## Import
+
+The LTS structuring configuration can be imported using `log_group_id` and `log_stream_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import g42cloud_lts_structuring_configuration.test <log_group_id>/<log_stream_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `template_type`, `template_id`,
+`demo_fields`, `tag_fields`, `quick_analysis`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "g42cloud_lts_structuring_configuration" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      template_type,
+      template_id,
+      demo_fields,
+      tag_fields,
+      quick_analysis,
+    ]
+  }
+}
+```

--- a/docs/resources/lts_structuring_custom_configuration.md
+++ b/docs/resources/lts_structuring_custom_configuration.md
@@ -1,0 +1,234 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_structuring_custom_configuration
+
+Manages an LTS structuring custom configuration resource within G42Cloud.
+
+## Example Usage
+
+### Creating with json structuring method
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  content       = "{'code':38,'user':{'name':'testdemo'}}"
+  layers        = 3
+  
+  demo_fields {
+    is_analysis = true
+    field_name  = "code"
+    content     = "38"
+    type        = "long"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "user.name"
+    content     = "testdemo"
+    type        = "string"
+  }
+
+  tag_fields {
+    is_analysis = true
+    field_name  = "hostIP"
+    content     = "192.168.2.134"
+    type        = "string"
+  }
+}
+```
+
+### Creating with split structuring method
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  content       = "2023-09-09/18:50:51 Error"
+  tokenizer     = " "
+  
+  demo_fields {
+    is_analysis = true
+    field_name  = "b1"
+    content     = "2023-09-09/18:50:51"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "b2"
+    content     = "Error"
+    type        = "string"
+  }
+}
+```
+
+### Creating with nginx structuring method
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  content       = "39.149.31.187 - - [12/Mar/2020:12:24:02 +0800] \"GET / HTTP/1.1\" 304 "
+  log_format    = "log_format  main   '$remote_addr - $remote_user [$time_local] \"$request\" '\n'$status ';"
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "remote_addr"
+    content     = "39.149.31.187"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "remote_user"
+    content     = "-"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "request_method"
+    content     = "GET"
+    type        = "string"
+  }
+}
+```
+
+### Creating with custom regex structuring method
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  content       = "2023-09-09/18:15:41 this log is Error NO 6323"
+  regex_rules   = "^(?<a01>[^ ]+)(?:[^ ]* ){1}(?<a02>\\w+)(?:[^ ]* ){1}(?<a03>\\w+)(?:[^ ]* )"
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "a01"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "a02"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "a03"
+    type        = "string"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `log_group_id` - (Required, String, ForceNew) Specifies the log group ID.
+  Changing this parameter will create a new resource.
+
+* `log_stream_id` - (Required, String, ForceNew) Specifies the log stream ID.
+  Changing this parameter will create a new resource.
+
+* `content` - (Required, String) Specifies a sample log event. LTS will create parsing rules based on the sample log.
+
+* `demo_fields` - (Required, List) Specifies the list of example fields. The maximum length is `200`. The field sequence
+  in `demo_fields` must be the same as that in `content`. The listed fields will be used as log extraction fields.
+  The [demo_fields](#StructCustomConfig_demo_fields) structure is documented below.
+
+* `regex_rules` - (Optional, String) Specifies the regular expression. The maximum length is `5000` characters.
+  When this field is specified, regular analysis will be used to parse the logs.
+
+* `layers` - (Optional, Int) Specifies the maximum parsing layers. The maximum value is `3`.
+  When this field is specified, the log body will be parsed in JSON format and split into key-value pairs.
+
+* `tokenizer` - (Optional, String) Specifies the delimiter, such as spaces and colons.
+  When this field is specified, the log body will be parsed by specifying separators.
+
+* `log_format` - (Optional, String) Specifies the nginx configuration.
+  When this field is specified, key-value pairs are extracted from Nginx log events.
+
+* `tag_fields` - (Optional, List) Specifies the tag field array. This field is only needed when tag fields are used for
+  parsing. The [tag_fields](#StructCustomConfig_tag_fields) structure is documented below.
+
+<a name="StructCustomConfig_demo_fields"></a>
+The `demo_fields` block supports:
+
+* `field_name` - (Optional, String) Specifies the field name. The value ranges from `1` to `50`.
+
+* `type` - (Optional, String) Specifies the field data type. Valid values are **string**, **long** and **float**.
+
+* `is_analysis` - (Optional, Bool) Specifies whether quick analysis is enabled. Defaults to **false**.
+
+* `content` - (Optional, String) Specifies the field content.
+
+<a name="StructCustomConfig_tag_fields"></a>
+The `tag_fields` block supports:
+
+* `field_name` - (Required, String) Specifies the field name. The value ranges from `1` to `50`.
+
+* `type` - (Required, String) Specifies the field data type. Valid values are **string**, **long** and **float**.
+
+* `is_analysis` - (Optional, Bool) Specifies whether quick analysis is enabled. Defaults to **false**.
+
+* `content` - (Optional, String) Specifies the field content.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The LTS structuring custom configuration can be imported using `log_group_id` and `log_stream_id`, separated by a slash,
+e.g.
+
+```bash
+$ terraform import g42cloud_lts_structuring_custom_configuration.test <log_group_id>/<log_stream_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `demo_fields`, `regex_rules`, `layers`,
+`tokenizer`, `log_format`, `tag_fields`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      demo_fields,
+      regex_rules,
+      layers,
+      tokenizer,
+      log_format,
+      tag_fields,
+    ]
+  }
+}
+```

--- a/docs/resources/lts_waf_access.md
+++ b/docs/resources/lts_waf_access.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# g42cloud_lts_waf_access
+
+Manages an LTS access WAF logs configuration resource within G42Cloud.
+
+-> **NOTE:** This resource depends on WAF instances, the instance can be Cloud Mode or Dedicated Mode.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "lts_group_id" {}
+variable "lts_attack_stream_id" {}
+variable "lts_access_stream_id" {}
+
+resource "g42cloud_lts_waf_access" "test" {
+  enterprise_project_id = var.enterprise_project_id
+  lts_group_id          = var.lts_group_id
+  lts_attack_stream_id  = var.lts_attack_stream_id
+  lts_access_stream_id  = var.lts_access_stream_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `lts_group_id` - (Required, String) Specifies the log group ID.
+
+* `lts_attack_stream_id` - (Optional, String) Specifies the log stream ID for attack logs.
+
+* `lts_access_stream_id` - (Optional, String) Specifies the log stream ID for access logs.
+
+-> The fields `lts_attack_stream_id` and `lts_access_stream_id` must be specified as different log streams.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID. If not specified, the
+  default enterprise project will be used. The default enterprise project ID is **0**.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The LTS access WAF logs configuration can be imported using the `enterprise_project_id`, e.g.
+
+```bash
+$ terraform import g42cloud_lts_waf_access.test <enterprise_project_id>
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -262,6 +262,8 @@ func Provider() *schema.Provider {
 			"g42cloud_lb_certificate":  lb.DataSourceLBCertificateV2(),
 			"g42cloud_lb_pools":        lb.DataSourcePools(),
 
+			"g42cloud_lts_structuring_custom_templates": lts.DataSourceCustomTemplates(),
+
 			"g42cloud_modelarts_datasets":         modelarts.DataSourceDatasets(),
 			"g42cloud_modelarts_dataset_versions": modelarts.DataSourceDatasetVerions(),
 			"g42cloud_modelarts_models":           modelarts.DataSourceModels(),
@@ -482,8 +484,17 @@ func Provider() *schema.Provider {
 			"g42cloud_lb_pool":         lb.ResourcePoolV2(),
 			"g42cloud_lb_whitelist":    lb.ResourceWhitelistV2(),
 
-			"g42cloud_lts_group":  lts.ResourceLTSGroup(),
-			"g42cloud_lts_stream": lts.ResourceLTSStream(),
+			"g42cloud_lts_aom_access":                       lts.ResourceAOMAccess(),
+			"g42cloud_lts_group":                            lts.ResourceLTSGroup(),
+			"g42cloud_lts_host_access":                      lts.ResourceHostAccessConfig(),
+			"g42cloud_lts_host_group":                       lts.ResourceHostGroup(),
+			"g42cloud_lts_keywords_alarm_rule":              lts.ResourceKeywordsAlarmRule(),
+			"g42cloud_lts_search_criteria":                  lts.ResourceSearchCriteria(),
+			"g42cloud_lts_sql_alarm_rule":                   lts.ResourceSQLAlarmRule(),
+			"g42cloud_lts_stream":                           lts.ResourceLTSStream(),
+			"g42cloud_lts_structuring_configuration":        lts.ResourceStructConfig(),
+			"g42cloud_lts_structuring_custom_configuration": lts.ResourceStructCustomConfig(),
+			"g42cloud_lts_waf_access":                       lts.ResourceWAFAccess(),
 
 			"g42cloud_mapreduce_cluster": mrs.ResourceMRSClusterV2(),
 			"g42cloud_mapreduce_job":     mrs.ResourceMRSJobV2(),

--- a/g42cloud/services/acceptance/acceptance.go
+++ b/g42cloud/services/acceptance/acceptance.go
@@ -73,6 +73,14 @@ var (
 
 	G42_ENTERPRISE_MIGRATE_PROJECT_ID_TEST = os.Getenv("G42_ENTERPRISE_MIGRATE_PROJECT_ID_TEST")
 	G42_MODELARTS_HAS_SUBSCRIBE_MODEL      = os.Getenv("G42_MODELARTS_HAS_SUBSCRIBE_MODEL")
+
+	G42_CCE_CLUSTER_ID                  = os.Getenv("G42_CCE_CLUSTER_ID")
+	G42_CCE_CLUSTER_NAME                = os.Getenv("G42_CCE_CLUSTER_NAME")
+	G42_CCE_CLUSTER_ID_ANOTHER          = os.Getenv("G42_CCE_CLUSTER_ID_ANOTHER")
+	G42_CCE_CLUSTER_NAME_ANOTHER        = os.Getenv("G42_CCE_CLUSTER_NAME_ANOTHER")
+	G42_LTS_STRUCT_CONFIG_TEMPLATE_ID   = os.Getenv("G42_LTS_STRUCT_CONFIG_TEMPLATE_ID")
+	G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME = os.Getenv("G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME")
+	G42_LTS_ENABLE_FLAG                 = os.Getenv("G42_LTS_ENABLE_FLAG")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -563,5 +571,35 @@ func TestAccPreCheckProjectId(t *testing.T) {
 func TestAccPreCheckSourceImage(t *testing.T) {
 	if G42_IMAGE_SHARE_SOURCE_IMAGE_ID == "" {
 		t.Skip("Skip the interface acceptance test because of the source image ID is missing.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsAomAccess(t *testing.T) {
+	if G42_CCE_CLUSTER_ID == "" || G42_CCE_CLUSTER_NAME == "" {
+		t.Skip("G42_CCE_CLUSTER_ID and G42_CCE_CLUSTER_NAME must be set for LTS AOM access acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsAomAccessUpdate(t *testing.T) {
+	if G42_CCE_CLUSTER_ID_ANOTHER == "" || G42_CCE_CLUSTER_NAME_ANOTHER == "" {
+		t.Skip("G42_CCE_CLUSTER_ID_ANOTHER and G42_CCE_CLUSTER_NAME_ANOTHER must be set for LTS AOM access" +
+			" acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsStructConfigCustom(t *testing.T) {
+	if G42_LTS_STRUCT_CONFIG_TEMPLATE_ID == "" || G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME == "" {
+		t.Skip("G42_LTS_STRUCT_CONFIG_TEMPLATE_ID and G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME must be" +
+			" set for LTS struct config custom acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsEnableFlag(t *testing.T) {
+	if G42_LTS_ENABLE_FLAG == "" {
+		t.Skip("Skip the LTS acceptance tests.")
 	}
 }

--- a/g42cloud/services/acceptance/lts/data_source_g42cloud_lts_structuring_custom_templates_test.go
+++ b/g42cloud/services/acceptance/lts/data_source_g42cloud_lts_structuring_custom_templates_test.go
@@ -1,0 +1,76 @@
+package lts
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDatasourceCustomTemplates_basic(t *testing.T) {
+	rName := "data.g42cloud_lts_structuring_custom_templates.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCustomTemplates_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.type"),
+					resource.TestCheckOutput("template_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCustomTemplates_basic() string {
+	return `
+data "g42cloud_lts_structuring_custom_templates" "test" {
+}
+
+data "g42cloud_lts_structuring_custom_templates" "template_id_filter" {
+  template_id = data.g42cloud_lts_structuring_custom_templates.test.templates.0.id
+}
+
+output "template_id_filter_is_useful" {
+  value = length(data.g42cloud_lts_structuring_custom_templates.template_id_filter.templates) > 0 && alltrue(
+    [for v in data.g42cloud_lts_structuring_custom_templates.template_id_filter.templates[*].id :
+    v == data.g42cloud_lts_structuring_custom_templates.template_id_filter.template_id]
+  )
+}
+
+data "g42cloud_lts_structuring_custom_templates" "name_filter" {
+  name = data.g42cloud_lts_structuring_custom_templates.test.templates.0.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.g42cloud_lts_structuring_custom_templates.name_filter.templates) > 0 && alltrue(
+    [for v in data.g42cloud_lts_structuring_custom_templates.name_filter.templates[*].name :
+    v == data.g42cloud_lts_structuring_custom_templates.name_filter.name]
+  )
+}
+
+data "g42cloud_lts_structuring_custom_templates" "type_filter" {
+  type = data.g42cloud_lts_structuring_custom_templates.test.templates.0.type
+}
+
+output "type_filter_is_useful" {
+  value = length(data.g42cloud_lts_structuring_custom_templates.type_filter.templates) > 0 && alltrue(
+    [for v in data.g42cloud_lts_structuring_custom_templates.type_filter.templates[*].type :
+    v == data.g42cloud_lts_structuring_custom_templates.type_filter.type]
+  )
+}
+`
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_aom_access_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_aom_access_test.go
@@ -1,0 +1,402 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAOMAccessResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.G42_REGION_NAME
+		httpUrl = "v2/{project_id}/lts/aom-mapping/{rule_id}"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		// there is no special error code here
+		return nil, fmt.Errorf("error retrieving AOM to LTS log mapping rule: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	arrayBody, ok := getRespBody.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error retrieving AOM to LTS log mapping rule: the API response is not array")
+	}
+	if len(arrayBody) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return arrayBody[0], nil
+}
+
+func TestAccAOMAccess_allWorkloads(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_aom_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAOMAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsAomAccess(t)
+			acceptance.TestAccPreCheckLtsAomAccessUpdate(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAOMAccess_allWorkloads(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.G42_CCE_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.G42_CCE_CLUSTER_NAME),
+					resource.TestCheckResourceAttr(rName, "namespace", "default"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/*"),
+					resource.TestCheckResourceAttr(rName, "access_rules.1.file_name", "/demo/demo.log"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_name",
+						"g42cloud_lts_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_name",
+						"g42cloud_lts_stream.test", "stream_name"),
+				),
+			},
+			{
+				Config: testAOMAccess_allWorkloads_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.G42_CCE_CLUSTER_ID_ANOTHER),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.G42_CCE_CLUSTER_NAME_ANOTHER),
+					resource.TestCheckResourceAttr(rName, "namespace", "test_namespace"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container_update"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/update/*"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAOMAccess_specifyWorkloads(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_aom_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAOMAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsAomAccess(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAOMAccess_specifyWorkloads(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.G42_CCE_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.G42_CCE_CLUSTER_NAME),
+					resource.TestCheckResourceAttr(rName, "namespace", "default"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "WORKLOAD_1"),
+					resource.TestCheckResourceAttr(rName, "workloads.1", "WORKLOAD_2"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "__ALL_FILES__"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_name",
+						"g42cloud_lts_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_name",
+						"g42cloud_lts_stream.test", "stream_name"),
+				),
+			},
+			{
+				Config: testAOMAccess_specifyWorkloads_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "namespace", "test_namespace"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "WORKLOAD_3"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container_update"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/*"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAOMAccess_withCCICluster(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_aom_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAOMAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAOMAccess_withCCICluster(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_id", "CCI-ClusterID"),
+					resource.TestCheckResourceAttr(rName, "cluster_name", "CCI-Cluster"),
+					resource.TestCheckResourceAttr(rName, "namespace", "default"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "__ALL_FILES__"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_name",
+						"g42cloud_lts_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_name",
+						"g42cloud_lts_stream.test", "stream_name"),
+				),
+			},
+			{
+				Config: testAOMAccess_withCCICluster_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "namespace", "test_namespace"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "WORKLOAD_3"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container_update"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/*"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccLtsAomAccess_base(rName string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_lts_group" "test" {
+  group_name  = "%s"
+  ttl_in_days = 1
+}
+resource "g42cloud_lts_stream" "test" {
+  group_id    = g42cloud_lts_group.test.id
+  stream_name = "%s"
+}
+`, rName, rName)
+}
+
+func testAOMAccess_allWorkloads(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_aom_access" "test" {
+  name           = "%[2]s"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "default"
+  workloads      = ["__ALL_DEPLOYMENTS__"]
+  container_name = "test_container"
+
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = g42cloud_lts_group.test.id
+    log_group_name  = g42cloud_lts_group.test.group_name
+    log_stream_id   = g42cloud_lts_stream.test.id
+    log_stream_name = g42cloud_lts_stream.test.stream_name
+  }
+
+  access_rules {
+    file_name       = "/demo/demo.log"
+    log_group_id    = g42cloud_lts_group.test.id
+    log_group_name  = g42cloud_lts_group.test.group_name
+    log_stream_id   = g42cloud_lts_stream.test.id
+    log_stream_name = g42cloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsAomAccess_base(name), name, acceptance.G42_CCE_CLUSTER_ID, acceptance.G42_CCE_CLUSTER_NAME)
+}
+
+func testAOMAccess_allWorkloads_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_aom_access" "test" {
+  name           = "%[2]s_update"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "test_namespace"
+  workloads      = ["__ALL_DEPLOYMENTS__"]
+  container_name = "test_container_update"
+
+  access_rules {
+    file_name       = "/test/update/*"
+    log_group_id    = g42cloud_lts_group.test.id
+    log_group_name  = g42cloud_lts_group.test.group_name
+    log_stream_id   = g42cloud_lts_stream.test.id
+    log_stream_name = g42cloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsAomAccess_base(name), name, acceptance.G42_CCE_CLUSTER_ID_ANOTHER, acceptance.G42_CCE_CLUSTER_NAME_ANOTHER)
+}
+
+func testAOMAccess_specifyWorkloads(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_aom_access" "test" {
+  name           = "%[2]s"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "default"
+  workloads      = ["WORKLOAD_1", "WORKLOAD_2"]
+  container_name = "test_container"
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = g42cloud_lts_group.test.id
+    log_group_name  = g42cloud_lts_group.test.group_name
+    log_stream_id   = g42cloud_lts_stream.test.id
+    log_stream_name = g42cloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsAomAccess_base(name), name, acceptance.G42_CCE_CLUSTER_ID, acceptance.G42_CCE_CLUSTER_NAME)
+}
+
+func testAOMAccess_specifyWorkloads_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_aom_access" "test" {
+  name           = "%[2]s_update"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "test_namespace"
+  workloads      = ["WORKLOAD_3"]
+  container_name = "test_container_update"
+
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = g42cloud_lts_group.test.id
+    log_group_name  = g42cloud_lts_group.test.group_name
+    log_stream_id   = g42cloud_lts_stream.test.id
+    log_stream_name = g42cloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsAomAccess_base(name), name, acceptance.G42_CCE_CLUSTER_ID, acceptance.G42_CCE_CLUSTER_NAME)
+}
+
+func testAOMAccess_withCCICluster(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_aom_access" "test" {
+  name           = "%[2]s"
+  cluster_id     = "CCI-ClusterID"
+  cluster_name   = "CCI-Cluster"
+  namespace      = "default"
+  workloads      = ["__ALL_DEPLOYMENTS__"]
+  container_name = "test_container"
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = g42cloud_lts_group.test.id
+    log_group_name  = g42cloud_lts_group.test.group_name
+    log_stream_id   = g42cloud_lts_stream.test.id
+    log_stream_name = g42cloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}
+
+func testAOMAccess_withCCICluster_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_aom_access" "test" {
+  name           = "%[2]s_update"
+  cluster_id     = "CCI-ClusterID"
+  cluster_name   = "CCI-Cluster"
+  namespace      = "test_namespace"
+  workloads      = ["WORKLOAD_3"]
+  container_name = "test_container_update"
+
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = g42cloud_lts_group.test.id
+    log_group_name  = g42cloud_lts_group.test.group_name
+    log_stream_id   = g42cloud_lts_stream.test.id
+    log_stream_name = g42cloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_host_access_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_host_access_test.go
@@ -1,0 +1,289 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getHostAccessConfigResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	ltsClient, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+
+	listHostAccessConfigHttpUrl := "v3/{project_id}/lts/access-config-list"
+	listHostAccessConfigPath := ltsClient.Endpoint + listHostAccessConfigHttpUrl
+	listHostAccessConfigPath = strings.ReplaceAll(listHostAccessConfigPath, "{project_id}", ltsClient.ProjectID)
+
+	listHostAccessConfigOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	name := state.Primary.Attributes["name"]
+	listHostAccessConfigOpt.JSONBody = map[string]interface{}{
+		"access_config_name_list": []string{name},
+	}
+
+	listHostAccessConfigResp, err := ltsClient.Request("POST", listHostAccessConfigPath, &listHostAccessConfigOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving host access config: %s", err)
+	}
+
+	listHostAccessConfigRespBody, err := utils.FlattenResponse(listHostAccessConfigResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flatten host access config response: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("result[?access_config_name=='%s']|[0]", name)
+	listHostAccessConfigRespBody = utils.PathSearch(jsonPath, listHostAccessConfigRespBody, nil)
+	if listHostAccessConfigRespBody == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return listHostAccessConfigRespBody, nil
+}
+
+func TestAccHostAccessConfig_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_host_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getHostAccessConfigResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testHostAccessConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var/log/*"),
+					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(rName, "access_type", "AGENT"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id", "g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id", "g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
+					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
+				),
+			},
+			{
+				Config: testHostAccessConfig_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var/log/*/*.log"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "/var/log/*/a.log"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value-updated"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(rName, "host_group_ids.0", "g42cloud_lts_host_group.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccHostAccessConfigImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func TestAccHostAccessConfig_windows(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_host_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getHostAccessConfigResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testHostAccessConfig_windows_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "D:\\data\\log\\*"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "D:\\data\\log\\a.log"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.windows_log_info.0.time_offset", "7"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.windows_log_info.0.time_offset_unit", "day"),
+					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(rName, "access_type", "AGENT"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id", "g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id", "g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
+					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccHostAccessConfigImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccHostAccessConfigImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		if name == "" {
+			return "", fmt.Errorf("can not find the 'name' parameter in %s", rName)
+		}
+		return name, nil
+	}
+}
+
+func testHostAccessConfig_base(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 30
+}
+
+resource "g42cloud_lts_stream" "test" {
+  group_id    = g42cloud_lts_group.test.id
+  stream_name = "%[1]s"
+}
+`, name)
+}
+
+func testHostAccessConfig_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# A host group without hosts
+resource "g42cloud_lts_host_group" "test" {
+  name = "%[2]s"
+  type = "linux"
+}
+
+resource "g42cloud_lts_host_access" "test" {
+  name          = "%[2]s"
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+
+  access_config {
+    paths = ["/var/log/*"]
+
+    single_log_format {
+      mode = "system"
+    }
+  }
+
+  tags = {
+    key = "value"
+    foo = "bar"
+  }
+}
+`, testHostAccessConfig_base(name), name)
+}
+
+func testHostAccessConfig_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# A host group without hosts
+resource "g42cloud_lts_host_group" "test" {
+  name = "%[2]s"
+  type = "linux"
+}
+
+resource "g42cloud_lts_host_access" "test" {
+  name           = "%[2]s"
+  log_group_id   = g42cloud_lts_group.test.id
+  log_stream_id  = g42cloud_lts_stream.test.id
+  host_group_ids = [g42cloud_lts_host_group.test.id]
+
+  access_config {
+    paths       = ["/var/log/*/*.log"]
+    black_paths = ["/var/log/*/a.log"]
+
+    multi_log_format {
+      mode  = "time"
+      value = "YYYY-MM-DD hh:mm:ss"
+    }
+  }
+
+  tags = {
+    key   = "value-updated"
+    owner = "terraform"
+  }
+}
+`, testHostAccessConfig_base(name), name)
+}
+
+func testHostAccessConfig_windows_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# A host group without hosts
+resource "g42cloud_lts_host_group" "test" {
+  name = "%[2]s"
+  type = "windows"
+}
+
+resource "g42cloud_lts_host_access" "test" {
+  name           = "%[2]s"
+  log_group_id   = g42cloud_lts_group.test.id
+  log_stream_id  = g42cloud_lts_stream.test.id
+  host_group_ids = [g42cloud_lts_host_group.test.id]
+
+  access_config {
+    paths       = ["D:\\data\\log\\*"]
+    black_paths = ["D:\\data\\log\\a.log"]
+
+    windows_log_info {
+      categorys        = ["System", "Application"]
+      event_level      = ["warning", "error"]
+      time_offset_unit = "day"
+      time_offset      = 7
+    }
+
+    single_log_format {
+      mode = "system"
+    }
+  }
+
+  tags = {
+    key = "value"
+    foo = "bar"
+  }
+}
+`, testHostAccessConfig_base(name), name)
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_host_group_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_host_group_test.go
@@ -1,0 +1,136 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lts"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getHostGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getHostGroup: Query the LTS HostGroup detail
+	var (
+		getHostGroupHttpUrl = "v3/{project_id}/lts/host-group-list"
+		getHostGroupProduct = "lts"
+	)
+	getHostGroupClient, err := cfg.NewServiceClient(getHostGroupProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS Client: %s", err)
+	}
+
+	getHostGroupPath := getHostGroupClient.Endpoint + getHostGroupHttpUrl
+	getHostGroupPath = strings.ReplaceAll(getHostGroupPath, "{project_id}", getHostGroupClient.ProjectID)
+
+	getHostGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	getHostGroupOpt.JSONBody = utils.RemoveNil(lts.BuildGetOrDeleteHostGroupBodyParams(state.Primary.ID))
+	getHostGroupResp, err := getHostGroupClient.Request("POST", getHostGroupPath, &getHostGroupOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving HostGroup: %s", err)
+	}
+
+	getHostGroupRespBody, err := utils.FlattenResponse(getHostGroupResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving HostGroup: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("result[?host_group_id=='%s']|[0]", state.Primary.ID)
+	getHostGroupRespBody = utils.PathSearch(jsonPath, getHostGroupRespBody, nil)
+	if getHostGroupRespBody == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return getHostGroupRespBody, nil
+}
+
+func TestAccHostGroup_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_host_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getHostGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testHostGroup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "linux"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testHostGroup_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
+					resource.TestCheckResourceAttr(rName, "type", "linux"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(rName, "tags.key_update", "value"),
+				),
+			},
+		},
+	})
+}
+
+func testHostGroup_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_lts_host_group" "test" {
+  name = "%s"
+  type = "linux"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name)
+}
+
+func testHostGroup_basic_update(name string) string {
+	return fmt.Sprintf(`
+
+resource "g42cloud_lts_host_group" "test" {
+  name = "%s-update"
+  type = "linux"
+
+  tags = {
+    foo        = "bar_update"
+    key_update = "value"
+  }
+}
+`, name)
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_keywords_alarm_rule_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_keywords_alarm_rule_test.go
@@ -1,0 +1,165 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getKeywordsAlarmRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getKeywordsAlarmRule: Query the LTS KeywordsAlarmRule detail
+	var (
+		getKeywordsAlarmRuleHttpUrl = "v2/{project_id}/lts/alarms/keywords-alarm-rule"
+		getKeywordsAlarmRuleProduct = "lts"
+	)
+	getKeywordsAlarmRuleClient, err := cfg.NewServiceClient(getKeywordsAlarmRuleProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+
+	getKeywordsAlarmRulePath := getKeywordsAlarmRuleClient.Endpoint + getKeywordsAlarmRuleHttpUrl
+	getKeywordsAlarmRulePath = strings.ReplaceAll(getKeywordsAlarmRulePath, "{project_id}", getKeywordsAlarmRuleClient.ProjectID)
+
+	getKeywordsAlarmRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getKeywordsAlarmRuleResp, err := getKeywordsAlarmRuleClient.Request("GET", getKeywordsAlarmRulePath, &getKeywordsAlarmRuleOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Keywords alarm rule: %s", err)
+	}
+
+	getKeywordsAlarmRuleRespBody, err := utils.FlattenResponse(getKeywordsAlarmRuleResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Keywords alarm rule: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("keywords_alarm_rules[?keywords_alarm_rule_id =='%s']|[0]", state.Primary.ID)
+	getKeywordsAlarmRuleRespBody = utils.PathSearch(jsonPath, getKeywordsAlarmRuleRespBody, nil)
+	if getKeywordsAlarmRuleRespBody == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return getKeywordsAlarmRuleRespBody, nil
+}
+
+func TestAccKeywordsAlarmRule_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_keywords_alarm_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getKeywordsAlarmRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeywordsAlarmRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "CRITICAL"),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				Config: testKeywordsAlarmRule_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "INFO"),
+					resource.TestCheckResourceAttr(rName, "status", "STOPPING"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "DAILY"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.hour_of_day", "6"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testKeywordsAlarmRule_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_keywords_alarm_rule" "test" {
+  name        = "%[2]s"
+  description = "created by terraform"
+  alarm_level = "CRITICAL"
+  
+  keywords_requests {
+    keywords               = "%[2]s_key_words"
+    condition              = ">"
+    number                 = 100
+    log_group_id           = g42cloud_lts_group.test.id
+    log_stream_id          = g42cloud_lts_stream.test.id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type = "HOURLY"
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}
+
+func testKeywordsAlarmRule_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_keywords_alarm_rule" "test" {
+  name        = "%[2]s"
+  description = ""
+  alarm_level = "INFO"
+  status      = "STOPPING"
+  
+  keywords_requests {
+    keywords               = "%[2]s_key_words"
+    condition              = ">"
+    number                 = 100
+    log_group_id           = g42cloud_lts_group.test.id
+    log_stream_id          = g42cloud_lts_stream.test.id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type        = "DAILY"
+    hour_of_day = 6
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_search_criteria_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_search_criteria_test.go
@@ -1,0 +1,132 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSearchCriteriaResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getSearchCriteria: Query the LTS search criteria detail
+	var (
+		getSearchCriteriaHttpUrl = "v1.0/{project_id}/groups/{group_id}/topics/{topic_id}/search-criterias"
+		getSearchCriteriaProduct = "lts"
+	)
+	getSearchCriteriaClient, err := cfg.NewServiceClient(getSearchCriteriaProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS Client: %s", err)
+	}
+
+	groupID := state.Primary.Attributes["log_group_id"]
+	streamID := state.Primary.Attributes["log_stream_id"]
+
+	getSearchCriteriaPath := getSearchCriteriaClient.Endpoint + getSearchCriteriaHttpUrl
+	getSearchCriteriaPath = strings.ReplaceAll(getSearchCriteriaPath, "{project_id}", getSearchCriteriaClient.ProjectID)
+	getSearchCriteriaPath = strings.ReplaceAll(getSearchCriteriaPath, "{group_id}", groupID)
+	getSearchCriteriaPath = strings.ReplaceAll(getSearchCriteriaPath, "{topic_id}", streamID)
+
+	getSearchCriteriaOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getSearchCriteriaResp, err := getSearchCriteriaClient.Request("GET", getSearchCriteriaPath, &getSearchCriteriaOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving search criteria: %s", err)
+	}
+
+	getSearchCriteriaRespBody, err := utils.FlattenResponse(getSearchCriteriaResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving search criteria: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("search_criterias[?id =='%s']|[0]", state.Primary.ID)
+	getSearchCriteriaRespBody = utils.PathSearch(jsonPath, getSearchCriteriaRespBody, nil)
+	if getSearchCriteriaRespBody == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return getSearchCriteriaRespBody, nil
+}
+
+func TestAccSearchCriteria_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_search_criteria.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSearchCriteriaResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSearchCriteria_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "criteria", "context:test"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "ORIGINALLOG"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: resourceSearchCriteriaImportState(rName),
+			},
+		},
+	})
+}
+
+func testSearchCriteria_basic(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 30
+}
+
+resource "g42cloud_lts_stream" "test" {
+  group_id    = g42cloud_lts_group.test.id
+  stream_name = "%[1]s"
+}
+
+resource "g42cloud_lts_search_criteria" "test" {
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+  
+  criteria = "context:test"
+  name     = "%[1]s"
+  type 	   = "ORIGINALLOG"
+}
+`, name)
+}
+
+func resourceSearchCriteriaImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		searchCriteriaID := rs.Primary.ID
+		groupID := rs.Primary.Attributes["log_group_id"]
+		streamID := rs.Primary.Attributes["log_stream_id"]
+
+		return fmt.Sprintf("%s/%s/%s", groupID, streamID, searchCriteriaID), nil
+	}
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_sql_alarm_rule_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_sql_alarm_rule_test.go
@@ -1,0 +1,248 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSQLAlarmRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getSQLAlarmRule: Query the LTS SQLAlarmRule detail
+	var (
+		getSQLAlarmRuleHttpUrl = "v2/{project_id}/lts/alarms/sql-alarm-rule"
+		getSQLAlarmRuleProduct = "lts"
+	)
+	getSQLAlarmRuleClient, err := cfg.NewServiceClient(getSQLAlarmRuleProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+
+	getSQLAlarmRulePath := getSQLAlarmRuleClient.Endpoint + getSQLAlarmRuleHttpUrl
+	getSQLAlarmRulePath = strings.ReplaceAll(getSQLAlarmRulePath, "{project_id}", getSQLAlarmRuleClient.ProjectID)
+
+	getSQLAlarmRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getSQLAlarmRuleResp, err := getSQLAlarmRuleClient.Request("GET", getSQLAlarmRulePath, &getSQLAlarmRuleOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving SQL alarm rule: %s", err)
+	}
+
+	getSQLAlarmRuleRespBody, err := utils.FlattenResponse(getSQLAlarmRuleResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving SQL alarm rule: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("sql_alarm_rules[?sql_alarm_rule_id =='%s']|[0]", state.Primary.ID)
+	getSQLAlarmRuleRespBody = utils.PathSearch(jsonPath, getSQLAlarmRuleRespBody, nil)
+	if getSQLAlarmRuleRespBody == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return getSQLAlarmRuleRespBody, nil
+}
+
+func TestAccSQLAlarmRule_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_sql_alarm_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSQLAlarmRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSQLAlarmRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(rName, "condition_expression", "t>0"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "CRITICAL"),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				Config: testSQLAlarmRule_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "condition_expression", "t>2"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "INFO"),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "DAILY"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.hour_of_day", "6"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testSQLAlarmRule_basic_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "condition_expression", "t>2"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "MINOR"),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "CRON"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.cron_expression", "0/5 * * * *"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testSQLAlarmRule_basic_update3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "condition_expression", "t>2"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "MAJOR"),
+					resource.TestCheckResourceAttr(rName, "status", "STOPPING"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "WEEKLY"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.day_of_week", "3"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testSQLAlarmRule_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_sql_alarm_rule" "test" {
+  name                 = "%[2]s"
+  description          = "created by terraform"
+  condition_expression = "t>0"
+  alarm_level          = "CRITICAL"
+
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = g42cloud_lts_group.test.id
+    log_stream_id          = g42cloud_lts_stream.test.id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type = "HOURLY"
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}
+
+func testSQLAlarmRule_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_sql_alarm_rule" "test" {
+  name                 = "%[2]s"
+  condition_expression = "t>2"
+  alarm_level          = "INFO"
+  status               = "RUNNING"
+
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = g42cloud_lts_group.test.id
+    log_stream_id          = g42cloud_lts_stream.test.id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type        = "DAILY"
+    hour_of_day = 6
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}
+
+func testSQLAlarmRule_basic_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_sql_alarm_rule" "test" {
+  name                 = "%[2]s"
+  condition_expression = "t>2"
+  alarm_level          = "MINOR"
+  status               = "RUNNING"
+
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = g42cloud_lts_group.test.id
+    log_stream_id          = g42cloud_lts_stream.test.id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type            = "CRON"
+    cron_expression = "0/5 * * * *"
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}
+
+func testSQLAlarmRule_basic_update3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_sql_alarm_rule" "test" {
+  name                 = "%[2]s"
+  condition_expression = "t>2"
+  alarm_level          = "MAJOR"
+  status               = "STOPPING"
+
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = g42cloud_lts_group.test.id
+    log_stream_id          = g42cloud_lts_stream.test.id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type        = "WEEKLY"
+    day_of_week = 3
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_structuring_configuration_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_structuring_configuration_test.go
@@ -1,0 +1,307 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getStructConfigResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region      = acceptance.G42_REGION_NAME
+		httpUrl     = "v2/{project_id}/lts/struct/template"
+		product     = "lts"
+		logGroupId  = state.Primary.Attributes["log_group_id"]
+		logStreamId = state.Primary.Attributes["log_stream_id"]
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += fmt.Sprintf("?logGroupId=%s&logStreamId=%s", logGroupId, logStreamId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	rawString, isString := getRespBody.(string)
+	if !isString {
+		return nil, fmt.Errorf("the detail API response is not string")
+	}
+
+	if rawString == "" {
+		// the structuring configuration is not exist
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return getRespBody, nil
+}
+
+func TestAccStructConfig_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_structuring_configuration.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStructConfigResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testStructConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(rName, "template_type", "built_in"),
+					resource.TestCheckResourceAttr(rName, "template_name", "CTS"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.#", "2"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "demo_log"),
+				),
+			},
+			{
+				Config: testStructConfig_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(rName, "template_type", "built_in"),
+					resource.TestCheckResourceAttr(rName, "template_name", "GAUSSDB_MYSQL_SLOW"),
+					resource.TestCheckResourceAttr(rName, "quick_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.#", "2"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "demo_log"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testLtsStructConfigImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"template_type",
+					"template_id",
+					"demo_fields",
+					"tag_fields",
+					"quick_analysis",
+				},
+			},
+		},
+	})
+}
+
+func TestAccStructConfig_customTemplate(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_structuring_configuration.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStructConfigResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsStructConfigCustom(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testStructConfig_custom(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(rName, "template_type", "custom"),
+					resource.TestCheckResourceAttr(rName, "template_id", acceptance.G42_LTS_STRUCT_CONFIG_TEMPLATE_ID),
+					resource.TestCheckResourceAttr(rName, "template_name", acceptance.G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME),
+					resource.TestCheckResourceAttr(rName, "quick_analysis", "true"),
+				),
+			},
+			{
+				Config: testStructConfig_custom_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(rName, "template_type", "built_in"),
+					resource.TestCheckResourceAttr(rName, "template_name", "GAUSSDB_MYSQL_SLOW"),
+					resource.TestCheckResourceAttr(rName, "quick_analysis", "false"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.#", "2"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testLtsStructConfigImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"template_type",
+					"template_id",
+					"demo_fields",
+					"tag_fields",
+					"quick_analysis",
+				},
+			},
+		},
+	})
+}
+
+func testStructConfig_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_structuring_configuration" "test" {
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+  template_type = "built_in"
+  template_name = "CTS"
+
+  demo_fields {
+    field_name  = "event_type"
+    is_analysis = true
+  }
+
+  demo_fields {
+    field_name  = "resource_type"
+    is_analysis = false
+  }
+
+  tag_fields {
+    field_name  = "hostIP"
+    is_analysis = true
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}
+
+func testStructConfig_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_structuring_configuration" "test" {
+  log_group_id   = g42cloud_lts_group.test.id
+  log_stream_id  = g42cloud_lts_stream.test.id
+  template_type  = "built_in"
+  template_name  = "GAUSSDB_MYSQL_SLOW"
+  quick_analysis = true
+
+  demo_fields {
+    field_name  = "query_time"
+    is_analysis = true
+  }
+
+  demo_fields {
+    field_name  = "rows_examined"
+    is_analysis = false
+  }
+
+  tag_fields {
+    field_name  = "hostName"
+    is_analysis = false
+  }
+}
+`, testAccLtsAomAccess_base(name))
+}
+
+func testStructConfig_custom(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_structuring_configuration" "test" {
+  log_group_id   = g42cloud_lts_group.test.id
+  log_stream_id  = g42cloud_lts_stream.test.id
+  template_type  = "custom"
+  template_id    = "%[2]s"
+  template_name  = "%[3]s"
+  quick_analysis = true
+}
+`, testAccLtsAomAccess_base(name), acceptance.G42_LTS_STRUCT_CONFIG_TEMPLATE_ID, acceptance.G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME)
+}
+
+func testStructConfig_custom_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_structuring_configuration" "test" {
+  log_group_id   = g42cloud_lts_group.test.id
+  log_stream_id  = g42cloud_lts_stream.test.id
+  template_type  = "built_in"
+  template_name  = "GAUSSDB_MYSQL_SLOW"
+  quick_analysis = false
+
+  demo_fields {
+    field_name  = "query_time"
+    is_analysis = true
+  }
+
+  demo_fields {
+    field_name  = "rows_examined"
+    is_analysis = true
+  }
+
+  tag_fields {
+    field_name  = "hostName"
+    is_analysis = true
+  }
+}
+`, testAccLtsAomAccess_base(name), name)
+}
+
+func testLtsStructConfigImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		logGroupId := rs.Primary.Attributes["log_group_id"]
+		logStreamId := rs.Primary.Attributes["log_stream_id"]
+		if logGroupId == "" || logStreamId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID (LTS structuring configuration),"+
+				" want '<log_group_id>/<log_stream_id>', but got '%s/%s'",
+				logGroupId, logStreamId)
+		}
+		return fmt.Sprintf("%s/%s", logGroupId, logStreamId), nil
+	}
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_structuring_custom_configuration_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_structuring_custom_configuration_test.go
@@ -1,0 +1,310 @@
+package lts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccStructCustomConfig_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_structuring_custom_configuration.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStructConfigResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testStructCustomConfig_json(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id",
+						"g42cloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id",
+						"g42cloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(rName, "content", "{'code':38,'user':{'name':'testdemo'}}"),
+					resource.TestCheckResourceAttr(rName, "layers", "3"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.#", "2"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.field_name", "code"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.content", "38"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.type", "long"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.field_name", "user.name"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.content", "test_demo"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.type", "string"),
+
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.field_name", "hostIP"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.content", "192.168.2.134"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.type", "string"),
+				),
+			},
+			{
+				Config: testStructCustomConfig_json_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "content", "{'error_code':400,'user':{'id':'000'}}"),
+					resource.TestCheckResourceAttr(rName, "layers", "3"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.is_analysis", "false"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.field_name", "error_code"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.content", "400"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.type", "long"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.field_name", "user.id"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.content", "000"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.type", "string"),
+
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.field_name", "hostName"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.content", "demoName"),
+					resource.TestCheckResourceAttr(rName, "tag_fields.0.type", "string"),
+				),
+			},
+			{
+				Config: testStructCustomConfig_split_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "content", "2023-09-09/18:50:51 Error"),
+					resource.TestCheckResourceAttr(rName, "tokenizer", " "),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.field_name", "b1"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.content", "2023-09-09/18:50:51"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.type", "string"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.field_name", "b2"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.content", "Error"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.type", "string"),
+
+					resource.TestCheckResourceAttr(rName, "tag_fields.#", "0"),
+				),
+			},
+			{
+				Config: testStructCustomConfig_nginx_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "content",
+						"39.149.31.187 - - [12/Mar/2020:12:24:02 +0800] \"GET / HTTP/1.1\" 304 "),
+					resource.TestCheckResourceAttr(rName, "log_format",
+						"log_format  main   '$remote_addr - $remote_user [$time_local] \"$request\" '\n'$status ';"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.field_name", "remote_addr"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.content", "39.149.31.187"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.type", "string"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.field_name", "remote_user"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.content", "-"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.type", "string"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.2.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.2.field_name", "request_method"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.2.content", "GET"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.2.type", "string"),
+				),
+			},
+			{
+				Config: testStructCustomConfig_custom_regex_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "content",
+						"2023-09-09/18:15:41 this log is Error NO 6323"),
+					resource.TestCheckResourceAttr(rName, "regex_rules",
+						"^(?<a01>[^ ]+)(?:[^ ]* ){1}(?<a02>\\w+)(?:[^ ]* ){1}(?<a03>\\w+)(?:[^ ]* )"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.field_name", "a01"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.0.type", "string"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.field_name", "a02"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.1.type", "string"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.2.is_analysis", "true"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.2.field_name", "a03"),
+					resource.TestCheckResourceAttr(rName, "demo_fields.2.type", "string"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testLtsStructConfigImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"demo_fields",
+					"regex_rules",
+					"layers",
+					"tokenizer",
+					"log_format",
+					"tag_fields",
+				},
+			},
+		},
+	})
+}
+
+func testStructCustomConfig_json(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+  content       = "{'code':38,'user':{'name':'testdemo'}}"
+  layers        = 3
+  
+  demo_fields {
+    is_analysis = true
+    field_name  = "code"
+    content     = "38"
+    type        = "long"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "user.name"
+    content     = "test_demo"
+    type        = "string"
+  }
+
+  tag_fields {
+    is_analysis = true
+    field_name  = "hostIP"
+    content     = "192.168.2.134"
+    type        = "string"
+  }
+}
+`, testAccLtsAomAccess_base(name))
+}
+
+func testStructCustomConfig_json_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+  content       = "{'error_code':400,'user':{'id':'000'}}"
+  layers        = 3
+  
+  demo_fields {
+    field_name  = "error_code"
+    content     = "400"
+    type        = "long"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "user.id"
+    content     = "000"
+    type        = "string"
+  }
+
+  tag_fields {
+    is_analysis = true
+    field_name  = "hostName"
+    content     = "demoName"
+    type        = "string"
+  }
+}
+`, testAccLtsAomAccess_base(name))
+}
+
+func testStructCustomConfig_split_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+  content       = "2023-09-09/18:50:51 Error"
+  tokenizer     = " "
+  
+  demo_fields {
+    is_analysis = true
+    field_name  = "b1"
+    content     = "2023-09-09/18:50:51"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "b2"
+    content     = "Error"
+    type        = "string"
+  }
+}
+`, testAccLtsAomAccess_base(name))
+}
+
+func testStructCustomConfig_nginx_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+  content       = "39.149.31.187 - - [12/Mar/2020:12:24:02 +0800] \"GET / HTTP/1.1\" 304 "
+  log_format    = "log_format  main   '$remote_addr - $remote_user [$time_local] \"$request\" '\n'$status ';"
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "remote_addr"
+    content     = "39.149.31.187"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "remote_user"
+    content     = "-"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "request_method"
+    content     = "GET"
+    type        = "string"
+  }
+}
+`, testAccLtsAomAccess_base(name))
+}
+
+func testStructCustomConfig_custom_regex_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_lts_structuring_custom_configuration" "test" {
+  log_group_id  = g42cloud_lts_group.test.id
+  log_stream_id = g42cloud_lts_stream.test.id
+  content       = "2023-09-09/18:15:41 this log is Error NO 6323"
+  regex_rules   = "^(?<a01>[^ ]+)(?:[^ ]* ){1}(?<a02>\\w+)(?:[^ ]* ){1}(?<a03>\\w+)(?:[^ ]* )"
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "a01"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "a02"
+    type        = "string"
+  }
+
+  demo_fields {
+    is_analysis = true
+    field_name  = "a03"
+    type        = "string"
+  }
+}
+`, testAccLtsAomAccess_base(name))
+}

--- a/g42cloud/services/acceptance/lts/resource_g42cloud_lts_waf_access_test.go
+++ b/g42cloud/services/acceptance/lts/resource_g42cloud_lts_waf_access_test.go
@@ -1,0 +1,316 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getWAFAccessResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.G42_REGION_NAME
+		httpUrl = "v1/{project_id}/waf/config/lts"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	if epsId := state.Primary.Attributes["enterprise_project_id"]; epsId != "" {
+		getPath += fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := utils.PathSearch("enabled", getRespBody, false).(bool)
+	if !enabled {
+		// the WAF access is not exist
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccWAFAccess_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_waf_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getWAFAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testWAFAccess_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"g42cloud_lts_group.groupA", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id",
+						"g42cloud_lts_stream.streamA1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
+						"g42cloud_lts_stream.streamA2", "id"),
+				),
+			},
+			{
+				Config: testWAFAccess_basic_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"g42cloud_lts_group.groupB", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id",
+						"g42cloud_lts_stream.streamB1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
+						"g42cloud_lts_stream.streamB2", "id"),
+				),
+			},
+			{
+				Config: testWAFAccess_basic_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"g42cloud_lts_group.groupB", "id"),
+					resource.TestCheckResourceAttr(rName, "lts_attack_stream_id", ""),
+					resource.TestCheckResourceAttr(rName, "lts_access_stream_id", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFAccessImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccWAFAccess_withEpsId(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_lts_waf_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getWAFAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testWAFAccess_withEpsId(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id",
+						acceptance.G42_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"g42cloud_lts_group.groupA", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id",
+						"g42cloud_lts_stream.streamA1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
+						"g42cloud_lts_stream.streamA2", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFAccessImportState(rName),
+			},
+		},
+	})
+}
+
+func testWAFAccess_base(name string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_lts_group" "groupA" {
+  group_name  = "%[1]s_a"
+  ttl_in_days = 30
+}
+
+resource "g42cloud_lts_stream" "streamA1" {
+  group_id    = g42cloud_lts_group.groupA.id
+  stream_name = "%[1]s_a1"
+}
+
+resource "g42cloud_lts_stream" "streamA2" {
+  group_id    = g42cloud_lts_group.groupA.id
+  stream_name = "%[1]s_a2"
+}
+
+resource "g42cloud_lts_group" "groupB" {
+  group_name  = "%[1]s_b"
+  ttl_in_days = 30
+}
+
+resource "g42cloud_lts_stream" "streamB1" {
+  group_id    = g42cloud_lts_group.groupB.id
+  stream_name = "%[1]s_b1"
+}
+
+resource "g42cloud_lts_stream" "streamB2" {
+  group_id    = g42cloud_lts_group.groupB.id
+  stream_name = "%[1]s_b2"
+}
+
+%[2]s
+
+resource "g42cloud_waf_dedicated_instance" "test" {
+  name               = "%[1]s"
+  available_zone     = data.g42cloud_availability_zones.test.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.g42cloud_compute_flavors.test.ids[0]
+  vpc_id             = g42cloud_vpc.test.id
+  subnet_id          = g42cloud_vpc_subnet.test.id
+  
+  security_group = [
+    g42cloud_networking_secgroup.test.id
+  ]
+}
+`, name, common.TestBaseComputeResources(name))
+}
+
+func testWAFAccess_epsId(name, epsId string) string {
+	return fmt.Sprintf(`
+resource "g42cloud_lts_group" "groupA" {
+  group_name  = "%[1]s_a"
+  ttl_in_days = 30
+}
+
+resource "g42cloud_lts_stream" "streamA1" {
+  group_id    = g42cloud_lts_group.groupA.id
+  stream_name = "%[1]s_a1"
+}
+
+resource "g42cloud_lts_stream" "streamA2" {
+  group_id    = g42cloud_lts_group.groupA.id
+  stream_name = "%[1]s_a2"
+}
+
+%[2]s
+
+resource "g42cloud_waf_dedicated_instance" "test" {
+  name                  = "%[1]s"
+  available_zone        = data.g42cloud_availability_zones.test.names[1]
+  specification_code    = "waf.instance.professional"
+  ecs_flavor            = data.g42cloud_compute_flavors.test.ids[0]
+  enterprise_project_id = "%[3]s"
+  vpc_id                = g42cloud_vpc.test.id
+  subnet_id             = g42cloud_vpc_subnet.test.id
+  
+  security_group = [
+    g42cloud_networking_secgroup.test.id
+  ]
+}
+`, name, common.TestBaseComputeResources(name), epsId)
+}
+
+func testWAFAccess_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_waf_access" "test" {
+  lts_group_id         = g42cloud_lts_group.groupA.id
+  lts_attack_stream_id = g42cloud_lts_stream.streamA1.id
+  lts_access_stream_id = g42cloud_lts_stream.streamA2.id
+
+  depends_on = [
+    g42cloud_waf_dedicated_instance.test
+  ]
+}
+`, testWAFAccess_base(name))
+}
+
+func testWAFAccess_basic_update1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_waf_access" "test" {
+  lts_group_id         = g42cloud_lts_group.groupB.id
+  lts_attack_stream_id = g42cloud_lts_stream.streamB1.id
+  lts_access_stream_id = g42cloud_lts_stream.streamB2.id
+}
+`, testWAFAccess_base(name))
+}
+
+func testWAFAccess_basic_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_waf_access" "test" {
+  lts_group_id = g42cloud_lts_group.groupB.id
+}
+`, testWAFAccess_base(name))
+}
+
+func testWAFAccess_withEpsId(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "g42cloud_lts_waf_access" "test" {
+  enterprise_project_id = "%[2]s"
+  lts_group_id          = g42cloud_lts_group.groupA.id
+  lts_attack_stream_id  = g42cloud_lts_stream.streamA1.id
+  lts_access_stream_id  = g42cloud_lts_stream.streamA2.id
+
+  depends_on = [
+    g42cloud_waf_dedicated_instance.test
+  ]
+}
+`, testWAFAccess_epsId(name, acceptance.G42_ENTERPRISE_PROJECT_ID_TEST), acceptance.G42_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testWAFAccessImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		if epsId == "" {
+			// the default enterprise project ID is `0`
+			epsId = "0"
+		}
+		return epsId, nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import LTS resource, unit test and document
this PR has modified `acceptance.go`. it will confilict with others.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```md
### resource_g42cloud_lts_aom_access

=== RUN   TestAccAOMAccess_allWorkloads
=== PAUSE TestAccAOMAccess_allWorkloads
=== CONT  TestAccAOMAccess_allWorkloads
--- PASS: TestAccAOMAccess_allWorkloads (53.99s)
PASS

coverage: 11.4% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccAOMAccess_specifyWorkloads
=== PAUSE TestAccAOMAccess_specifyWorkloads
=== CONT  TestAccAOMAccess_specifyWorkloads
--- PASS: TestAccAOMAccess_specifyWorkloads (56.08s)
PASS

coverage: 11.3% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccAOMAccess_withCCICluster
=== PAUSE TestAccAOMAccess_withCCICluster
=== CONT  TestAccAOMAccess_withCCICluster
--- PASS: TestAccAOMAccess_withCCICluster (49.40s)
PASS
```


```md

### resource_g42cloud_lts_host_group
=== RUN   TestAccHostGroup_basic
=== PAUSE TestAccHostGroup_basic
=== CONT  TestAccHostGroup_basic
--- PASS: TestAccHostGroup_basic (60.04s)
PASS
coverage: 11.0% of statements in ../../../../../terraform-provider-g42cloud/...
```
```md

### resource_g42cloud_lts_host_access

=== RUN   TestAccHostAccessConfig_basic
=== PAUSE TestAccHostAccessConfig_basic
=== CONT  TestAccHostAccessConfig_basic
--- PASS: TestAccHostAccessConfig_basic (70.23s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccHostAccessConfig_windows
=== PAUSE TestAccHostAccessConfig_windows
=== CONT  TestAccHostAccessConfig_windows
--- PASS: TestAccHostAccessConfig_windows (38.25s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md
### resource_g42cloud_lts_keywords_alarm_rule

=== RUN   TestAccKeywordsAlarmRule_basic
=== PAUSE TestAccKeywordsAlarmRule_basic
=== CONT  TestAccKeywordsAlarmRule_basic
--- PASS: TestAccKeywordsAlarmRule_basic (59.67s)
PASS
```

```md
### resource_g42cloud_lts_search_criteria

=== RUN   TestAccSearchCriteria_basic
=== PAUSE TestAccSearchCriteria_basic
=== CONT  TestAccSearchCriteria_basic
--- PASS: TestAccSearchCriteria_basic (30.23s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...

```

```md

### resource_g42cloud_lts_sql_alarm_rule

=== RUN   TestAccSQLAlarmRule_basic
=== PAUSE TestAccSQLAlarmRule_basic
=== CONT  TestAccSQLAlarmRule_basic
--- PASS: TestAccSQLAlarmRule_basic (48.70s)
PASS

coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_lts_structing_configuration

=== RUN   TestAccStructConfig_basic
=== PAUSE TestAccStructConfig_basic
=== CONT  TestAccStructConfig_basic
--- PASS: TestAccStructConfig_basic (48.89s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccStructConfig_customTemplate
=== PAUSE TestAccStructConfig_customTemplate
=== CONT  TestAccStructConfig_customTemplate
--- PASS: TestAccStructConfig_customTemplate (56.00s)
PASS

coverage: 11.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_lts_structing_custom_configuration

=== RUN   TestAccStructCustomConfig_basic
=== PAUSE TestAccStructCustomConfig_basic
=== CONT  TestAccStructCustomConfig_basic
--- PASS: TestAccStructCustomConfig_basic (104.97s)
PASS

coverage: 11.1% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_waf_access

=== RUN   TestAccWAFAccess_basic
=== PAUSE TestAccWAFAccess_basic
=== CONT  TestAccWAFAccess_basic
--- PASS: TestAccWAFAccess_basic (460.88s)
PASS

coverage: 11.6% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### data_source_g42cloud_lts_structing_custom_templates

=== RUN   TestAccDatasourceCustomTemplates_basic
=== PAUSE TestAccDatasourceCustomTemplates_basic
=== CONT  TestAccDatasourceCustomTemplates_basic
--- PASS: TestAccDatasourceCustomTemplates_basic (22.85s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...
```



