### PR TITLE
feat(RDS): import RDS resource and dataSource, and its unit test and document

### DIFF
--- a/docs/data-sources/rds_backups.md
+++ b/docs/data-sources/rds_backups.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_backups
+
+Use this data source to get the list of RDS backups.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "g42cloud_rds_backups" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Instance ID.
+
+* `backup_id` - (Optional, String) Backup ID.
+
+* `backup_type` - (Optional, String) Backup type.  
+  The options are as follows:
+    - **auto**: Automated full backup.
+    - **manual**: Manual full backup.
+    - **fragment**: Differential full backup.
+    - **incremental**: Automated incremental backup.
+
+* `begin_time` - (Optional, String) Start time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `end_time` - (Optional, String) End time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `name` - (Optional, String) Backup name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `backups` - Backup list. For details, see Data structure of the Backup field.
+  The [backups](#Backup_Backup) structure is documented below.
+
+<a name="Backup_Backup"></a>
+The `backups` block supports:
+
+* `id` - Backup ID.
+
+* `instance_id` - RDS instance ID.
+
+* `name` - Backup name.
+
+* `type` - Backup type.  
+  The options are as follows:
+    - **auto**: Automated full backup.
+    - **manual**: Manual full backup.
+    - **fragment**: Differential full backup.
+    - **incremental**: Automated incremental backup.
+
+* `size` - Backup size in KB.
+
+* `status` - Backup status.  
+  The options are as follows:
+    - **BUILDING**: Backup in progress.
+    - **COMPLETED**: Backup completed.
+    - **FAILED**: Backup failed.
+    - **DELETING**: Backup being deleted.
+
+* `begin_time` - Backup start time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `end_time` - Backup end time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `associated_with_ddm` - Whether a DDM instance has been associated.
+
+* `datastore` - The database information.
+  The [datastore](#Backup_BackupDatastore) structure is documented below.
+
+* `databases` - Database been backed up.
+  The [databases](#Backup_BackupDatabases) structure is documented below.
+
+<a name="Backup_BackupDatastore"></a>
+The `datastore` block supports:
+
+* `type` - DB engine. The value can be **MySQL**, **PostgreSQL**, **SQLServer**.
+
+* `version` - DB engine version.
+
+<a name="Backup_BackupDatabases"></a>
+The `databases` block supports:
+
+* `name` - Database to be backed up for Microsoft SQL Server.

--- a/docs/data-sources/rds_engine_versions.md
+++ b/docs/data-sources/rds_engine_versions.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_engine_versions
+
+Use this data source to obtain all version information of the specified engine type of G42Cloud RDS.
+
+## Example Usage
+
+```hcl
+data "g42cloud_rds_engine_versions" "test" {
+  type = "SQLServer"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the RDS engine versions.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the RDS engine type.
+  The valid values are **MySQL**, **PostgreSQL**, **SQLServer** , default to **MySQL**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID in hashcode format.
+
+* `versions` - List of RDS versions. The [versions](#rds_versions) object structure is documented below.
+
+<a name="rds_versions"></a>
+The `versions` block contains:
+
+* `id` - Version ID.
+
+* `name` - Version name.

--- a/docs/data-sources/rds_instances.md
+++ b/docs/data-sources/rds_instances.md
@@ -1,0 +1,132 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_instances
+
+Use this data source to list all available RDS instances.
+
+## Example Usage
+
+```hcl
+data "g42cloud_rds_instances" "this" {
+  name = "rds-instance"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the instances. If omitted, the provider-level region will
+  be used.
+
+* `name` - (Optional, String) Specifies the name of the instance.
+
+* `type` - (Optional, String) Specifies the type of the instance. Valid values are **Single**, **Ha**, **Replica**,
+  and **Enterprise**.
+
+* `datastore_type` - (Optional, String) Specifies the type of the database. Valid values are **MySQL**, **PostgreSQL**
+  and **SQLServer**.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID.
+
+* `subnet_id` - (Optional, String) Specifies the network ID of a subnet.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the data source.
+
+* `instances` - An array of available instances. The [instances](#rds_instances) object structure is documented below.
+
+<a name="rds_instances"></a>
+The `instances` block supports:
+
+* `region` - The region of the instance.
+
+* `name` - Indicates the name of the instance.
+
+* `availability_zone` - Indicates the availability zone name.
+
+* `flavor` - Indicates the instance specifications.
+
+* `vpc_id` - Indicates the VPC ID.
+
+* `subnet_id` - Indicates the network ID of a subnet.
+
+* `id` - Indicates the ID of the instance.
+
+* `security_group_id` - Indicates the security group ID.
+
+* `param_group_id` - Indicates the configuration ID.
+
+* `enterprise_project_id` - Indicates the enterprise project id.
+
+* `fixed_ip` - Indicates the intranet floating IP address of the instance.
+
+* `ssl_enable` - Indicates whether to enable SSL.
+
+* `tags` - Indicates the tags of the instance.
+
+* `ha_replication_mode` - Indicates the replication mode for the standby DB instance.
+
+* `time_zone` - Indicates the time zone.
+
+* `private_ips` - Indicates the private ips in list.
+
+* `public_ips` - Indicates the public ips in list.
+
+* `status` - Indicates the DB instance status.
+
+* `created` - Indicates the creation time.
+
+* `db` - Indicates the database information. The [db](#rds_db) object structure is documented below.
+
+* `volume` - Indicates the volume information. The [volume](#rds_volume) object structure is documented below.
+
+* `backup_strategy` - Indicates the advanced backup policy. The [backup_strategy](#rds_backup_strategy) object
+  structure is documented below.
+
+* `nodes` - Indicates the instance nodes information. The [nodes](#rds_nodes) object structure is documented below.
+
+<a name="rds_db"></a>
+The `db` block supports:
+
+* `type` - Indicates the database engine.
+
+* `version` - Indicates the database version.
+
+* `port` - Indicates the database port.
+
+* `user_name` - Indicates the database username.
+
+<a name="rds_volume"></a>
+The `volume` block supports:
+
+* `size` - Indicates the volume size.
+
+* `type` - Indicates the volume type.
+
+* `disk_encryption_id` - Indicates the kms key id.
+
+<a name="rds_backup_strategy"></a>
+The `backup_strategy` block supports:
+
+* `start_time` - Indicates the backup time window.
+
+* `keep_days` - Indicates the number of days to retain the generated.
+
+<a name="rds_nodes"></a>
+The `nodes` block supports:
+
+* `id` - Indicates the node ID.
+
+* `name` - Indicates the node name.
+
+* `status` - Indicates the node status.
+
+* `role` - Indicates the node type.
+
+* `availability_zone` - Indicates the availability zone where the node resides.

--- a/docs/data-sources/rds_sqlserver_collations.md
+++ b/docs/data-sources/rds_sqlserver_collations.md
@@ -1,0 +1,28 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_sqlserver_collations
+
+Use this data source to get the list of RDS SQLServer collations.
+
+## Example Usage
+
+```hcl
+data "g42cloud_rds_sqlserver_collations" "collations" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `char_sets` - Indicates the character set information list.

--- a/docs/data-sources/rds_storage_types.md
+++ b/docs/data-sources/rds_storage_types.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_storage_types
+
+Use this data source to get the list of RDS storage types.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "g42cloud_rds_storage_types" "test" {
+  db_type    = "MySQL"
+  db_version = "8.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `db_type` - (Required, String) DB engine. The valid values are **MySQL**, **PostgreSQL**, **SQLServer**.
+
+* `db_version` - (Required, String) DB version number.
+
+* `instance_mode` - (Optional, String) HA mode. The valid values are **single**, **ha**, **replica**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `storage_types` - Storage type list. For details, see Data structure of the storage_type field.
+  The [storage_types](#Storagetype_storageType) structure is documented below.
+
+<a name="Storagetype_storageType"></a>
+The `storage_types` block supports:
+
+* `name` - Storage type.  
+  The options are as follows:
+    - **ULTRAHIGH**: SSD storage.
+    - **LOCALSSD**: Local SSD storage.
+    - **CLOUDSSD**: Cloud SSD storage.
+        This storage type is supported only with general-purpose and dedicated DB instances.
+    - **ESSD**: extreme SSD storage.
+        This storage type is supported only with dedicated DB instances.
+
+* `az_status` - The status details of the AZs to which the specification belongs.
+  Key indicates the AZ ID, and value indicates the specification status in the AZ.
+  The options of value are as follows:
+    - **normal**: The specifications in the AZ are available.
+    - **unsupported**: The specifications are not supported by the AZ.
+    - **sellout**: The specifications in the AZ are sold out.
+
+* `support_compute_group_type` - Performance specifications.
+  The options are as follows:
+    - **normal**: General-enhanced.
+    - **normal2**: General-enhanced II.
+    - **armFlavors**: Kunpeng general-enhanced.
+    - **dedicicatenormal**: Exclusive x86.
+    - **armlocalssd**: Standard Kunpeng.
+    - **normallocalssd**: Standard x86.
+    - **general**: General-purpose.
+    - **dedicated**: Dedicated, which is only supported for cloud SSDs.
+    - **rapid**: Dedicated, which is only supported for extreme SSDs.
+    - **bigmen**: Large-memory.

--- a/docs/resources/rds_backup.md
+++ b/docs/resources/rds_backup.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_backup
+
+Manages a RDS manual backup resource within G42Cloud.  
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "backup_name" {}
+
+resource "g42cloud_rds_backup" "test" {
+  instance_id = var.instance_id
+  name        = var.backup_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Backup name.  
+  It must be 4 to 64 characters long, start with a letter, and contain only letters (case-sensitive),
+  digits, hyphens (-), and underscores (_).
+
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Instance ID.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) The description about the backup.  
+  It contains a maximum of 256 characters and cannot contain the following special characters: >!<"&'=.
+
+  Changing this parameter will create a new resource.
+
+* `databases` - (Optional, List, ForceNew) List of self-built Microsoft SQL Server databases that are partially
+  backed up. The [databases](#Backup_BackupDatabase) structure is documented below.
+  (Only Microsoft SQL Server supports partial backups).
+
+  Changing this parameter will create a new resource.
+
+<a name="Backup_BackupDatabase"></a>
+The `databases` block supports:
+
+* `name` - (Required, String, ForceNew) Database to be backed up for Microsoft SQL Server.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `begin_time` - Backup start time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `end_time` - Backup end time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `status` - Backup status.  
+  The options are as follows:
+    + **BUILDING**: Backup in progress.
+    + **COMPLETED**: Backup completed.
+    + **FAILED**: Backup failed.
+    + **DELETING**: Backup being deleted.
+
+* `size` - Backup size in KB.
+
+* `associated_with_ddm` - Whether a DDM instance has been associated.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The rds manual backup can be imported using the instance ID and the backup ID separated by a slash, e.g.:
+
+```shell
+terraform import g42cloud_rds_backup.test 1ce123456a00f2591fabc00385ff1235/0ce123456a00f2591fabc00385ff1234
+```

--- a/docs/resources/rds_mysql_account.md
+++ b/docs/resources/rds_mysql_account.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_mysql_account
+
+Manages RDS Mysql account resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "g42cloud_rds_mysql_account" "test" {
+  instance_id = var.instance_id
+  name        = "test"
+  password    = "Test@12345678"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the rds account resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the rds instance id. Changing this will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the username of the db account. Only lowercase letters, digits,
+  hyphens (-), and userscores (_) are allowed. Changing this will create a new resource.
+  + If the database version is MySQL 5.6, the username consists of 1 to 16 characters.
+  + If the database version is MySQL 5.7 or 8.0, the username consists of 1 to 32 characters.
+
+* `password` - (Required, String) Specifies the password of the db account. The parameter must be 8 to 32 characters
+  long and contain only letters(case-sensitive), digits, and special characters(~!@#$%^*-_=+?,()&). The value must be
+  different from `name` or `name` spelled backwards.
+
+* `hosts` - (Optional, List, ForceNew) Specifies the IP addresses that are allowed to access your DB instance.
+  + If the IP address is set to %, all IP addresses are allowed to access your instance.
+  + If the IP address is set to 10.10.10.%, all IP addresses in the subnet 10.10.10.X are allowed to access
+    your instance.
+  + Multiple IP addresses can be added.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies remarks of the database account. The parameter must be 1 to 512
+  characters long and is supported only for MySQL 8.0.25 and later versions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of account which is formatted `<instance_id>/<name>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+RDS account can be imported using the `instance_id` and `name` separated by a slash, e.g.:
+
+```bash
+$ terraform import g42cloud_rds_mysql_account.account_1 <instance_id>/<name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `password`. It is generally recommended
+running `terraform plan` after importing the RDS Mysql account. You can then decide if changes should be applied to
+the RDS Mysql account, or the resource definition should be updated to align with the RDS Mysql account. Also you
+can ignore changes as below.
+
+```hcl
+resource "g42cloud_rds_mysql_account" "account_1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      password
+    ]
+  }
+}
+```

--- a/docs/resources/rds_mysql_database.md
+++ b/docs/resources/rds_mysql_database.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_mysql_database
+
+Manages RDS Mysql database resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "g42cloud_rds_mysql_database" "test" {
+  instance_id   = var.instance_id
+  name          = "test"
+  character_set = "utf8"
+  description   = "test database"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the RDS database resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the RDS instance ID. Changing this will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the database name. The database name contains **1** to **64**
+  characters. The name can only consist of lowercase letters, digits, hyphens (-), underscores (_) and dollar signs
+  ($). The total number of hyphens (-) and dollar signs ($) cannot exceed **10**. RDS for **MySQL 8.0** does not
+  support dollar signs ($). Changing this will create a new resource.
+
+* `character_set` - (Required, String, ForceNew) Specifies the character set used by the database, For example **utf8**,
+  **gbk**, **ascii**, etc. Changing this will create a new resource.
+
+* `description` - (Optional, String) Specifies the database description. The value can contain **0** to **512** characters.
+  This parameter takes effect only for DB instances whose kernel versions are at least **5.6.51.3**, **5.7.33.1**,
+  or **8.0.21.4**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of database which is formatted `<instance_id>/<name>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+RDS database can be imported using the `instance id` and `name` separated by slash, e.g.
+
+```bash
+$ terraform import g42cloud_rds_mysql_database.database_1 <instance_id>/<name>
+```

--- a/docs/resources/rds_mysql_database_privilege.md
+++ b/docs/resources/rds_mysql_database_privilege.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_mysql_database_privilege
+
+Manages RDS Mysql database privilege resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "db_name" {}
+variable "user_name_1" {}
+variable "user_name_2" {}
+
+resource "g42cloud_rds_mysql_database_privilege" "test" {
+  instance_id = var.instance_id
+  db_name     = var.db_name
+
+  users {
+    name     = var.user_name_1
+    readonly = true
+  }
+
+  users {
+    name     = var.user_name_2
+    readonly = false
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the RDS database privilege resource. If omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the RDS instance ID. Changing this will create a new resource.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name. Changing this creates a new resource.
+
+* `users` - (Required, List) Specifies the account that associated with the database. The [users](#rds_users) object
+  structure is documented below.
+
+<a name="rds_users"></a>
+The `users` block supports:
+
+* `name` - (Required, String) Specifies the username of the database account.
+
+* `readonly` - (Optional, Bool) Specifies the read-only permission. The value can be:
+  + **true**: indicates the read-only permission.
+  + **false**: indicates the read and write permission.
+
+  The default value is **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of database privilege which is formatted `<instance_id>/<db_name>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+RDS database privilege can be imported using the `instance id` and `db_name`, e.g.
+
+```bash
+$ terraform import g42cloud_rds_mysql_database_privilege.test <instance_id>/<db_name>
+```

--- a/docs/resources/rds_sql_audit.md
+++ b/docs/resources/rds_sql_audit.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# g42cloud_rds_sql_audit
+
+Manages RDS SQL audit resource within G42Cloud.
+
+-> **NOTE:** Only MySQL and PostgreSQL engines are supported.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "g42cloud_rds_sql_audit" "test" {
+  instance_id = var.instance_id
+  keep_days   = 5
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the RDS instance.
+
+  Changing this parameter will create a new resource.
+
+* `keep_days` - (Required, Int) Specifies the number of days for storing audit logs. Value ranges from `1` to `732`.
+
+* `reserve_auditlogs` - (Optional, Bool) Specifies whether the historical audit logs will be reserved for some time
+  when SQL audit is disabled. It is valid only when SQL audit is disabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The RDS SQL audit can be imported using the `id`, e.g.
+
+```bash
+$ terraform import g42cloud_rds_sql_audit.test <id>
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -245,7 +245,12 @@ func Provider() *schema.Provider {
 
 			"g42cloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
-			"g42cloud_rds_flavors": rds.DataSourceRdsFlavor(),
+			"g42cloud_rds_backups":              rds.DataSourceBackup(),
+			"g42cloud_rds_engine_versions":      rds.DataSourceRdsEngineVersionsV3(),
+			"g42cloud_rds_instances":            rds.DataSourceRdsInstances(),
+			"g42cloud_rds_sqlserver_collations": rds.DataSourceSQLServerCollations(),
+			"g42cloud_rds_storage_types":        rds.DataSourceStoragetype(),
+			"g42cloud_rds_flavors":              rds.DataSourceRdsFlavor(),
 
 			"g42cloud_rms_policy_definitions": rms.DataSourcePolicyDefinitions(),
 
@@ -429,9 +434,14 @@ func Provider() *schema.Provider {
 			"g42cloud_rms_resource_aggregation_authorization": rms.ResourceAggregationAuthorization(),
 			"g42cloud_rms_resource_recorder":                  rms.ResourceRecorder(),
 
-			"g42cloud_rds_instance":              ResourceRdsInstanceV3(),
-			"g42cloud_rds_parametergroup":        rds.ResourceRdsConfiguration(),
-			"g42cloud_rds_read_replica_instance": rds.ResourceRdsReadReplicaInstance(),
+			"g42cloud_rds_instance":                 ResourceRdsInstanceV3(),
+			"g42cloud_rds_backup":                   rds.ResourceBackup(),
+			"g42cloud_rds_mysql_account":            rds.ResourceMysqlAccount(),
+			"g42cloud_rds_mysql_database":           rds.ResourceMysqlDatabase(),
+			"g42cloud_rds_mysql_database_privilege": rds.ResourceMysqlDatabasePrivilege(),
+			"g42cloud_rds_parametergroup":           rds.ResourceRdsConfiguration(),
+			"g42cloud_rds_read_replica_instance":    rds.ResourceRdsReadReplicaInstance(),
+			"g42cloud_rds_sql_audit":                rds.ResourceSQLAudit(),
 
 			"g42cloud_servicestage_application":                 servicestage.ResourceApplication(),
 			"g42cloud_servicestage_component_instance":          servicestage.ResourceComponentInstance(),

--- a/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_backups_test.go
+++ b/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_backups_test.go
@@ -1,0 +1,56 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDatasourceBackup_basic(t *testing.T) {
+	rName := "data.g42cloud_rds_backups.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceBackup_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.id", "g42cloud_rds_backup.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.name", "g42cloud_rds_backup.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "backups.0.type", "manual"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.size"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.end_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.associated_with_ddm"),
+					resource.TestCheckResourceAttr(rName, "backups.0.datastore.#", "1"),
+					resource.TestCheckResourceAttr(rName, "backups.0.databases.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceBackup_basic() string {
+	backupConfig := testBackup_mysql_basic(acceptance.RandomAccResourceName())
+	return fmt.Sprintf(`
+%s 
+
+data "g42cloud_rds_backups" "test" {
+  instance_id = g42cloud_rds_instance.test.id
+  backup_type = "manual"
+
+  depends_on = [
+    g42cloud_rds_backup.test
+  ]
+}
+`, backupConfig)
+}

--- a/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_engine_versions_test.go
+++ b/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_engine_versions_test.go
@@ -1,0 +1,98 @@
+package rds
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccRdsEngineVersionsV3DataSource_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_rds_engine_versions.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsEngineVersionsV3DataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "MySQL"),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_rds_engine_versions.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsEngineVersionsV3DataSource_PostgreSQL_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "PostgreSQL"),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsEngineVersionsV3DataSource_SQLServer_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_rds_engine_versions.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsEngineVersionsV3DataSource_SQLServer_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "SQLServer"),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func testAccRdsEngineVersionsV3DataSource_basic() string {
+	return fmt.Sprintf(`
+data "g42cloud_rds_engine_versions" "test" {
+  type = "MySQL"
+}
+`)
+}
+
+func testAccRdsEngineVersionsV3DataSource_PostgreSQL_basic() string {
+	return fmt.Sprintf(`
+data "g42cloud_rds_engine_versions" "test" {
+  type = "PostgreSQL"
+}
+`)
+}
+
+func testAccRdsEngineVersionsV3DataSource_SQLServer_basic() string {
+	return fmt.Sprintf(`
+data "g42cloud_rds_engine_versions" "test" {
+  type = "SQLServer"
+}
+`)
+}

--- a/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_instances_test.go
+++ b/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_instances_test.go
@@ -1,0 +1,250 @@
+package rds
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccRdsInstanceDataSource_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_rds_instances.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceDataSource_basic(rName, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile("\\d+")),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceDataSource_SQLServer_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_rds_instances.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceDataSource_SQLServer_basic(rName, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile("\\d+")),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceDataSource_PostgreSQL_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_rds_instances.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceDataSource_PostgreSQL_basic(rName, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile("\\d+")),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testMySQL_base(rName, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%[2]s"
+}
+
+resource "g42cloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.mysql.c6.large.4"
+  availability_zone = [data.g42cloud_availability_zones.test.names[0]]
+  security_group_id = g42cloud_networking_secgroup.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  vpc_id            = g42cloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "%[3]s"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+`, common.TestVpc(rName), rName, dbPwd)
+}
+
+func testSQLServer_base(rName, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.mssql.se.c6.large.4"
+  availability_zone = [data.g42cloud_availability_zones.test.names[0]]
+  security_group_id = g42cloud_networking_secgroup.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  vpc_id            = g42cloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "Huangwei!120521"
+    type     = "SQLServer"
+    version  = "2019_SE"
+    port     = 8631
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+`, common.TestVpc(rName), rName, dbPwd)
+}
+
+func testPostgreSQL_base(rName, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.c6.large.4"
+  availability_zone = [data.g42cloud_availability_zones.test.names[0]]
+  security_group_id = g42cloud_networking_secgroup.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  vpc_id            = g42cloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "Huangwei!120521"
+    type     = "PostgreSQL"
+    version  = "14"
+    port     = 8632
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+`, common.TestVpc(rName), rName, dbPwd)
+}
+
+func testAccRdsInstanceDataSource_basic(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_rds_instances" "test" {
+  depends_on = [
+    g42cloud_rds_instance.test,
+  ]
+}
+`, testMySQL_base(name, dbPwd))
+}
+
+func testAccRdsInstanceDataSource_SQLServer_basic(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_rds_instances" "test" {
+  depends_on = [
+    g42cloud_rds_instance.test,
+  ]
+}
+`, testSQLServer_base(name, dbPwd))
+}
+
+func testAccRdsInstanceDataSource_PostgreSQL_basic(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_rds_instances" "test" {
+  depends_on = [
+    g42cloud_rds_instance.test,
+  ]
+}
+`, testPostgreSQL_base(name, dbPwd))
+}

--- a/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_sqlserver_collations_test.go
+++ b/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_sqlserver_collations_test.go
@@ -1,0 +1,34 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDatasourceSQLServerCollations_basic(t *testing.T) {
+	rName := "data.g42cloud_rds_sqlserver_collations.collations"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceSQLServerCollations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "char_sets.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceSQLServerCollations_basic() string {
+	return `
+data "g42cloud_rds_sqlserver_collations" "collations" {}
+`
+}

--- a/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_storage_types_test.go
+++ b/g42cloud/services/acceptance/rds/data_source_g42cloud_rds_storage_types_test.go
@@ -1,0 +1,99 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDatasourceStoragetype_basic(t *testing.T) {
+	rName := "data.g42cloud_rds_storage_types.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceStoragetype_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.az_status.%"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.support_compute_group_type.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceStoragetype_PostgreSQL_basic(t *testing.T) {
+	rName := "data.g42cloud_rds_storage_types.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceStoragetype_PostgreSQL_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.az_status.%"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.support_compute_group_type.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceStoragetype_SQLServer_basic(t *testing.T) {
+	rName := "data.g42cloud_rds_storage_types.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceStoragetype_SQLServer_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.az_status.%"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.support_compute_group_type.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceStoragetype_basic() string {
+	return `
+data "g42cloud_rds_storage_types" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "replica"
+}`
+}
+
+func testAccDatasourceStoragetype_PostgreSQL_basic() string {
+	return `
+data "g42cloud_rds_storage_types" "test" {
+  db_type       = "PostgreSQL"
+  db_version    = "14"
+  instance_mode = "ha"
+}`
+}
+
+func testAccDatasourceStoragetype_SQLServer_basic() string {
+	return `
+data "g42cloud_rds_storage_types" "test" {
+  db_type       = "SQLServer"
+  db_version    = "2019_SE"
+  instance_mode = "single"
+}`
+}

--- a/g42cloud/services/acceptance/rds/resource_g42cloud_rds_backup_test.go
+++ b/g42cloud/services/acceptance/rds/resource_g42cloud_rds_backup_test.go
@@ -1,0 +1,338 @@
+package rds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getBackupResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getBackup: Query the RDS manual backup
+	var (
+		getBackupHttpUrl = "v3/{project_id}/backups"
+		getBackupProduct = "rds"
+	)
+	getBackupClient, err := config.NewServiceClient(getBackupProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Backup Client: %s", err)
+	}
+
+	getBackupPath := getBackupClient.Endpoint + getBackupHttpUrl
+	getBackupPath = strings.Replace(getBackupPath, "{project_id}", getBackupClient.ProjectID, -1)
+
+	getBackupqueryParams := fmt.Sprintf("?instance_id=%s&backup_id=%s",
+		state.Primary.Attributes["instance_id"], state.Primary.ID)
+	getBackupPath = getBackupPath + getBackupqueryParams
+	getBackupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getBackupResp, err := getBackupClient.Request("GET", getBackupPath, &getBackupOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Backup: %s", err)
+	}
+
+	getBackupRespBody, err := utils.FlattenResponse(getBackupResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Backup: %s", err)
+	}
+
+	count := utils.PathSearch("total_count", getBackupRespBody, 0)
+	if fmt.Sprintf("%v", count) == "0" {
+		return nil, fmt.Errorf("error retrieving Backup: %s", err)
+	}
+
+	return getBackupRespBody, nil
+}
+
+func TestAccBackup_mysql_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_rds_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_mysql_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func TestAccBackup_sqlserver_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_rds_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_sqlserver_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func TestAccBackup_pg_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_rds_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_pg_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_mysql_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.mysql.c6.large.4"
+  availability_zone = [data.g42cloud_availability_zones.test.names[0]]
+  security_group_id = g42cloud_networking_secgroup.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  vpc_id            = g42cloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "Huangwei!120521"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "g42cloud_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = g42cloud_rds_instance.test.id
+}
+`, common.TestVpc(name), name)
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_sqlserver_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.mssql.se.c6.large.4"
+  availability_zone = [data.g42cloud_availability_zones.test.names[0]]
+  security_group_id = g42cloud_networking_secgroup.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  vpc_id            = g42cloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "Huangwei!120521"
+    type     = "SQLServer"
+    version  = "2019_SE"
+    port     = 8631
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "g42cloud_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = g42cloud_rds_instance.test.id
+}
+`, common.TestVpc(name), name)
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_pg_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "g42cloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.c6.large.4"
+  availability_zone = [data.g42cloud_availability_zones.test.names[0]]
+  security_group_id = g42cloud_networking_secgroup.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  vpc_id            = g42cloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "Huangwei!120521"
+    type     = "PostgreSQL"
+    version  = "14"
+    port     = 8632
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "g42cloud_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = g42cloud_rds_instance.test.id
+}
+`, common.TestVpc(name), name)
+}
+
+func testAccBackupImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}

--- a/g42cloud/services/acceptance/rds/resource_g42cloud_rds_mysql_account_test.go
+++ b/g42cloud/services/acceptance/rds/resource_g42cloud_rds_mysql_account_test.go
@@ -1,0 +1,199 @@
+package rds
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/pagination"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getMysqlAccountResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getMysqlAccount: query RDS Mysql account
+	var (
+		getMysqlAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/detail?page=1&limit=100"
+		getMysqlAccountProduct = "rds"
+	)
+	getMysqlAccountClient, err := cfg.NewServiceClient(getMysqlAccountProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and user from resource id
+	parts := strings.Split(state.Primary.ID, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<name>")
+	}
+	instanceId := parts[0]
+	accountName := parts[1]
+
+	getMysqlAccountPath := getMysqlAccountClient.Endpoint + getMysqlAccountHttpUrl
+	getMysqlAccountPath = strings.ReplaceAll(getMysqlAccountPath, "{project_id}", getMysqlAccountClient.ProjectID)
+	getMysqlAccountPath = strings.ReplaceAll(getMysqlAccountPath, "{instance_id}", instanceId)
+
+	getMysqlAccountResp, err := pagination.ListAllItems(
+		getMysqlAccountClient,
+		"page",
+		getMysqlAccountPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS Mysql account")
+	}
+
+	getMysqlAccountRespJson, err := json.Marshal(getMysqlAccountResp)
+	if err != nil {
+		return nil, err
+	}
+	var getMysqlAccountRespBody interface{}
+	err = json.Unmarshal(getMysqlAccountRespJson, &getMysqlAccountRespBody)
+	if err != nil {
+		return nil, err
+	}
+
+	account := utils.PathSearch(fmt.Sprintf("users[?name=='%s']|[0]", accountName), getMysqlAccountRespBody, nil)
+
+	if account != nil {
+		return account, nil
+	}
+
+	return nil, fmt.Errorf("error get RDS Mysql account by instanceID %s and account %s", instanceId, accountName)
+}
+
+func TestAccMysqlAccount_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_rds_mysql_account.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getMysqlAccountResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testMysqlAccount_basic(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test_description"),
+					resource.TestCheckResourceAttr(rName, "hosts.0", "10.10.%"),
+				),
+			},
+			{
+				Config: testMysqlAccount_basic_update(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test_description_update"),
+					resource.TestCheckResourceAttr(rName, "hosts.0", "10.10.%"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testMysql_base(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_networking_secgroup" "test" {
+  name = "%[2]s"
+}
+
+resource "g42cloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.mysql.c6.large.4"
+  availability_zone = [data.g42cloud_availability_zones.test.names[0]]
+  security_group_id = g42cloud_networking_secgroup.test.id
+  subnet_id         = g42cloud_vpc_subnet.test.id
+  vpc_id            = g42cloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "%[3]s"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+`, common.TestVpc(name), name, dbPwd)
+}
+
+func testMysqlAccount_basic(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_rds_mysql_account" "test" {
+  instance_id = g42cloud_rds_instance.test.id
+  name        = "%s"
+  password    = "Test@12345678"
+  description = "test_description"
+
+  hosts = [
+    "10.10.%%"
+  ]
+}
+`, testMysql_base(name, dbPwd), name)
+}
+
+func testMysqlAccount_basic_update(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_rds_mysql_account" "test" {
+  instance_id = g42cloud_rds_instance.test.id
+  name        = "%s"
+  password    = "Test@123456789"
+  description = "test_description_update"
+
+  hosts = [
+    "10.10.%%"
+  ]
+}
+`, testMysql_base(name, dbPwd), name)
+}

