### PR TITLE
feat(er): import er resource, unit tests and docs

### DIFF
--- a/docs/data-sources/er_instances.md
+++ b/docs/data-sources/er_instances.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# g42cloud_er_instances
+
+Use this data source to filter ER instances within G42Cloud.
+
+## Example Usage
+
+```hcl
+data "g42cloud_er_instances" "test" {
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the ER instances are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Optional, String) Specifies the ID used to query specified ER instance.
+
+* `name` - (Optional, String) Specifies the name used to filter the ER instances.
+  The valid length is limited from `1` to `64`, only Chinese and English letters, digits, underscores (_) and
+  hyphens (-) are allowed.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the ER instances to be queried.
+
+* `owned_by_self` - (Optional, Bool) Specifies whether resources belong to the current renant.
+
+* `status` - (Optional, String) Specifies the status used to filter the ER instances.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs used to filter the ER instances.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - All instances that match the filter parameters.  
+  The [instances](#er_data_instances) structure is documented below.
+
+<a name="er_data_instances"></a>
+The `instances` block supports:
+
+* `id` - The ER instance ID.
+
+* `asn` - The BGP AS number of the ER instance.
+
+* `name` - The name of the ER instance.
+
+* `description` - The description of the ER instance.
+
+* `status` - The current status of the ER instance.
+
+* `enterprise_project_id` - The ID of enterprise project to which the ER instance belongs.
+
+* `tags` - The key/value pairs to associate with the ER instance.
+
+* `created_at` - The creation time of the ER instance.
+
+* `updated_at` - The last update time of the ER instance.
+
+* `enable_default_propagation` - Whether to enable the propagation of the default route table.
+
+* `enable_default_association` - Whether to enable the association of the default route table.
+
+* `auto_accept_shared_attachments` - Whether to automatically accept the creation of shared attachment.
+
+* `default_propagation_route_table_id` - The ID of the default propagation route table.
+
+* `default_association_route_table_id` - The ID of the default association route table.
+
+* `availability_zones` - The availability zone list where the ER instance is located.

--- a/docs/data-sources/er_route_tables.md
+++ b/docs/data-sources/er_route_tables.md
@@ -1,0 +1,121 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# g42cloud_er_route_tables
+
+Use this data source to query the route tables under the ER instance within G42Cloud.
+
+## Example Usage
+
+### Querying specified route tables under ER instance using name
+
+```hcl
+variable "instance_id" {}
+variable "route_table_name" {}
+
+data "g42cloud_er_route_tables" "test" {
+  instance_id = var.instance_id
+  name        = var.route_table_name
+}
+```
+
+### Querying specified route tables under ER instance using tags
+
+```hcl
+variable "instance_id" {}
+
+data "g42cloud_er_route_tables" "test" {
+  instance_id = var.instance_id
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the ER instance and route table are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the ER instance to which the route tables belongs.
+
+* `route_table_id` - (Optional, String) Specifies the route table ID used to query specified route table.
+
+* `name` - (Optional, String) Specifies the name used to filter the route tables.  
+  The name can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-) and
+  dots (.) allowed.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs used to filter the route tables.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `route_tables` - All route tables that match the filter parameters.  
+  The [object](#route_tables) structure is documented below.
+
+<a name="route_tables"></a>
+The `route_tables` block supports:
+
+* `id` - The route table ID.
+
+* `name` - The name of the route table.
+
+* `description` - The description of the route table.
+
+* `associations` - The association configurations of the route table.  
+  The [object](#route_table_relationship) structure is documented below.
+
+* `propagations` - The propagation configurations of the route table.  
+  The [object](#route_table_relationship) structure is documented below.
+
+* `routes` - The route details of the route table.  
+  The [object](#route_table_routes) structure is documented below.
+
+* `is_default_association` - Whether this route table is the default association route table.
+
+* `is_default_propagation` - Whether this route table is the default propagation route table.
+
+* `status` - The current status of the route table.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+<a name="route_table_relationship"></a>
+The `associations` or `propagations` block supports:
+
+* `id` - The ID of the association/propagation.
+
+* `attachment_id` - The attachment ID corresponding to the routing association/propagation.
+
+* `attachment_type` - The attachment type corresponding to the routing association/propagation.
+
+<a name="route_table_routes"></a>
+The `routes` block supports:
+
+* `id` - The route ID.
+
+* `destination` - The destination address (CIDR) of the route.
+
+* `is_blackhole` - Whether route is the black hole route.
+
+* `attachments` - The details of the attachment corresponding to the route.  
+  The [object](#route_table_route_attachments) structure is documented below.
+
+* `status` - The current status of the route.
+
+<a name="route_table_route_attachments"></a>
+The `attachments` block supports:
+
+* `attachment_id` - The ID of the nexthop attachment.
+
+* `attachment_type` - The type of the nexthop attachment.
+
+* `resource_id` - The ID of the resource associated with the attachment.

--- a/docs/resources/er_instance.md
+++ b/docs/resources/er_instance.md
@@ -1,0 +1,95 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# g42cloud_er_instance
+
+Manages an ER instance resource within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "router_name" {}
+variable "bgp_as_number" {}
+variable "availability_zones" {
+  type = list(string)
+}
+
+resource "g42cloud_er_instance" "test" {
+  availability_zones = var.availability_zones
+
+  name = var.router_name
+  asn  = var.bgp_as_number
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) The router name.  
+  The name can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_) and hyphens (-) are
+  allowed.
+
+* `availability_zones` - (Required, List) The availability zone list where the ER instance is located.
+  The maximum number of availability zone is two. Select two AZs to configure active-active deployment for high
+  availability which will ensure reliability and disaster recovery.
+
+* `asn` - (Required, Int, ForceNew) The BGP AS number of the ER instance.  
+  The valid value is range from `64,512` to `65534` or range from `4,200,000,000` to `4,294,967,294`.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) The description of the ER instance.  
+  The description contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID to which the ER instance
+belongs.
+  Changing this parameter will create a new resource.
+
+* `enable_default_propagation` - (Optional, Bool) Whether to enable the propagation of the default route table.  
+  The default value is **false**.
+
+* `enable_default_association` - (Optional, Bool) Whether to enable the association of the default route table.  
+  The default value is **false**.
+
+* `auto_accept_shared_attachments` - (Optional, Bool) Whether to automatically accept the creation of shared
+attachment.
+  The default value is **false**.
+
+* `default_propagation_route_table_id` - (Optional, String) The ID of the default propagation route table.
+
+* `default_association_route_table_id` - (Optional, String) The ID of the default association route table.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - Current status of the router.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 5 minutes.
+
+## Import
+
+The router instance can be imported using the `id`, e.g.
+
+```
+$ terraform import g42cloud_er_instance.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/docs/resources/er_route_table.md
+++ b/docs/resources/er_route_table.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# g42cloud_er_route_table
+
+Manages a route table resource under the ER instance within G42Cloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "route_table_name" {}
+
+resource "g42cloud_er_route_table" "test" {
+  instance_id = var.instance_id
+  name        = var.route_table_name
+  description = "Route table created by terraform"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the ER instance and route table are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the ER instance to which the route table belongs.  
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the route table.  
+  The name can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-) and
+  dots (.) allowed.
+
+* `description` - (Optional, String) Specifies the description of the route table.  
+  The description contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the route table.  
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `is_default_association` - Whether this route table is the default association route table.
+
+* `is_default_propagation` - Whether this route table is the default propagation route table.
+
+* `status` - The current status of the route table.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.
+
+## Import
+
+Route tables can be imported using their `id` and the related `instance_id`, separated by slashes (/), e.g.
+
+```
+$ terraform import g42cloud_er_route_table.test &ltinstance_id&gt/&ltid&gt
+```

--- a/g42cloud/provider.go
+++ b/g42cloud/provider.go
@@ -2,6 +2,7 @@ package g42cloud
 
 import (
 	"fmt"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ges"
 	"log"
 	"strings"
@@ -252,6 +253,10 @@ func Provider() *schema.Provider {
 			"g42cloud_elb_loadbalancers": elb.DataSourceElbLoadbalances(),
 			"g42cloud_elb_pools":         elb.DataSourcePools(),
 
+			"g42cloud_er_availability_zones": er.DataSourceAvailabilityZones(),
+			"g42cloud_er_instances":          er.DataSourceInstances(),
+			"g42cloud_er_route_tables":       er.DataSourceRouteTables(),
+
 			"g42cloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 
 			"g42cloud_identity_role": iam.DataSourceIdentityRole(),
@@ -467,6 +472,9 @@ func Provider() *schema.Provider {
 
 			"g42cloud_ges_metadata": ges.ResourceGesMetadata(),
 
+			"g42cloud_er_instance":    er.ResourceInstance(),
+			"g42cloud_er_route_table": er.ResourceRouteTable(),
+
 			"g42cloud_identity_provider":            iam.ResourceIdentityProvider(),
 			"g42cloud_identity_provider_conversion": iam.ResourceIAMProviderConversion(),
 
@@ -592,13 +600,13 @@ func Provider() *schema.Provider {
 			"g42cloud_vpcep_service":  vpcep.ResourceVPCEndpointService(),
 
 			"g42cloud_waf_certificate":                waf.ResourceWafCertificateV1(),
-			"g42cloud_waf_domain":                     waf.ResourceWafDomainV1(),
+			"g42cloud_waf_domain":                     waf.ResourceWafDomain(),
 			"g42cloud_waf_policy":                     waf.ResourceWafPolicyV1(),
 			"g42cloud_waf_rule_blacklist":             waf.ResourceWafRuleBlackListV1(),
 			"g42cloud_waf_rule_data_masking":          waf.ResourceWafRuleDataMaskingV1(),
 			"g42cloud_waf_rule_web_tamper_protection": waf.ResourceWafRuleWebTamperProtectionV1(),
 			"g42cloud_waf_dedicated_instance":         waf.ResourceWafDedicatedInstance(),
-			"g42cloud_waf_dedicated_domain":           waf.ResourceWafDedicatedDomainV1(),
+			"g42cloud_waf_dedicated_domain":           waf.ResourceWafDedicatedDomain(),
 			"g42cloud_waf_reference_table":            waf.ResourceWafReferenceTableV1(),
 			"g42cloud_waf_rule_cc_protection":         waf.ResourceRuleCCProtection(),
 			"g42cloud_waf_rule_precise_protection":    waf.ResourceRulePreciseProtection(),

--- a/g42cloud/services/acceptance/acceptance.go
+++ b/g42cloud/services/acceptance/acceptance.go
@@ -81,6 +81,8 @@ var (
 	G42_LTS_STRUCT_CONFIG_TEMPLATE_ID   = os.Getenv("G42_LTS_STRUCT_CONFIG_TEMPLATE_ID")
 	G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME = os.Getenv("G42_LTS_STRUCT_CONFIG_TEMPLATE_NAME")
 	G42_LTS_ENABLE_FLAG                 = os.Getenv("G42_LTS_ENABLE_FLAG")
+
+	G42_ER_TEST_ON = os.Getenv("G42_ER_TEST_ON")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -601,5 +603,10 @@ func TestAccPreCheckLtsStructConfigCustom(t *testing.T) {
 func TestAccPreCheckLtsEnableFlag(t *testing.T) {
 	if G42_LTS_ENABLE_FLAG == "" {
 		t.Skip("Skip the LTS acceptance tests.")
+	}
+}
+func TestAccPreCheckER(t *testing.T) {
+	if G42_ER_TEST_ON == "" {
+		t.Skip("Skip all ER acceptance tests.")
 	}
 }

--- a/g42cloud/services/acceptance/dli/resource_g42cloud_dli_database_test.go
+++ b/g42cloud/services/acceptance/dli/resource_g42cloud_dli_database_test.go
@@ -19,7 +19,7 @@ func getDatabaseResourceFunc(conf *config.Config, state *terraform.ResourceState
 		return nil, fmt.Errorf("error creating DLI v1 client: %s", err)
 	}
 
-	return dli.GetDliSqlDatabaseByName(c, state.Primary.Attributes["name"])
+	return dli.GetDliSQLDatabaseByName(c, state.Primary.Attributes["name"])
 }
 
 func TestAccDliDatabase_basic(t *testing.T) {

--- a/g42cloud/services/acceptance/er/data_source_g42cloud_er_availability_zones_test.go
+++ b/g42cloud/services/acceptance/er/data_source_g42cloud_er_availability_zones_test.go
@@ -1,0 +1,30 @@
+package er
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccDataSourceAZs_basic(t *testing.T) {
+	dataSourceName := "data.g42cloud_er_availability_zones.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAZs_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "names.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAZs_basic string = `data "g42cloud_er_availability_zones" "all" {}`

--- a/g42cloud/services/acceptance/er/data_source_g42cloud_er_instances_test.go
+++ b/g42cloud/services/acceptance/er/data_source_g42cloud_er_instances_test.go
@@ -1,0 +1,252 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccInstancesDataSource_basic(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_instances.filter_by_name"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByName(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_er_instance" "test" {
+  availability_zones    = slice(data.g42cloud_availability_zones.test.names, 0, 1)
+  name                  = "%[1]s"
+  asn                   = %[2]d
+  description           = "Created by terraform test"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo   = "bar"
+    key   = "value"
+    owner = "terraform"
+  }
+}
+`, name, bgpAsNum)
+}
+
+func testAccInstancesDataSource_filterByName(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_instances" "filter_by_name" {
+  depends_on = [
+    g42cloud_er_instance.test,
+  ]
+
+  name = g42cloud_er_instance.test.name
+}
+
+output "is_name_filter_useful" {
+  value = alltrue([for v in data.g42cloud_er_instances.filter_by_name.instances[*].id : v == g42cloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterById(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_instances.filter_by_id"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterById(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterById(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_instances" "filter_by_id" {
+  instance_id = g42cloud_er_instance.test.id
+}
+
+output "is_id_filter_useful" {
+  value = alltrue([for v in data.g42cloud_er_instances.filter_by_id.instances[*].id : v == g42cloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterByStatus(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_instances.filter_by_status"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByStatus(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterByStatus(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_instances" "filter_by_status" {
+  status = g42cloud_er_instance.test.status
+}
+
+output "is_status_filter_useful" {
+  value = alltrue([for v in data.g42cloud_er_instances.filter_by_status.instances[*].status : v == g42cloud_er_instance.test.status])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterByEpsId(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_instances.filter_by_eps_id"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByEpsId(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterByEpsId(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_instances" "filter_by_eps_id" {
+  depends_on = [
+    g42cloud_er_instance.test,
+  ]
+
+  // Query all instances belonging to the default enterprise project.
+  enterprise_project_id = "0"
+}
+
+output "is_eps_id_filter_useful" {
+  value = alltrue([for v in data.g42cloud_er_instances.filter_by_eps_id.instances[*].enterprise_project_id : v == g42cloud_er_instance.test.enterprise_project_id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterByTags(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_instances.filter_by_tags"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByTags(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterByTags(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_instances" "filter_by_tags" {
+  depends_on = [
+    g42cloud_er_instance.test,
+  ]
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+output "is_tags_filter_is_useful" {
+  value = alltrue([for v in data.g42cloud_er_instances.filter_by_tags.instances[*].id : v == g42cloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}

--- a/g42cloud/services/acceptance/er/data_source_g42cloud_er_route_table_test.go
+++ b/g42cloud/services/acceptance/er/data_source_g42cloud_er_route_table_test.go
@@ -1,0 +1,225 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+)
+
+func TestAccRouteTablesDataSource_basic(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_basic(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dName, "route_tables.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRouteTablesDataSource_byName(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_byName(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("route_tables_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRouteTablesDataSource_byId(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_byId(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("route_tables_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRouteTablesDataSource_byTags(t *testing.T) {
+	var (
+		dName    = "data.g42cloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_byTags(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("route_tables_count", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRouteTablesDataSource_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+data "g42cloud_availability_zones" "test" {}
+
+resource "g42cloud_er_instance" "test" {
+  availability_zones = slice(data.g42cloud_availability_zones.test.names, 0, 1)
+
+  name = "%[1]s"
+  asn  = %[2]d
+}
+
+resource "g42cloud_er_route_table" "test" {
+  instance_id = g42cloud_er_instance.test.id
+  name        = "%[1]s"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+
+resource "g42cloud_er_route_table" "another" {
+  instance_id = g42cloud_er_instance.test.id
+  name        = "%[1]s_another"
+
+  tags = {
+    owner = "terraform"
+  }
+}
+`, name, bgpAsNum)
+}
+
+func testAccRouteTablesDataSource_basic(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_route_tables" "test" {
+  depends_on = [
+    g42cloud_er_route_table.test
+  ]
+
+  instance_id = g42cloud_er_instance.test.id
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}
+
+func testAccRouteTablesDataSource_byName(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_route_tables" "test" {
+  depends_on = [
+    g42cloud_er_route_table.test
+  ]
+
+  instance_id = g42cloud_er_instance.test.id
+  name        = "%[2]s"
+}
+
+output "route_tables_count" {
+  value = length(data.g42cloud_er_route_tables.test.route_tables)
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}
+
+func testAccRouteTablesDataSource_byId(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_route_tables" "test" {
+  depends_on = [
+    g42cloud_er_route_table.test
+  ]
+
+  instance_id    = g42cloud_er_instance.test.id
+  route_table_id = g42cloud_er_route_table.test.id
+}
+
+output "route_tables_count" {
+  value = length(data.g42cloud_er_route_tables.test.route_tables)
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}
+
+func testAccRouteTablesDataSource_byTags(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "g42cloud_er_route_tables" "test" {
+  depends_on = [
+    g42cloud_er_route_table.test
+  ]
+
+  instance_id = g42cloud_er_instance.test.id
+
+  tags = {
+    owner = "terraform"
+  }
+}
+
+output "route_tables_count" {
+  value = length(data.g42cloud_er_route_tables.test.route_tables)
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}

--- a/g42cloud/services/acceptance/er/resource_g42cloud_er_instance_test.go
+++ b/g42cloud/services/acceptance/er/resource_g42cloud_er_instance_test.go
@@ -1,0 +1,136 @@
+package er
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getInstanceResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.G42_REGION_NAME
+	// getInstance: Query the Enterprise router instance detail
+	var (
+		getInstanceHttpUrl = "v3/{project_id}/enterprise-router/instances/{id}"
+		getInstanceProduct = "er"
+	)
+	getInstanceClient, err := cfg.NewServiceClient(getInstanceProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Instance Client: %s", err)
+	}
+
+	getInstancePath := getInstanceClient.Endpoint + getInstanceHttpUrl
+	getInstancePath = strings.ReplaceAll(getInstancePath, "{project_id}", getInstanceClient.ProjectID)
+	getInstancePath = strings.ReplaceAll(getInstancePath, "{id}", state.Primary.ID)
+
+	getInstanceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getInstanceResp, err := getInstanceClient.Request("GET", getInstancePath, &getInstanceOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Instance: %s", err)
+	}
+	return utils.FlattenResponse(getInstanceResp)
+}
+
+func TestAccInstance_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "g42cloud_er_instance.test"
+	bgpAsNum := acctest.RandIntRange(64512, 65534)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInstanceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testInstance_basic_step1(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "availability_zones.0",
+						"data.g42cloud_er_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(rName, "asn", fmt.Sprintf("%v", bgpAsNum)),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testInstance_basic_step2(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "asn", fmt.Sprintf("%v", bgpAsNum)),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(rName, "tags.newkey", "valuee"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testInstance_basic_step1(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+data "g42cloud_er_availability_zones" "test" {}
+
+resource "g42cloud_er_instance" "test" {
+  availability_zones = data.g42cloud_er_availability_zones.test.names
+
+  name = "%[1]s"
+  asn  = %[2]d
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name, bgpAsNum)
+}
+
+func testInstance_basic_step2(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+data "g42cloud_er_availability_zones" "test" {}
+
+resource "g42cloud_er_instance" "test" {
+  availability_zones = data.g42cloud_er_availability_zones.test.names
+
+  name = "%[1]s"
+  asn  = %[2]d
+
+  tags = {
+    foo    = "baar"
+    newkey = "valuee"
+  }
+}
+`, name, bgpAsNum)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/g42cloud-terraform/terraform-provider-g42cloud
 go 1.18
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4
+	github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b
+	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.62
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.57.0
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.58.0
+	github.com/zclconf/go-cty v1.11.0
 )
 
 require (
@@ -25,7 +27,6 @@ require (
 	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.4 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hc-install v0.4.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.14.1 // indirect
@@ -56,7 +57,6 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
-	github.com/zclconf/go-cty v1.11.0 // indirect
 	go.mongodb.org/mongo-driver v1.12.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4 h1:Hwcokg8qsuPlybCcI2Q/ZRtcrA0oNNveB5Gt/XVYCdA=
-github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b h1:HdQqladAqLkzzRkx435FF5LhmTN6fepC5OwOqHmta00=
+github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -124,8 +124,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.62 h1:KIdJHehTBMAe9rWllPWZsQ4ERMP89zVcu2JyNwHgrEI=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.62/go.mod h1:AZT3IyeViMA1qIoo6lM2eDobcTXORpqIQzSqdodah7E=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.57.0 h1:N0Jm5jF508SI6deRs6Vw5BvZ52a1DuwN779oPK1V/FY=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.57.0/go.mod h1:mS7OsM7dYgeYiEhCCOpB9nsvsqHlwywRKoK8gzdKnzo=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.58.0 h1:+TLDbdHJ0iFs1Fvd3egPw10/52mSyXKKIvNSg4CUfE0=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.58.0/go.mod h1:YUx9Q3Cfw7cD2fr9xZC5W9VH1BEl1W7vLa0JfkhKbQ4=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceAZs_basic
=== PAUSE TestAccDataSourceAZs_basic
=== CONT  TestAccDataSourceAZs_basic
--- PASS: TestAccDataSourceAZs_basic (18.28s)
PASS

coverage: 8.0% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccInstancesDataSource_basic

=== PAUSE TestAccInstancesDataSource_basic

=== CONT  TestAccInstancesDataSource_basic

--- PASS: TestAccInstancesDataSource_basic (67.80s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccInstancesDataSource_filterById
=== PAUSE TestAccInstancesDataSource_filterById
=== CONT  TestAccInstancesDataSource_filterById
--- PASS: TestAccInstancesDataSource_filterById (69.43s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccInstancesDataSource_filterByStatus
=== PAUSE TestAccInstancesDataSource_filterByStatus
=== CONT  TestAccInstancesDataSource_filterByStatus
--- PASS: TestAccInstancesDataSource_filterByStatus (65.05s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccInstancesDataSource_filterByEpsId
=== PAUSE TestAccInstancesDataSource_filterByEpsId
=== CONT  TestAccInstancesDataSource_filterByEpsId
--- PASS: TestAccInstancesDataSource_filterByEpsId (68.77s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...

```

```
=== RUN   TestAccInstancesDataSource_filterByTags
=== PAUSE TestAccInstancesDataSource_filterByTags
=== CONT  TestAccInstancesDataSource_filterByTags
--- PASS: TestAccInstancesDataSource_filterByTags (64.10s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccRouteTablesDataSource_basic
=== PAUSE TestAccRouteTablesDataSource_basic
=== CONT  TestAccRouteTablesDataSource_basic
--- PASS: TestAccRouteTablesDataSource_basic (103.57s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccRouteTablesDataSource_byName
=== PAUSE TestAccRouteTablesDataSource_byName
=== CONT  TestAccRouteTablesDataSource_byName
--- PASS: TestAccRouteTablesDataSource_byName (97.33s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccRouteTablesDataSource_byId
=== PAUSE TestAccRouteTablesDataSource_byId
=== CONT  TestAccRouteTablesDataSource_byId
--- PASS: TestAccRouteTablesDataSource_byId (93.89s)
PASS
coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccRouteTablesDataSource_byTags
=== PAUSE TestAccRouteTablesDataSource_byTags
=== CONT  TestAccRouteTablesDataSource_byTags
--- PASS: TestAccRouteTablesDataSource_byTags (102.31s)
PASS

coverage: 8.3% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (89.48s)
PASS
coverage: 11.2% of statements in ../../../../../terraform-provider-g42cloud/...
```

```
=== RUN   TestAccRouteTable_basic
=== PAUSE TestAccRouteTable_basic
=== CONT  TestAccRouteTable_basic
--- PASS: TestAccRouteTable_basic (123.24s)
PASS
```