--- a/g42cloud/services/acceptance/rds/resource_g42cloud_rds_mysql_database_privilege_test.go
+++ b/g42cloud/services/acceptance/rds/resource_g42cloud_rds_mysql_database_privilege_test.go
@@ -1,0 +1,174 @@
+package rds
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/pagination"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getMysqlDatabasePrivilegeResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getMysqlDatabasePrivilege: query RDS Mysql database privilege
+	var (
+		getMysqlDatabasePrivilegeHttpUrl = "v3/{project_id}/instances/{instance_id}/database/db_user"
+		getMysqlDatabasePrivilegeProduct = "rds"
+	)
+	getMysqlDatabasePrivilegeClient, err := cfg.NewServiceClient(getMysqlDatabasePrivilegeProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and database from resource id
+	parts := strings.Split(state.Primary.ID, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<db_name>")
+	}
+	instanceId := parts[0]
+	dbName := parts[1]
+
+	getMysqlDatabasePrivilegePath := getMysqlDatabasePrivilegeClient.Endpoint + getMysqlDatabasePrivilegeHttpUrl
+	getMysqlDatabasePrivilegePath = strings.ReplaceAll(getMysqlDatabasePrivilegePath, "{project_id}",
+		getMysqlDatabasePrivilegeClient.ProjectID)
+	getMysqlDatabasePrivilegePath = strings.ReplaceAll(getMysqlDatabasePrivilegePath, "{instance_id}", instanceId)
+
+	getMysqlDatabasePrivilegeQueryParams := buildGetMysqlDatabasePrivilegeQueryParams(dbName)
+	getMysqlDatabasePrivilegePath += getMysqlDatabasePrivilegeQueryParams
+
+	getMysqlDatabasePrivilegeResp, err := pagination.ListAllItems(
+		getMysqlDatabasePrivilegeClient,
+		"page",
+		getMysqlDatabasePrivilegePath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Mysql database privilege: %s", err)
+	}
+
+	getMysqlDatabasePrivilegeRespJson, err := json.Marshal(getMysqlDatabasePrivilegeResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Mysql database privilege: %s", err)
+	}
+	var getMysqlDatabasePrivilegeRespBody interface{}
+	err = json.Unmarshal(getMysqlDatabasePrivilegeRespJson, &getMysqlDatabasePrivilegeRespBody)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Mysql database privilege: %s", err)
+	}
+
+	curJson := utils.PathSearch("users", getMysqlDatabasePrivilegeRespBody, make([]interface{}, 0))
+	if len(curJson.([]interface{})) == 0 {
+		return nil, fmt.Errorf("error get RDS Mysql database privilege")
+	}
+
+	return getMysqlDatabasePrivilegeRespBody, nil
+}
+
+func buildGetMysqlDatabasePrivilegeQueryParams(dbName string) string {
+	return fmt.Sprintf("?db-name=%s&page=1&limit=100", dbName)
+}
+
+func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_rds_mysql_database_privilege.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
+		acctest.RandIntRange(10, 99))
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getMysqlDatabasePrivilegeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsDatabasePrivilege_basic(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "db_name",
+						"g42cloud_rds_mysql_database.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "users.0.name",
+						"g42cloud_rds_mysql_account.test_1", "name"),
+					resource.TestCheckResourceAttr(rName, "users.0.readonly", "false"),
+				),
+			},
+			{
+				Config: testAccRdsDatabasePrivilege_basic_update(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "db_name",
+						"g42cloud_rds_mysql_database.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "users.0.name",
+						"g42cloud_rds_mysql_account.test_2", "name"),
+					resource.TestCheckResourceAttr(rName, "users.0.readonly", "true"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRdsDatabasePrivilege_basic(rName, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_rds_mysql_account" "test_1" {
+  instance_id = g42cloud_rds_instance.test.id
+  name        = "%s_1"
+  password    = "Test@12345678"
+}
+
+resource "g42cloud_rds_mysql_database_privilege" "test" {
+  instance_id = g42cloud_rds_instance.test.id
+  db_name     = g42cloud_rds_mysql_database.test.name
+
+  users {
+    name = g42cloud_rds_mysql_account.test_1.name
+  }
+}
+`, testMysqlDatabase_basic(rName, dbPwd, rName), rName)
+}
+
+func testAccRdsDatabasePrivilege_basic_update(rName, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_rds_mysql_account" "test_2" {
+  instance_id = g42cloud_rds_instance.test.id
+  name        = "%s_2"
+  password    = "Test@12345678"
+}
+
+resource "g42cloud_rds_mysql_database_privilege" "test" {
+  instance_id = g42cloud_rds_instance.test.id
+  db_name     = g42cloud_rds_mysql_database.test.name
+
+  users {
+    name     = g42cloud_rds_mysql_account.test_2.name
+    readonly = true
+  }
+}
+`, testMysqlDatabase_basic(rName, dbPwd, rName), rName)
+}

--- a/g42cloud/services/acceptance/rds/resource_g42cloud_rds_mysql_database_test.go
+++ b/g42cloud/services/acceptance/rds/resource_g42cloud_rds_mysql_database_test.go
@@ -1,0 +1,132 @@
+package rds
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/pagination"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getMysqlDatabaseResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getMysqlDatabase: query RDS Mysql database
+	var (
+		getMysqlDatabaseHttpUrl = "v3/{project_id}/instances/{instance_id}/database/detail?page=1&limit=100"
+		getMysqlDatabaseProduct = "rds"
+	)
+	getMysqlDatabaseClient, err := cfg.NewServiceClient(getMysqlDatabaseProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and database from resource id
+	parts := strings.Split(state.Primary.ID, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<name>")
+	}
+	instanceId := parts[0]
+	dbName := parts[1]
+
+	getMysqlDatabasePath := getMysqlDatabaseClient.Endpoint + getMysqlDatabaseHttpUrl
+	getMysqlDatabasePath = strings.ReplaceAll(getMysqlDatabasePath, "{project_id}", getMysqlDatabaseClient.ProjectID)
+	getMysqlDatabasePath = strings.ReplaceAll(getMysqlDatabasePath, "{instance_id}", instanceId)
+
+	getMysqlDatabaseResp, err := pagination.ListAllItems(
+		getMysqlDatabaseClient,
+		"page",
+		getMysqlDatabasePath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving MysqlDatabase")
+	}
+
+	getMysqlDatabaseRespJson, err := json.Marshal(getMysqlDatabaseResp)
+	if err != nil {
+		return nil, err
+	}
+	var getMysqlDatabaseRespBody interface{}
+	err = json.Unmarshal(getMysqlDatabaseRespJson, &getMysqlDatabaseRespBody)
+	if err != nil {
+		return nil, err
+	}
+
+	database := utils.PathSearch(fmt.Sprintf("databases[?name=='%s']|[0]", dbName), getMysqlDatabaseRespBody, nil)
+	if database != nil {
+		return database, nil
+	}
+
+	return nil, fmt.Errorf("error get RDS Mysql database by instanceID %s and database %s", instanceId, dbName)
+}
+
+func TestAccMysqlDatabase_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_rds_mysql_database.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getMysqlDatabaseResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testMysqlDatabase_basic(name, dbPwd, "test database"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "character_set", "utf8"),
+					resource.TestCheckResourceAttr(rName, "description", "test database"),
+				),
+			},
+			{
+				Config: testMysqlDatabase_basic(name, dbPwd, "test database update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "character_set", "utf8"),
+					resource.TestCheckResourceAttr(rName, "description", "test database update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testMysqlDatabase_basic(name, dbPwd, description string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_rds_mysql_database" "test" {
+  instance_id   = g42cloud_rds_instance.test.id
+  name          = "%s"
+  character_set = "utf8"
+  description   = "%s"
+}
+`, testMysql_base(name, dbPwd), name, description)
+}

--- a/g42cloud/services/acceptance/rds/resource_g42cloud_rds_sql_audit_test.go
+++ b/g42cloud/services/acceptance/rds/resource_g42cloud_rds_sql_audit_test.go
@@ -1,0 +1,123 @@
+package rds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSQLAuditResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getSQLAudit: Query the RDS SQL audit
+	var (
+		getSQLAuditHttpUrl = "v3/{project_id}/instances/{instance_id}/auditlog-policy"
+		getSQLAuditProduct = "rds"
+	)
+	getSQLAuditClient, err := cfg.NewServiceClient(getSQLAuditProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	getSQLAuditPath := getSQLAuditClient.Endpoint + getSQLAuditHttpUrl
+	getSQLAuditPath = strings.ReplaceAll(getSQLAuditPath, "{project_id}", getSQLAuditClient.ProjectID)
+	getSQLAuditPath = strings.ReplaceAll(getSQLAuditPath, "{instance_id}", state.Primary.ID)
+
+	getSQLAuditOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getSQLAuditResp, err := getSQLAuditClient.Request("GET", getSQLAuditPath, &getSQLAuditOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQL audit: %s", err)
+	}
+
+	getSQLAuditRespBody, err := utils.FlattenResponse(getSQLAuditResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQL audit: %s", err)
+	}
+
+	keepDays := utils.PathSearch("keep_days", getSQLAuditRespBody, 0).(float64)
+	if keepDays == 0 {
+		return nil, fmt.Errorf("error retrieving RDS SQL audit: %s", err)
+	}
+
+	return getSQLAuditRespBody, nil
+}
+
+func TestAccSQLAudit_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_rds_sql_audit.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSQLAuditResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSQLAudit_basic(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "5"),
+				),
+			},
+			{
+				Config: testSQLAudit_basic_update(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"g42cloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "9"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testSQLAudit_basic(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_rds_sql_audit" "test" {
+  instance_id = g42cloud_rds_instance.test.id
+  keep_days   = "5"
+}
+`, testMysql_base(name, dbPwd))
+}
+
+func testSQLAudit_basic_update(name, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "g42cloud_rds_sql_audit" "test" {
+  instance_id = g42cloud_rds_instance.test.id
+  keep_days   = "9"
+}
+`, testMysql_base(name, dbPwd))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import RDS resource and dataSource, and its unit test and document

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

‍‍‍‍‍‍‍
```md

### resource_g42cloud_rds_backup

=== RUN   TestAccBackup_mysql_basic
=== PAUSE TestAccBackup_mysql_basic
=== CONT  TestAccBackup_mysql_basic
--- PASS: TestAccBackup_mysql_basic (1266.59s)
PASS

coverage: 29.7% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccBackup_sqlserver_basic
=== PAUSE TestAccBackup_sqlserver_basic
=== CONT  TestAccBackup_sqlserver_basic
--- PASS: TestAccBackup_sqlserver_basic (2294.28s)
PASS

coverage: 29.7% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccBackup_pg_basic
=== PAUSE TestAccBackup_pg_basic
=== CONT  TestAccBackup_pg_basic
--- PASS: TestAccBackup_pg_basic (1304.61s)
PASS

coverage: 29.7% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_rds_mysql_account

=== RUN   TestAccMysqlAccount_basic
--- PASS: TestAccMysqlAccount_basic (788.88s)
PASS

coverage: 29.7% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_rds_mysql_database

=== RUN   TestAccMysqlDatabase_basic
=== PAUSE TestAccMysqlDatabase_basic
=== CONT  TestAccMysqlDatabase_basic
--- PASS: TestAccMysqlDatabase_basic (1056.45s)
PASS

coverage: 29.7% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_rds_mysql_database_privilege

=== RUN   TestAccRdsDatabasePrivilege_basic
=== PAUSE TestAccRdsDatabasePrivilege_basic
=== CONT  TestAccRdsDatabasePrivilege_basic
--- PASS: TestAccRdsDatabasePrivilege_basic (673.53s)
PASS

coverage: 29.7% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### resource_g42cloud_rds_sql_audit

=== RUN   TestAccSQLAudit_basic
=== PAUSE TestAccSQLAudit_basic
=== CONT  TestAccSQLAudit_basic
--- PASS: TestAccSQLAudit_basic (1210.41s)
PASS

coverage: 29.7% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### data_source_g42cloud_rds_backups

=== RUN   TestAccDatasourceBackup_basic
=== PAUSE TestAccDatasourceBackup_basic
=== CONT  TestAccDatasourceBackup_basic
--- PASS: TestAccDatasourceBackup_basic (935.01s)
PASS

coverage: 26.7% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### data_source_g42cloud_rds_engine_versions

=== RUN   TestAccRdsEngineVersionsV3DataSource_basic
=== PAUSE TestAccRdsEngineVersionsV3DataSource_basic
=== CONT  TestAccRdsEngineVersionsV3DataSource_basic
--- PASS: TestAccRdsEngineVersionsV3DataSource_basic (18.51s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic
=== PAUSE TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic
=== CONT  TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic
--- PASS: TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic (18.91s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccRdsEngineVersionsV3DataSource_SQLServer_basic
=== PAUSE TestAccRdsEngineVersionsV3DataSource_SQLServer_basic
=== CONT  TestAccRdsEngineVersionsV3DataSource_SQLServer_basic
--- PASS: TestAccRdsEngineVersionsV3DataSource_SQLServer_basic (19.05s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...

```

```md

### data_source_g42cloud_rds_instances

=== RUN   TestAccRdsInstanceDataSource_basic
=== PAUSE TestAccRdsInstanceDataSource_basic
=== CONT  TestAccRdsInstanceDataSource_basic
--- PASS: TestAccRdsInstanceDataSource_basic (1148.52s)
PASS

coverage: 26.6% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccRdsInstanceDataSource_PostgreSQL_basic
=== PAUSE TestAccRdsInstanceDataSource_PostgreSQL_basic
=== CONT  TestAccRdsInstanceDataSource_PostgreSQL_basic
--- PASS: TestAccRdsInstanceDataSource_PostgreSQL_basic (740.55s)
PASS

coverage: 26.6% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccRdsInstanceDataSource_SQLServer_basic
=== PAUSE TestAccRdsInstanceDataSource_SQLServer_basic
=== CONT  TestAccRdsInstanceDataSource_SQLServer_basic
--- PASS: TestAccRdsInstanceDataSource_SQLServer_basic (1446.96s)
PASS

coverage: 26.6% of statements in ../../../../../terraform-provider-g42cloud/...

```

```md

### data_source_g42cloud_rds_sqlserver_collations

=== RUN   TestAccDatasourceSQLServerCollations_basic
=== PAUSE TestAccDatasourceSQLServerCollations_basic
=== CONT  TestAccDatasourceSQLServerCollations_basic
--- PASS: TestAccDatasourceSQLServerCollations_basic (18.15s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...
```

```md

### data_source_g42cloud_rds_storage_types

=== RUN   TestAccDatasourceStoragetype_basic
=== PAUSE TestAccDatasourceStoragetype_basic
=== CONT  TestAccDatasourceStoragetype_basic
--- PASS: TestAccDatasourceStoragetype_basic (19.01s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...

=== RUN   TestAccDatasourceStoragetype_PostgreSQL_basic
=== PAUSE TestAccDatasourceStoragetype_PostgreSQL_basic
=== CONT  TestAccDatasourceStoragetype_PostgreSQL_basic
--- PASS: TestAccDatasourceStoragetype_PostgreSQL_basic (20.36s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...


=== RUN   TestAccDatasourceStoragetype_SQLServer_basic
=== PAUSE TestAccDatasourceStoragetype_SQLServer_basic
=== CONT  TestAccDatasourceStoragetype_SQLServer_basic
--- PASS: TestAccDatasourceStoragetype_SQLServer_basic (18.22s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...
```
